### PR TITLE
feat: add UpdateBuilder and DeleteBuilder

### DIFF
--- a/dbrepo/delete_builder.go
+++ b/dbrepo/delete_builder.go
@@ -1,0 +1,69 @@
+package dbrepo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// DeleteBuilder constructs composable DELETE queries with WHERE and RETURNING clauses.
+type DeleteBuilder struct {
+	table     string
+	where     *WhereBuilder
+	returning []string
+	dialect   chuck.Dialect
+}
+
+// NewDelete creates a new DeleteBuilder for the given table.
+func NewDelete(table string) *DeleteBuilder {
+	return &DeleteBuilder{
+		table: table,
+		where: NewWhere(),
+	}
+}
+
+// Where sets the WhereBuilder for filtering.
+func (d *DeleteBuilder) Where(w *WhereBuilder) *DeleteBuilder {
+	d.where = w
+	return d
+}
+
+// WithDialect sets the dialect for identifier quoting.
+func (d *DeleteBuilder) WithDialect(dial chuck.Dialect) *DeleteBuilder {
+	d.dialect = dial
+	return d
+}
+
+// Returning sets columns to return after the delete (Postgres/SQLite RETURNING clause).
+func (d *DeleteBuilder) Returning(cols ...string) *DeleteBuilder {
+	d.returning = cols
+	return d
+}
+
+// Build returns the complete SQL query string and the collected arguments.
+func (d *DeleteBuilder) Build() (query string, args []any) {
+	var parts []string
+
+	tableName := d.table
+	if d.dialect != nil {
+		tableName = d.dialect.QuoteIdentifier(d.table)
+	}
+
+	parts = append(parts, fmt.Sprintf("DELETE FROM %s", tableName))
+
+	if d.where.HasConditions() {
+		parts = append(parts, d.where.String())
+	}
+
+	args = d.where.Args()
+
+	if len(d.returning) > 0 && d.dialect != nil {
+		rc := d.dialect.ReturningClause(Columns(d.returning...))
+		if rc != "" {
+			parts = append(parts, rc)
+		}
+	}
+
+	return strings.Join(parts, " "), args
+}

--- a/dbrepo/delete_builder_test.go
+++ b/dbrepo/delete_builder_test.go
@@ -1,0 +1,99 @@
+package dbrepo
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteBuilder(t *testing.T) {
+	t.Run("basic_no_where", func(t *testing.T) {
+		q, args := NewDelete("Users").Build()
+		assert.Equal(t, "DELETE FROM Users", q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("with_where", func(t *testing.T) {
+		w := NewWhere().And("ID = @ID", sql.Named("ID", 42))
+		q, args := NewDelete("Users").
+			Where(w).
+			Build()
+		assert.Equal(t, "DELETE FROM Users WHERE ID = @ID", q)
+		assert.Len(t, args, 1)
+	})
+
+	t.Run("with_where_semantic_filters", func(t *testing.T) {
+		w := NewWhere().NotDeleted().HasStatus("active")
+		q, args := NewDelete("Tasks").
+			Where(w).
+			Build()
+		assert.Contains(t, q, "DELETE FROM Tasks")
+		assert.Contains(t, q, "WHERE DeletedAt IS NULL AND Status = @Status")
+		assert.Len(t, args, 1)
+	})
+
+	t.Run("with_dialect_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `DELETE FROM "Users"`, q)
+	})
+
+	t.Run("with_dialect_mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, "DELETE FROM [Users]", q)
+	})
+
+	t.Run("with_dialect_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `DELETE FROM "Users"`, q)
+	})
+
+	t.Run("returning_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Returning("ID").
+			Build()
+		assert.Equal(t, `DELETE FROM "Users" RETURNING ID`, q)
+	})
+
+	t.Run("returning_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Returning("ID", "Name").
+			Build()
+		assert.Equal(t, `DELETE FROM "Users" RETURNING ID, Name`, q)
+	})
+
+	t.Run("returning_mssql_noop", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, _ := NewDelete("Users").
+			WithDialect(d).
+			Returning("ID").
+			Build()
+		assert.Equal(t, "DELETE FROM [Users]", q)
+	})
+
+	t.Run("full_query_with_where_and_returning", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		w := NewWhere().And("ID = @ID", sql.Named("ID", 1))
+		q, args := NewDelete("Users").
+			WithDialect(d).
+			Where(w).
+			Returning("ID").
+			Build()
+		assert.Equal(t, `DELETE FROM "Users" WHERE ID = @ID RETURNING ID`, q)
+		assert.Len(t, args, 1)
+	})
+}

--- a/dbrepo/update_builder.go
+++ b/dbrepo/update_builder.go
@@ -1,0 +1,76 @@
+package dbrepo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// UpdateBuilder constructs composable UPDATE queries with SET, WHERE, and RETURNING clauses.
+type UpdateBuilder struct {
+	table     string
+	cols      []string
+	where     *WhereBuilder
+	returning []string
+	dialect   chuck.Dialect
+}
+
+// NewUpdate creates a new UpdateBuilder for the given table and columns.
+// The columns are used to generate the SET clause (e.g., "Name = @Name, Email = @Email").
+func NewUpdate(table string, columns ...string) *UpdateBuilder {
+	return &UpdateBuilder{
+		table: table,
+		cols:  columns,
+		where: NewWhere(),
+	}
+}
+
+// Where sets the WhereBuilder for filtering.
+func (u *UpdateBuilder) Where(w *WhereBuilder) *UpdateBuilder {
+	u.where = w
+	return u
+}
+
+// WithDialect sets the dialect for identifier quoting.
+func (u *UpdateBuilder) WithDialect(d chuck.Dialect) *UpdateBuilder {
+	u.dialect = d
+	return u
+}
+
+// Returning sets columns to return after the update (Postgres/SQLite RETURNING clause).
+func (u *UpdateBuilder) Returning(cols ...string) *UpdateBuilder {
+	u.returning = cols
+	return u
+}
+
+// Build returns the complete SQL query string and the collected arguments.
+func (u *UpdateBuilder) Build() (query string, args []any) {
+	var parts []string
+
+	tableName := u.table
+	var setClause string
+	if u.dialect != nil {
+		tableName = u.dialect.QuoteIdentifier(u.table)
+		setClause = SetClauseQ(u.dialect, u.cols...)
+	} else {
+		setClause = SetClause(u.cols...)
+	}
+
+	parts = append(parts, fmt.Sprintf("UPDATE %s SET %s", tableName, setClause))
+
+	if u.where.HasConditions() {
+		parts = append(parts, u.where.String())
+	}
+
+	args = u.where.Args()
+
+	if len(u.returning) > 0 && u.dialect != nil {
+		rc := u.dialect.ReturningClause(Columns(u.returning...))
+		if rc != "" {
+			parts = append(parts, rc)
+		}
+	}
+
+	return strings.Join(parts, " "), args
+}

--- a/dbrepo/update_builder_test.go
+++ b/dbrepo/update_builder_test.go
@@ -1,0 +1,103 @@
+package dbrepo
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateBuilder(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		q, args := NewUpdate("Users", "Name", "Email").Build()
+		assert.Equal(t, "UPDATE Users SET Name = @Name, Email = @Email", q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("with_where", func(t *testing.T) {
+		w := NewWhere().And("ID = @ID", sql.Named("ID", 42))
+		q, args := NewUpdate("Users", "Name", "Email").
+			Where(w).
+			Build()
+		assert.Equal(t, "UPDATE Users SET Name = @Name, Email = @Email WHERE ID = @ID", q)
+		assert.Len(t, args, 1)
+	})
+
+	t.Run("with_where_semantic_filters", func(t *testing.T) {
+		w := NewWhere().NotDeleted().HasStatus("active")
+		q, args := NewUpdate("Tasks", "Title").
+			Where(w).
+			Build()
+		assert.Contains(t, q, "UPDATE Tasks SET Title = @Title")
+		assert.Contains(t, q, "WHERE DeletedAt IS NULL AND Status = @Status")
+		assert.Len(t, args, 1)
+	})
+
+	t.Run("with_dialect_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, args := NewUpdate("Users", "Name", "Email").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = @Name, "Email" = @Email`, q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("with_dialect_mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, args := NewUpdate("Users", "Name").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, "UPDATE [Users] SET [Name] = @Name", q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("with_dialect_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		q, args := NewUpdate("Users", "Name").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = @Name`, q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("returning_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, _ := NewUpdate("Users", "Name").
+			WithDialect(d).
+			Returning("ID", "Name").
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = @Name RETURNING ID, Name`, q)
+	})
+
+	t.Run("returning_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		q, _ := NewUpdate("Users", "Name").
+			WithDialect(d).
+			Returning("ID").
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = @Name RETURNING ID`, q)
+	})
+
+	t.Run("returning_mssql_noop", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, _ := NewUpdate("Users", "Name").
+			WithDialect(d).
+			Returning("ID").
+			Build()
+		// MSSQL does not support RETURNING, so it should not appear
+		assert.Equal(t, "UPDATE [Users] SET [Name] = @Name", q)
+	})
+
+	t.Run("full_query_with_where_and_returning", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		w := NewWhere().And("ID = @ID", sql.Named("ID", 1))
+		q, args := NewUpdate("Users", "Name", "Email").
+			WithDialect(d).
+			Where(w).
+			Returning("ID", "Name", "Email").
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = @Name, "Email" = @Email WHERE ID = @ID RETURNING ID, Name, Email`, q)
+		assert.Len(t, args, 1)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `UpdateBuilder` for composing UPDATE queries with SET, WHERE, dialect quoting, and RETURNING clauses
- Adds `DeleteBuilder` for composing DELETE queries with WHERE, dialect quoting, and RETURNING clauses
- Both builders follow the same patterns as `SelectBuilder` (fluent API, `WhereBuilder` integration, `Build()` method)
- Tests cover all three dialects (Postgres, SQLite, MSSQL), RETURNING clause behavior, semantic filters, and edge cases

Closes #3

## Test plan

- [x] All new tests pass (`go test ./...`)
- [x] All existing tests continue to pass
- [x] Dialect-aware quoting verified for Postgres (`"table"`), SQLite (`"table"`), and MSSQL (`[table]`)
- [x] RETURNING clause works for Postgres/SQLite, is a no-op for MSSQL
- [x] DELETE without WHERE produces valid SQL
- [x] WhereBuilder semantic filters (NotDeleted, HasStatus) integrate correctly