### PR TITLE
feat: add CHECK constraint support to column builder

### DIFF
--- a/schema/column.go
+++ b/schema/column.go
@@ -90,6 +90,7 @@ type ColumnDef struct {
 	refColumn  string
 	onDelete   string
 	onUpdate   string
+	checkExpr  string
 }
 
 // Col creates a new column definition. By default columns are nullable and mutable.
@@ -165,6 +166,9 @@ func (c ColumnDef) OnDelete(action string) ColumnDef { c.onDelete = action; retu
 // OnUpdate sets the referential action for UPDATE (e.g. "CASCADE", "SET NULL").
 func (c ColumnDef) OnUpdate(action string) ColumnDef { c.onUpdate = action; return c }
 
+// Check adds a CHECK constraint with the given SQL expression (e.g. "age >= 0").
+func (c ColumnDef) Check(expr string) ColumnDef { c.checkExpr = expr; return c }
+
 // Name returns the column name.
 func (c ColumnDef) Name() string { return c.name }
 
@@ -201,6 +205,10 @@ func (c ColumnDef) ddl(d chuck.Dialect) string {
 			ref += " ON UPDATE " + c.onUpdate
 		}
 		parts = append(parts, ref)
+	}
+
+	if c.checkExpr != "" {
+		parts = append(parts, fmt.Sprintf("CHECK (%s)", c.checkExpr))
 	}
 
 	return strings.Join(parts, " ")

--- a/schema/snapshot.go
+++ b/schema/snapshot.go
@@ -21,6 +21,7 @@ type ColumnSnapshot struct {
 	RefColumn  string `json:"references_column,omitempty"`
 	OnDelete   string `json:"on_delete,omitempty"`
 	OnUpdate   string `json:"on_update,omitempty"`
+	Check      string `json:"check,omitempty"`
 }
 
 // IndexSnapshot describes a single index.
@@ -74,6 +75,7 @@ func (t *TableDef) Snapshot(d chuck.Dialect) TableSnapshot {
 			cs.OnDelete = c.onDelete
 			cs.OnUpdate = c.onUpdate
 		}
+		cs.Check = c.checkExpr
 		snap.Columns = append(snap.Columns, cs)
 	}
 
@@ -131,6 +133,9 @@ func (t *TableDef) SnapshotString(d chuck.Dialect) string {
 				ref += " ON UPDATE " + c.OnUpdate
 			}
 			parts = append(parts, ref)
+		}
+		if c.Check != "" {
+			parts = append(parts, fmt.Sprintf("CHECK (%s)", c.Check))
 		}
 		if !c.Mutable {
 			parts = append(parts, "[immutable]")

--- a/schema/snapshot_test.go
+++ b/schema/snapshot_test.go
@@ -140,6 +140,44 @@ func TestSnapshotOnDeleteOnUpdate(t *testing.T) {
 	assert.Equal(t, "CASCADE", reqID.OnUpdate)
 }
 
+func TestSnapshotCheck(t *testing.T) {
+	table := NewTable("Products").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Price", TypeDecimal(10, 2)).NotNull().Check("Price > 0"),
+			Col("Status", TypeVarchar(20)).Check("Status IN ('active', 'draft')"),
+		)
+
+	t.Run("struct_fields", func(t *testing.T) {
+		snap := table.Snapshot(chuck.PostgresDialect{})
+
+		price := snap.Columns[1]
+		assert.Equal(t, "price", price.Name)
+		assert.Equal(t, "Price > 0", price.Check)
+
+		status := snap.Columns[2]
+		assert.Equal(t, "status", status.Name)
+		assert.Equal(t, "Status IN ('active', 'draft')", status.Check)
+	})
+
+	t.Run("json_serializable", func(t *testing.T) {
+		snap := table.Snapshot(chuck.SQLiteDialect{})
+		data, err := json.MarshalIndent(snap, "", "  ")
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"check":`)
+		// Verify the check field round-trips through JSON
+		var decoded TableSnapshot
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, "Price > 0", decoded.Columns[1].Check)
+	})
+
+	t.Run("snapshot_string", func(t *testing.T) {
+		s := table.SnapshotString(chuck.PostgresDialect{})
+		assert.Contains(t, s, "CHECK (Price > 0)")
+		assert.Contains(t, s, "CHECK (Status IN ('active', 'draft'))")
+	})
+}
+
 func TestSchemaSnapshot(t *testing.T) {
 	users := NewTable("Users").
 		Columns(AutoIncrCol("ID"))

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -329,6 +329,43 @@ func TestColumnDDL(t *testing.T) {
 		ddl := c.ddl(ms)
 		assert.Contains(t, ddl, `REFERENCES [Tasks]([ID]) ON DELETE CASCADE ON UPDATE SET NULL`)
 	})
+
+	t.Run("check_basic", func(t *testing.T) {
+		c := Col("Age", TypeInt()).Check("Age >= 0")
+		ddl := c.ddl(d)
+		assert.Contains(t, ddl, "CHECK (Age >= 0)")
+	})
+
+	t.Run("check_multiple_conditions", func(t *testing.T) {
+		c := Col("Status", TypeVarchar(20)).Check("Status IN ('active', 'inactive', 'pending')")
+		ddl := c.ddl(d)
+		assert.Contains(t, ddl, "CHECK (Status IN ('active', 'inactive', 'pending'))")
+	})
+
+	t.Run("check_with_not_null", func(t *testing.T) {
+		c := Col("Price", TypeDecimal(10, 2)).NotNull().Check("Price > 0")
+		ddl := c.ddl(d)
+		assert.Contains(t, ddl, "NOT NULL")
+		assert.Contains(t, ddl, "CHECK (Price > 0)")
+	})
+
+	t.Run("check_postgres", func(t *testing.T) {
+		c := Col("Quantity", TypeInt()).NotNull().Check("Quantity >= 0")
+		ddl := c.ddl(chuck.PostgresDialect{})
+		assert.Contains(t, ddl, `"quantity" INTEGER NOT NULL CHECK (Quantity >= 0)`)
+	})
+
+	t.Run("check_sqlite", func(t *testing.T) {
+		c := Col("Quantity", TypeInt()).NotNull().Check("Quantity >= 0")
+		ddl := c.ddl(chuck.SQLiteDialect{})
+		assert.Contains(t, ddl, `"Quantity" INTEGER NOT NULL CHECK (Quantity >= 0)`)
+	})
+
+	t.Run("check_mssql", func(t *testing.T) {
+		c := Col("Quantity", TypeInt()).NotNull().Check("Quantity >= 0")
+		ddl := c.ddl(chuck.MSSQLDialect{})
+		assert.Contains(t, ddl, `[Quantity] INT NOT NULL CHECK (Quantity >= 0)`)
+	})
 }
 
 func TestTableFactories(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `.Check(expr string)` method to `ColumnDef` for inline CHECK constraints with raw SQL expressions
- CHECK constraints render in DDL output for all three dialects (Postgres, SQLite, MSSQL)
- CHECK constraints appear in snapshots (struct field, JSON serialization, and human-readable string output)

## Test plan

- [x] Basic CHECK constraint DDL rendering
- [x] CHECK with multiple conditions (e.g. IN clause)
- [x] CHECK combined with other constraints (NOT NULL)
- [x] CHECK DDL output verified for Postgres, SQLite, and MSSQL dialects
- [x] Snapshot struct field populated correctly
- [x] JSON round-trip serialization
- [x] Snapshot string includes CHECK expression
- [x] All existing tests still pass

Closes #6