### PR TITLE
feat: bulk INSERT builder

### DIFF
--- a/dbrepo/fragments.go
+++ b/dbrepo/fragments.go
@@ -92,6 +92,46 @@ func InsertIntoQ(d chuck.Identifier, table string, cols ...string) string {
 		d.QuoteIdentifier(table), ColumnsQ(d, cols...), Placeholders(cols...))
 }
 
+// BulkInsertInto builds a multi-row INSERT INTO … VALUES … statement with
+// dialect-specific positional placeholders and quoted identifiers.
+//
+// Unlike InsertInto/InsertIntoQ which use @Name placeholders, BulkInsertInto
+// uses the dialect's Placeholder method to produce positional parameters
+// ($1, $2 for Postgres; ? for SQLite; @p1, @p2 for MSSQL).
+//
+// The caller is responsible for ensuring the total parameter count
+// (len(cols) * rowCount) stays within the database engine's limit:
+//   - SQLite:    999 (default SQLITE_MAX_VARIABLE_NUMBER)
+//   - MSSQL:    2100
+//   - Postgres: 65535
+//
+// Example:
+//
+//	BulkInsertInto(pgDialect, "users", []string{"name", "email"}, 3)
+//	// => INSERT INTO "users" ("name", "email") VALUES ($1, $2), ($3, $4), ($5, $6)
+func BulkInsertInto(d chuck.Dialect, table string, cols []string, rowCount int) string {
+	quotedTable := d.QuoteIdentifier(table)
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = d.QuoteIdentifier(c)
+	}
+	colList := strings.Join(quotedCols, ", ")
+
+	rows := make([]string, rowCount)
+	n := 1
+	for r := range rowCount {
+		ph := make([]string, len(cols))
+		for c := range cols {
+			ph[c] = d.Placeholder(n)
+			n++
+		}
+		rows[r] = "(" + strings.Join(ph, ", ") + ")"
+	}
+
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+		quotedTable, colList, strings.Join(rows, ", "))
+}
+
 // NamedArgs converts a map to a slice of sql.NamedArg values suitable for
 // passing to database/sql query methods. Keys are sorted for deterministic output.
 func NamedArgs(m map[string]any) []any {

--- a/dbrepo/fragments_test.go
+++ b/dbrepo/fragments_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/catgoose/chuck"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,6 +25,72 @@ func TestSetClause(t *testing.T) {
 func TestInsertInto(t *testing.T) {
 	result := InsertInto("Users", "Name", "Email")
 	assert.Equal(t, "INSERT INTO Users (Name, Email) VALUES (@Name, @Email)", result)
+}
+
+func TestBulkInsertInto(t *testing.T) {
+	tests := []struct {
+		name     string
+		dialect  chuck.Dialect
+		table    string
+		cols     []string
+		rowCount int
+		want     string
+	}{
+		{
+			name:     "postgres 2 cols 3 rows",
+			dialect:  chuck.PostgresDialect{},
+			table:    "users",
+			cols:     []string{"name", "email"},
+			rowCount: 3,
+			want:     `INSERT INTO "users" ("name", "email") VALUES ($1, $2), ($3, $4), ($5, $6)`,
+		},
+		{
+			name:     "sqlite 2 cols 3 rows",
+			dialect:  chuck.SQLiteDialect{},
+			table:    "Users",
+			cols:     []string{"Name", "Email"},
+			rowCount: 3,
+			want:     `INSERT INTO "Users" ("Name", "Email") VALUES (?, ?), (?, ?), (?, ?)`,
+		},
+		{
+			name:     "mssql 2 cols 3 rows",
+			dialect:  chuck.MSSQLDialect{},
+			table:    "Users",
+			cols:     []string{"Name", "Email"},
+			rowCount: 3,
+			want:     `INSERT INTO [Users] ([Name], [Email]) VALUES (@p1, @p2), (@p3, @p4), (@p5, @p6)`,
+		},
+		{
+			name:     "postgres single row",
+			dialect:  chuck.PostgresDialect{},
+			table:    "events",
+			cols:     []string{"type", "payload", "created_at"},
+			rowCount: 1,
+			want:     `INSERT INTO "events" ("type", "payload", "created_at") VALUES ($1, $2, $3)`,
+		},
+		{
+			name:     "sqlite single column many rows",
+			dialect:  chuck.SQLiteDialect{},
+			table:    "tags",
+			cols:     []string{"label"},
+			rowCount: 5,
+			want:     `INSERT INTO "tags" ("label") VALUES (?), (?), (?), (?), (?)`,
+		},
+		{
+			name:     "mssql 4 cols 2 rows",
+			dialect:  chuck.MSSQLDialect{},
+			table:    "Orders",
+			cols:     []string{"CustomerID", "Product", "Qty", "Price"},
+			rowCount: 2,
+			want:     `INSERT INTO [Orders] ([CustomerID], [Product], [Qty], [Price]) VALUES (@p1, @p2, @p3, @p4), (@p5, @p6, @p7, @p8)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BulkInsertInto(tt.dialect, tt.table, tt.cols, tt.rowCount)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestNamedArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `BulkInsertInto(dialect, table, cols, rowCount)` to the `dbrepo` package for generating multi-row INSERT statements
- Uses each dialect's `Placeholder()` method for correct positional syntax: `$N` (Postgres), `?` (SQLite), `@pN` (MSSQL)
- Quotes table and column identifiers via `QuoteIdentifier()`
- Documents per-engine parameter limits (SQLite 999, MSSQL 2100, Postgres 65535) without auto-chunking

## Test plan

- [x] Postgres: 2 cols x 3 rows, single row with 3 cols
- [x] SQLite: 2 cols x 3 rows, single col x 5 rows
- [x] MSSQL: 2 cols x 3 rows, 4 cols x 2 rows
- [x] All existing tests pass (`go test ./...`)

Closes #5