### PR TITLE
feat: table dependency ordering (topological sort by FKs)

### DIFF
--- a/schema/order.go
+++ b/schema/order.go
@@ -1,0 +1,103 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// CreationOrder returns tables sorted so that foreign key dependencies are
+// satisfied: parents appear before children. Self-referential foreign keys
+// (a table referencing itself) are allowed and do not constitute a cycle.
+// Tables with no FK dependencies may appear in any stable order.
+func CreationOrder(tables ...*TableDef) ([]*TableDef, error) {
+	return topoSort(tables, false)
+}
+
+// DropOrder returns tables sorted so that children appear before parents,
+// which is the reverse of CreationOrder. This is the safe order for DROP TABLE.
+func DropOrder(tables ...*TableDef) ([]*TableDef, error) {
+	return topoSort(tables, true)
+}
+
+// topoSort performs a topological sort using Kahn's algorithm.
+// If reverse is true, the result is reversed (drop order).
+func topoSort(tables []*TableDef, reverse bool) ([]*TableDef, error) {
+	// Build a name -> table index.
+	byName := make(map[string]*TableDef, len(tables))
+	for _, t := range tables {
+		byName[t.Name] = t
+	}
+
+	// Build adjacency: edges go from dependency (parent) -> dependent (child).
+	// inDegree counts how many parents each table has.
+	inDegree := make(map[string]int, len(tables))
+	// children[parent] = list of child table names
+	children := make(map[string][]string, len(tables))
+
+	for _, t := range tables {
+		if _, ok := inDegree[t.Name]; !ok {
+			inDegree[t.Name] = 0
+		}
+		for _, col := range t.cols {
+			ref := col.refTable
+			if ref == "" {
+				continue
+			}
+			// Skip self-references — not a real dependency edge.
+			if ref == t.Name {
+				continue
+			}
+			// Only count references to tables in the input set.
+			if _, ok := byName[ref]; !ok {
+				continue
+			}
+			inDegree[t.Name]++
+			children[ref] = append(children[ref], t.Name)
+		}
+	}
+
+	// Seed queue with tables that have no dependencies.
+	var queue []string
+	for _, t := range tables {
+		if inDegree[t.Name] == 0 {
+			queue = append(queue, t.Name)
+		}
+	}
+
+	var sorted []*TableDef
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, byName[name])
+
+		for _, child := range children[name] {
+			inDegree[child]--
+			if inDegree[child] == 0 {
+				queue = append(queue, child)
+			}
+		}
+	}
+
+	if len(sorted) != len(tables) {
+		// Find tables involved in the cycle for a useful error message.
+		var cycled []string
+		for _, t := range tables {
+			if inDegree[t.Name] > 0 {
+				cycled = append(cycled, t.Name)
+			}
+		}
+		return nil, fmt.Errorf("%w: %s", ErrCyclicDependency, strings.Join(cycled, ", "))
+	}
+
+	if reverse {
+		for i, j := 0, len(sorted)-1; i < j; i, j = i+1, j-1 {
+			sorted[i], sorted[j] = sorted[j], sorted[i]
+		}
+	}
+
+	return sorted, nil
+}
+
+// ErrCyclicDependency is returned when tables have circular foreign key references.
+var ErrCyclicDependency = errors.New("cyclic foreign key dependency among tables")

--- a/schema/order_test.go
+++ b/schema/order_test.go
@@ -1,0 +1,206 @@
+package schema
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreationOrder_LinearChain(t *testing.T) {
+	// Users -> Posts -> Comments (each references the previous)
+	users := NewTable("Users").Columns(AutoIncrCol("ID"))
+	posts := NewTable("Posts").Columns(
+		AutoIncrCol("ID"),
+		Col("UserID", TypeInt()).NotNull().References("Users", "ID"),
+	)
+	comments := NewTable("Comments").Columns(
+		AutoIncrCol("ID"),
+		Col("PostID", TypeInt()).NotNull().References("Posts", "ID"),
+	)
+
+	// Pass in scrambled order.
+	sorted, err := CreationOrder(comments, users, posts)
+	require.NoError(t, err)
+	require.Len(t, sorted, 3)
+
+	idx := nameIndex(sorted)
+	assert.Less(t, idx["Users"], idx["Posts"], "Users before Posts")
+	assert.Less(t, idx["Posts"], idx["Comments"], "Posts before Comments")
+}
+
+func TestDropOrder_LinearChain(t *testing.T) {
+	users := NewTable("Users").Columns(AutoIncrCol("ID"))
+	posts := NewTable("Posts").Columns(
+		AutoIncrCol("ID"),
+		Col("UserID", TypeInt()).NotNull().References("Users", "ID"),
+	)
+	comments := NewTable("Comments").Columns(
+		AutoIncrCol("ID"),
+		Col("PostID", TypeInt()).NotNull().References("Posts", "ID"),
+	)
+
+	sorted, err := DropOrder(comments, users, posts)
+	require.NoError(t, err)
+	require.Len(t, sorted, 3)
+
+	idx := nameIndex(sorted)
+	assert.Less(t, idx["Comments"], idx["Posts"], "Comments before Posts")
+	assert.Less(t, idx["Posts"], idx["Users"], "Posts before Users")
+}
+
+func TestCreationOrder_Diamond(t *testing.T) {
+	//     A
+	//    / \
+	//   B   C
+	//    \ /
+	//     D
+	a := NewTable("A").Columns(AutoIncrCol("ID"))
+	b := NewTable("B").Columns(
+		AutoIncrCol("ID"),
+		Col("AID", TypeInt()).References("A", "ID"),
+	)
+	c := NewTable("C").Columns(
+		AutoIncrCol("ID"),
+		Col("AID", TypeInt()).References("A", "ID"),
+	)
+	d := NewTable("D").Columns(
+		AutoIncrCol("ID"),
+		Col("BID", TypeInt()).References("B", "ID"),
+		Col("CID", TypeInt()).References("C", "ID"),
+	)
+
+	sorted, err := CreationOrder(d, c, b, a)
+	require.NoError(t, err)
+	require.Len(t, sorted, 4)
+
+	idx := nameIndex(sorted)
+	assert.Less(t, idx["A"], idx["B"])
+	assert.Less(t, idx["A"], idx["C"])
+	assert.Less(t, idx["B"], idx["D"])
+	assert.Less(t, idx["C"], idx["D"])
+}
+
+func TestCreationOrder_SelfReference(t *testing.T) {
+	// A table with WithParent-style self-reference should not error.
+	categories := NewTable("Categories").Columns(
+		AutoIncrCol("ID"),
+		Col("Name", TypeVarchar(255)).NotNull(),
+		Col("ParentID", TypeInt()).References("Categories", "ID"),
+	)
+
+	sorted, err := CreationOrder(categories)
+	require.NoError(t, err)
+	require.Len(t, sorted, 1)
+	assert.Equal(t, "Categories", sorted[0].Name)
+}
+
+func TestCreationOrder_SelfReferenceWithOtherTables(t *testing.T) {
+	// Self-referencing table that also depends on another table.
+	orgs := NewTable("Orgs").Columns(AutoIncrCol("ID"))
+	departments := NewTable("Departments").Columns(
+		AutoIncrCol("ID"),
+		Col("OrgID", TypeInt()).NotNull().References("Orgs", "ID"),
+		Col("ParentID", TypeInt()).References("Departments", "ID"),
+	)
+
+	sorted, err := CreationOrder(departments, orgs)
+	require.NoError(t, err)
+	require.Len(t, sorted, 2)
+
+	idx := nameIndex(sorted)
+	assert.Less(t, idx["Orgs"], idx["Departments"])
+}
+
+func TestCreationOrder_CycleError(t *testing.T) {
+	// A -> B -> A
+	a := NewTable("A").Columns(
+		AutoIncrCol("ID"),
+		Col("BID", TypeInt()).References("B", "ID"),
+	)
+	b := NewTable("B").Columns(
+		AutoIncrCol("ID"),
+		Col("AID", TypeInt()).References("A", "ID"),
+	)
+
+	_, err := CreationOrder(a, b)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCyclicDependency))
+	assert.Contains(t, err.Error(), "A")
+	assert.Contains(t, err.Error(), "B")
+}
+
+func TestCreationOrder_IndependentTables(t *testing.T) {
+	a := NewTable("Alpha").Columns(AutoIncrCol("ID"))
+	b := NewTable("Beta").Columns(AutoIncrCol("ID"))
+	c := NewTable("Gamma").Columns(AutoIncrCol("ID"))
+
+	sorted, err := CreationOrder(a, b, c)
+	require.NoError(t, err)
+	require.Len(t, sorted, 3)
+
+	// All three should be present; order is stable but unspecified.
+	names := make(map[string]bool)
+	for _, tbl := range sorted {
+		names[tbl.Name] = true
+	}
+	assert.True(t, names["Alpha"])
+	assert.True(t, names["Beta"])
+	assert.True(t, names["Gamma"])
+}
+
+func TestCreationOrder_Empty(t *testing.T) {
+	sorted, err := CreationOrder()
+	require.NoError(t, err)
+	assert.Empty(t, sorted)
+}
+
+func TestCreationOrder_ExternalReference(t *testing.T) {
+	// A table referencing a table NOT in the input set should not block ordering.
+	posts := NewTable("Posts").Columns(
+		AutoIncrCol("ID"),
+		Col("UserID", TypeInt()).NotNull().References("Users", "ID"),
+	)
+
+	sorted, err := CreationOrder(posts)
+	require.NoError(t, err)
+	require.Len(t, sorted, 1)
+	assert.Equal(t, "Posts", sorted[0].Name)
+}
+
+func TestDropOrder_Diamond(t *testing.T) {
+	a := NewTable("A").Columns(AutoIncrCol("ID"))
+	b := NewTable("B").Columns(
+		AutoIncrCol("ID"),
+		Col("AID", TypeInt()).References("A", "ID"),
+	)
+	c := NewTable("C").Columns(
+		AutoIncrCol("ID"),
+		Col("AID", TypeInt()).References("A", "ID"),
+	)
+	d := NewTable("D").Columns(
+		AutoIncrCol("ID"),
+		Col("BID", TypeInt()).References("B", "ID"),
+		Col("CID", TypeInt()).References("C", "ID"),
+	)
+
+	sorted, err := DropOrder(d, c, b, a)
+	require.NoError(t, err)
+	require.Len(t, sorted, 4)
+
+	idx := nameIndex(sorted)
+	assert.Less(t, idx["D"], idx["B"])
+	assert.Less(t, idx["D"], idx["C"])
+	assert.Less(t, idx["B"], idx["A"])
+	assert.Less(t, idx["C"], idx["A"])
+}
+
+// nameIndex builds a map from table name to its position in the slice.
+func nameIndex(tables []*TableDef) map[string]int {
+	m := make(map[string]int, len(tables))
+	for i, t := range tables {
+		m[t.Name] = i
+	}
+	return m
+}


### PR DESCRIPTION
## Summary

- Adds `CreationOrder(tables ...*TableDef) ([]*TableDef, error)` that topologically sorts tables so FK parents are created before children
- Adds `DropOrder(tables ...*TableDef) ([]*TableDef, error)` that returns the reverse (children before parents)
- Cycle detection returns `ErrCyclicDependency` with the involved table names
- Self-referential tables (e.g. `WithParent`) are handled gracefully and do not count as cycles
- References to tables outside the input set are silently ignored

## Test plan

- [x] Linear chain (Users -> Posts -> Comments)
- [x] Diamond dependencies (A -> B,C -> D)
- [x] Self-referential table alone and combined with other dependencies
- [x] Cycle detection returns error with table names
- [x] Independent tables (no FKs) all present in output
- [x] Empty input returns empty slice
- [x] External references (to tables not in input) do not block ordering
- [x] Drop order verified as reverse of creation order
- [x] All existing tests pass (`go test ./...`)

Closes #10