### PR TITLE
feat: add typed SeedValues API for Go-value seed data

### DIFF
--- a/schema/seed_values.go
+++ b/schema/seed_values.go
@@ -1,0 +1,107 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// SeedValues represents a row of seed data as column name to Go value pairs.
+// Supported value types: string, int, int64, float64, bool, nil, and SQLExpr.
+// Values are automatically converted to SQL literals per dialect.
+type SeedValues map[string]interface{}
+
+// sqlExpr is a raw SQL expression that bypasses quoting.
+type sqlExpr struct {
+	expr string
+}
+
+// SQLExpr wraps a raw SQL expression so it is emitted verbatim in seed data.
+// Use this for database functions like CURRENT_TIMESTAMP or dialect-specific expressions.
+func SQLExpr(expr string) sqlExpr {
+	return sqlExpr{expr: expr}
+}
+
+// goValueToSQL converts a Go value to a SQL literal string for the given dialect.
+func goValueToSQL(d chuck.Dialect, v interface{}) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case sqlExpr:
+		return val.expr
+	case string:
+		escaped := strings.ReplaceAll(val, "'", "''")
+		return "'" + escaped + "'"
+	case bool:
+		switch d.Engine() {
+		case chuck.Postgres:
+			if val {
+				return "TRUE"
+			}
+			return "FALSE"
+		default: // SQLite, MSSQL
+			if val {
+				return "1"
+			}
+			return "0"
+		}
+	case int:
+		return fmt.Sprintf("%d", val)
+	case int64:
+		return fmt.Sprintf("%d", val)
+	case float64:
+		return fmt.Sprintf("%g", val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+// toSeedRow converts a SeedValues to a SeedRow using the given dialect for SQL literal conversion.
+func (sv SeedValues) toSeedRow(d chuck.Dialect) SeedRow {
+	row := make(SeedRow, len(sv))
+	for k, v := range sv {
+		row[k] = goValueToSQL(d, v)
+	}
+	return row
+}
+
+// WithSeedValues declares initial seed data using Go values instead of SQL literals.
+// Values are automatically quoted per dialect when SeedSQL is called.
+func (t *TableDef) WithSeedValues(rows ...SeedValues) *TableDef {
+	t.seedValueRows = append(t.seedValueRows, rows...)
+	return t
+}
+
+// SeedSQL returns idempotent INSERT statements for all seed rows (both SeedRow and SeedValues)
+// using the dialect's InsertOrIgnore method.
+// Only columns present in the seed row are included -- missing columns use their DB defaults.
+func (t *TableDef) seedValuesSQL(d chuck.Dialect) []string {
+	if len(t.seedValueRows) == 0 {
+		return nil
+	}
+
+	insertCols := t.InsertColumns()
+	var stmts []string
+	for _, sv := range t.seedValueRows {
+		row := sv.toSeedRow(d)
+		var cols []string
+		var vals []string
+		for _, col := range insertCols {
+			if v, ok := row[col]; ok {
+				cols = append(cols, d.NormalizeIdentifier(col))
+				vals = append(vals, v)
+			}
+		}
+		if len(cols) == 0 {
+			continue
+		}
+		stmts = append(stmts, d.InsertOrIgnore(
+			d.NormalizeIdentifier(t.Name),
+			strings.Join(cols, ", "),
+			strings.Join(vals, ", "),
+		))
+	}
+	return stmts
+}

--- a/schema/seed_values_test.go
+++ b/schema/seed_values_test.go
@@ -1,0 +1,224 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoValueToSQL(t *testing.T) {
+	pg := chuck.PostgresDialect{}
+	sq := chuck.SQLiteDialect{}
+	ms := chuck.MSSQLDialect{}
+
+	t.Run("nil", func(t *testing.T) {
+		assert.Equal(t, "NULL", goValueToSQL(pg, nil))
+		assert.Equal(t, "NULL", goValueToSQL(sq, nil))
+		assert.Equal(t, "NULL", goValueToSQL(ms, nil))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		assert.Equal(t, "'hello'", goValueToSQL(pg, "hello"))
+		assert.Equal(t, "'hello'", goValueToSQL(sq, "hello"))
+		assert.Equal(t, "'hello'", goValueToSQL(ms, "hello"))
+	})
+
+	t.Run("string_with_single_quote", func(t *testing.T) {
+		assert.Equal(t, "'it''s'", goValueToSQL(pg, "it's"))
+		assert.Equal(t, "'it''s'", goValueToSQL(sq, "it's"))
+		assert.Equal(t, "'it''s'", goValueToSQL(ms, "it's"))
+	})
+
+	t.Run("string_empty", func(t *testing.T) {
+		assert.Equal(t, "''", goValueToSQL(pg, ""))
+	})
+
+	t.Run("int", func(t *testing.T) {
+		assert.Equal(t, "42", goValueToSQL(pg, 42))
+		assert.Equal(t, "0", goValueToSQL(sq, 0))
+		assert.Equal(t, "-1", goValueToSQL(ms, -1))
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		assert.Equal(t, "9999999999", goValueToSQL(pg, int64(9999999999)))
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		assert.Equal(t, "3.14", goValueToSQL(pg, 3.14))
+		assert.Equal(t, "0", goValueToSQL(sq, 0.0))
+	})
+
+	t.Run("bool_postgres", func(t *testing.T) {
+		assert.Equal(t, "TRUE", goValueToSQL(pg, true))
+		assert.Equal(t, "FALSE", goValueToSQL(pg, false))
+	})
+
+	t.Run("bool_sqlite", func(t *testing.T) {
+		assert.Equal(t, "1", goValueToSQL(sq, true))
+		assert.Equal(t, "0", goValueToSQL(sq, false))
+	})
+
+	t.Run("bool_mssql", func(t *testing.T) {
+		assert.Equal(t, "1", goValueToSQL(ms, true))
+		assert.Equal(t, "0", goValueToSQL(ms, false))
+	})
+
+	t.Run("sql_expr", func(t *testing.T) {
+		expr := SQLExpr("CURRENT_TIMESTAMP")
+		assert.Equal(t, "CURRENT_TIMESTAMP", goValueToSQL(pg, expr))
+		assert.Equal(t, "CURRENT_TIMESTAMP", goValueToSQL(sq, expr))
+		assert.Equal(t, "CURRENT_TIMESTAMP", goValueToSQL(ms, expr))
+	})
+}
+
+func TestSeedValuesSQL(t *testing.T) {
+	table := NewTable("Statuses").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+			Col("Label", TypeVarchar(100)).NotNull(),
+			Col("Active", TypeBool()).NotNull(),
+		).
+		WithSeedValues(
+			SeedValues{"Name": "active", "Label": "Active", "Active": true},
+			SeedValues{"Name": "draft", "Label": "Draft", "Active": false},
+		)
+
+	assert.True(t, table.HasSeedData())
+
+	t.Run("sqlite", func(t *testing.T) {
+		stmts := table.SeedSQL(chuck.SQLiteDialect{})
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[0], `INSERT OR IGNORE INTO "Statuses"`)
+		assert.Contains(t, stmts[0], "'active'")
+		assert.Contains(t, stmts[0], "'Active'")
+		assert.Contains(t, stmts[0], "1") // bool true -> 1
+		assert.Contains(t, stmts[1], "'draft'")
+		assert.Contains(t, stmts[1], "0") // bool false -> 0
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		stmts := table.SeedSQL(chuck.PostgresDialect{})
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[0], `INSERT INTO "statuses"`)
+		assert.Contains(t, stmts[0], "ON CONFLICT DO NOTHING")
+		assert.Contains(t, stmts[0], "'active'")
+		assert.Contains(t, stmts[0], "TRUE")
+		assert.Contains(t, stmts[1], "FALSE")
+	})
+
+	t.Run("mssql", func(t *testing.T) {
+		stmts := table.SeedSQL(chuck.MSSQLDialect{})
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[0], "INSERT INTO [Statuses]")
+		assert.Contains(t, stmts[0], "BEGIN TRY")
+		assert.Contains(t, stmts[0], "'active'")
+		assert.Contains(t, stmts[0], "1") // bool true -> 1
+	})
+}
+
+func TestSeedValuesWithNil(t *testing.T) {
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+			Col("Description", TypeText()),
+		).
+		WithSeedValues(
+			SeedValues{"Name": "test", "Description": nil},
+		)
+
+	stmts := table.SeedSQL(chuck.SQLiteDialect{})
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0], "'test'")
+	assert.Contains(t, stmts[0], "NULL")
+}
+
+func TestSeedValuesWithSQLExpr(t *testing.T) {
+	table := NewTable("Events").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+			Col("CreatedAt", TypeTimestamp()).NotNull(),
+		).
+		WithSeedValues(
+			SeedValues{"Name": "boot", "CreatedAt": SQLExpr("CURRENT_TIMESTAMP")},
+		)
+
+	stmts := table.SeedSQL(chuck.SQLiteDialect{})
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0], "'boot'")
+	assert.Contains(t, stmts[0], "CURRENT_TIMESTAMP")
+}
+
+func TestSeedValuesNumericTypes(t *testing.T) {
+	table := NewTable("Metrics").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Count", TypeInt()).NotNull(),
+			Col("BigCount", TypeBigInt()),
+			Col("Rate", TypeFloat()),
+		).
+		WithSeedValues(
+			SeedValues{"Count": 42, "BigCount": int64(9999999999), "Rate": 3.14},
+		)
+
+	stmts := table.SeedSQL(chuck.PostgresDialect{})
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0], "42")
+	assert.Contains(t, stmts[0], "9999999999")
+	assert.Contains(t, stmts[0], "3.14")
+}
+
+func TestSeedValuesStringEscaping(t *testing.T) {
+	table := NewTable("Notes").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Body", TypeText()).NotNull(),
+		).
+		WithSeedValues(
+			SeedValues{"Body": "it's a \"test\""},
+		)
+
+	stmts := table.SeedSQL(chuck.SQLiteDialect{})
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0], "it''s a \"test\"")
+}
+
+func TestMixedSeedRowsAndSeedValues(t *testing.T) {
+	table := NewTable("Statuses").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+			Col("Active", TypeBool()).NotNull(),
+		).
+		WithSeedRows(
+			SeedRow{"Name": "'legacy'", "Active": "1"},
+		).
+		WithSeedValues(
+			SeedValues{"Name": "modern", "Active": true},
+		)
+
+	assert.True(t, table.HasSeedData())
+
+	stmts := table.SeedSQL(chuck.SQLiteDialect{})
+	require.Len(t, stmts, 2)
+	// First statement from SeedRow (raw SQL literals)
+	assert.Contains(t, stmts[0], "'legacy'")
+	// Second statement from SeedValues (Go values converted)
+	assert.Contains(t, stmts[1], "'modern'")
+	assert.Contains(t, stmts[1], "1")
+}
+
+func TestSeedValuesEmpty(t *testing.T) {
+	table := NewTable("Empty").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)),
+		)
+
+	assert.False(t, table.HasSeedData())
+	assert.Nil(t, table.SeedSQL(chuck.SQLiteDialect{}))
+}

--- a/schema/table.go
+++ b/schema/table.go
@@ -35,6 +35,7 @@ type TableDef struct {
 	indexes           []IndexDef
 	uniqueConstraints []UniqueConstraint
 	seedRows          []SeedRow
+	seedValueRows     []SeedValues
 	hasSoftDelete     bool
 	hasVersion        bool
 	hasExpiry         bool
@@ -159,14 +160,15 @@ func (t *TableDef) SeedRows() []SeedRow {
 
 // HasSeedData reports whether any seed rows have been declared.
 func (t *TableDef) HasSeedData() bool {
-	return len(t.seedRows) > 0
+	return len(t.seedRows) > 0 || len(t.seedValueRows) > 0
 }
 
 // SeedSQL returns idempotent INSERT statements for all seed rows using the
-// dialect's InsertOrIgnore method.
-// Only columns present in the SeedRow are included — missing columns use their DB defaults.
+// dialect's InsertOrIgnore method. It includes both raw SeedRow entries and
+// typed SeedValues entries (SeedValues are converted to SQL literals per dialect).
+// Only columns present in the seed row are included — missing columns use their DB defaults.
 func (t *TableDef) SeedSQL(d chuck.Dialect) []string {
-	if len(t.seedRows) == 0 {
+	if len(t.seedRows) == 0 && len(t.seedValueRows) == 0 {
 		return nil
 	}
 
@@ -190,6 +192,7 @@ func (t *TableDef) SeedSQL(d chuck.Dialect) []string {
 			strings.Join(vals, ", "),
 		))
 	}
+	stmts = append(stmts, t.seedValuesSQL(d)...)
 	return stmts
 }
 


### PR DESCRIPTION
## Summary

- Adds `SeedValues` type (`map[string]interface{}`) that accepts Go values and auto-converts them to dialect-correct SQL literals (strings are single-quoted with escaping, bools become TRUE/FALSE on Postgres and 1/0 on SQLite/MSSQL, nil becomes NULL, numbers pass through)
- Adds `SQLExpr()` escape hatch for raw SQL expressions (e.g., `SQLExpr("CURRENT_TIMESTAMP")`)
- Integrates with existing `SeedSQL()` generation -- `SeedRow` (raw SQL literals) continues to work alongside `SeedValues`

## Test plan

- [x] Unit tests for all Go type conversions (string, int, int64, float64, bool, nil, SQLExpr) across all three dialects
- [x] Tests for string escaping (single quotes within strings)
- [x] Tests for mixed SeedRow + SeedValues on the same table
- [x] Tests for empty seed data edge case
- [x] All existing tests pass (`go test ./...`)

Closes #11