### PR TITLE
feat: add UPSERT builder (INSERT ... ON CONFLICT DO UPDATE)

### DIFF
--- a/chuck.go
+++ b/chuck.go
@@ -53,6 +53,7 @@ type DDLWriter interface {
 	DropTableIfExists(table string) string
 	CreateIndexIfNotExists(indexName, table, columns string) string
 	InsertOrIgnore(table, columns, values string) string
+	Upsert(table, columns, values, conflictColumns, updateSet string) string
 	ReturningClause(columns string) string
 }
 

--- a/chuck_test.go
+++ b/chuck_test.go
@@ -187,6 +187,15 @@ func TestMSSQLDialect(t *testing.T) {
 		assert.Contains(t, stmt, "'Alice'")
 		assert.Contains(t, stmt, "END CATCH")
 	})
+
+	t.Run("Upsert", func(t *testing.T) {
+		stmt := d.Upsert("Users", "[Name], [Email]", "@Name, @Email", "[Email]", "[Name] = Source.[Name]")
+		assert.Contains(t, stmt, "MERGE [Users] AS Target")
+		assert.Contains(t, stmt, "USING (VALUES (@Name, @Email)) AS Source ([Name], [Email])")
+		assert.Contains(t, stmt, "ON Target.[Email] = Source.[Email]")
+		assert.Contains(t, stmt, "WHEN MATCHED THEN UPDATE SET [Name] = Source.[Name]")
+		assert.Contains(t, stmt, "WHEN NOT MATCHED THEN INSERT ([Name], [Email]) VALUES (@Name, @Email)")
+	})
 }
 
 func TestSQLiteDialect(t *testing.T) {
@@ -270,6 +279,11 @@ func TestSQLiteDialect(t *testing.T) {
 	t.Run("InsertOrIgnore", func(t *testing.T) {
 		stmt := d.InsertOrIgnore("Users", "Name, Email", "'Alice', 'alice@test.com'")
 		assert.Equal(t, `INSERT OR IGNORE INTO "Users" (Name, Email) VALUES ('Alice', 'alice@test.com')`, stmt)
+	})
+
+	t.Run("Upsert", func(t *testing.T) {
+		stmt := d.Upsert("Users", `"Name", "Email"`, "@Name, @Email", `"Email"`, `"Name" = EXCLUDED."Name"`)
+		assert.Equal(t, `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name"`, stmt)
 	})
 }
 
@@ -369,6 +383,11 @@ func TestPostgresDialect(t *testing.T) {
 		stmt := d.InsertOrIgnore("Users", "Name, Email", "'Alice', 'alice@test.com'")
 		assert.Equal(t, `INSERT INTO "Users" (Name, Email) VALUES ('Alice', 'alice@test.com') ON CONFLICT DO NOTHING`, stmt)
 	})
+
+	t.Run("Upsert", func(t *testing.T) {
+		stmt := d.Upsert("Users", `"Name", "Email"`, "@Name, @Email", `"Email"`, `"Name" = EXCLUDED."Name"`)
+		assert.Equal(t, `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name"`, stmt)
+	})
 }
 
 // TestDialectConsistency verifies cross-dialect invariants that all
@@ -414,6 +433,12 @@ func TestDialectConsistency(t *testing.T) {
 				assert.NotEmpty(t, d.ReturningClause("id"),
 					"dialect without SupportsLastInsertID or LastInsertIDQuery must support ReturningClause")
 			}
+		})
+
+		t.Run(name+"/upsert_contains_table_name", func(t *testing.T) {
+			table := "test_table"
+			stmt := d.Upsert(table, "col1, col2", "@col1, @col2", "col1", "col2 = EXCLUDED.col2")
+			assert.Contains(t, stmt, table)
 		})
 
 		t.Run(name+"/ddl_contains_table_name", func(t *testing.T) {

--- a/dbrepo/example_test.go
+++ b/dbrepo/example_test.go
@@ -241,6 +241,13 @@ func ExampleNamedArgs() {
 	// Name=Alice
 }
 
+func ExampleUpsertIntoQ() {
+	d, _ := chuck.New(chuck.Postgres)
+	fmt.Println(dbrepo.UpsertIntoQ(d, "Users", []string{"Email"}, "Email", "Name", "Age"))
+	// Output:
+	// INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name", "Age" = EXCLUDED."Age"
+}
+
 func ExampleBuildOrderByClause() {
 	columnMap := map[string]string{
 		"name":       "Name",

--- a/dbrepo/fragments.go
+++ b/dbrepo/fragments.go
@@ -132,6 +132,75 @@ func BulkInsertInto(d chuck.Dialect, table string, cols []string, rowCount int) 
 		quotedTable, colList, strings.Join(rows, ", "))
 }
 
+// UpsertInto builds a dialect-aware UPSERT statement (INSERT ... ON CONFLICT DO UPDATE
+// or MERGE for MSSQL). conflictCols are the columns that determine uniqueness; all
+// remaining columns in cols are updated on conflict.
+//
+//	UpsertInto(pgDialect, "Users", []string{"Email"}, "Email", "Name", "Age") =>
+//	  INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age)
+//	  ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name", "Age" = EXCLUDED."Age"
+func UpsertInto(d chuck.Dialect, table string, conflictCols []string, cols ...string) string {
+	updateCols := nonConflictCols(cols, conflictCols)
+	updateSet := upsertSetClause(d, updateCols)
+	return d.Upsert(table, Columns(cols...), Placeholders(cols...), Columns(conflictCols...), updateSet)
+}
+
+// UpsertIntoQ builds a dialect-aware UPSERT statement with identifier quoting.
+//
+//	UpsertIntoQ(pgDialect, "Users", []string{"Email"}, "Email", "Name", "Age") =>
+//	  INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age)
+//	  ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name", "Age" = EXCLUDED."Age"
+func UpsertIntoQ(d chuck.Dialect, table string, conflictCols []string, cols ...string) string {
+	updateCols := nonConflictCols(cols, conflictCols)
+	updateSet := upsertSetClauseQ(d, updateCols)
+	return d.Upsert(table, ColumnsQ(d, cols...), Placeholders(cols...), ColumnsQ(d, conflictCols...), updateSet)
+}
+
+// nonConflictCols returns columns from cols that are not in conflictCols.
+func nonConflictCols(cols, conflictCols []string) []string {
+	conflict := make(map[string]bool, len(conflictCols))
+	for _, c := range conflictCols {
+		conflict[c] = true
+	}
+	var result []string
+	for _, c := range cols {
+		if !conflict[c] {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// upsertSetClause builds the SET fragment for an upsert's update portion.
+// For Postgres/SQLite it uses EXCLUDED.col, for MSSQL it uses Source.col.
+func upsertSetClause(d chuck.Dialect, cols []string) string {
+	ref := excludedRef(d)
+	parts := make([]string, len(cols))
+	for i, c := range cols {
+		parts[i] = fmt.Sprintf("%s = %s.%s", c, ref, c)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// upsertSetClauseQ builds the SET fragment with identifier quoting.
+func upsertSetClauseQ(d chuck.Dialect, cols []string) string {
+	ref := excludedRef(d)
+	parts := make([]string, len(cols))
+	for i, c := range cols {
+		qc := d.QuoteIdentifier(c)
+		parts[i] = fmt.Sprintf("%s = %s.%s", qc, ref, qc)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// excludedRef returns the source-row reference keyword for upsert SET clauses.
+func excludedRef(d chuck.Dialect) string {
+	if d.Engine() == chuck.MSSQL {
+		return "Source"
+	}
+	return "EXCLUDED"
+}
+
 // NamedArgs converts a map to a slice of sql.NamedArg values suitable for
 // passing to database/sql query methods. Keys are sorted for deterministic output.
 func NamedArgs(m map[string]any) []any {

--- a/dbrepo/fragments_test.go
+++ b/dbrepo/fragments_test.go
@@ -103,3 +103,76 @@ func TestNamedArgs(t *testing.T) {
 	assert.Equal(t, sql.Named("Email", "gobo@chuck.rock"), args[0])
 	assert.Equal(t, sql.Named("Name", "Gobo"), args[1])
 }
+
+func TestUpsertInto(t *testing.T) {
+	t.Run("Postgres", func(t *testing.T) {
+		d, _ := chuck.New(chuck.Postgres)
+		result := UpsertInto(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		expected := `INSERT INTO "Users" (Email, Name, Age) VALUES (@Email, @Name, @Age) ON CONFLICT (Email) DO UPDATE SET Name = EXCLUDED.Name, Age = EXCLUDED.Age`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("SQLite", func(t *testing.T) {
+		d, _ := chuck.New(chuck.SQLite)
+		result := UpsertInto(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		expected := `INSERT INTO "Users" (Email, Name, Age) VALUES (@Email, @Name, @Age) ON CONFLICT (Email) DO UPDATE SET Name = EXCLUDED.Name, Age = EXCLUDED.Age`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("MSSQL", func(t *testing.T) {
+		d, _ := chuck.New(chuck.MSSQL)
+		result := UpsertInto(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		assert.Contains(t, result, "MERGE [Users] AS Target")
+		assert.Contains(t, result, "USING (VALUES (@Email, @Name, @Age)) AS Source (Email, Name, Age)")
+		assert.Contains(t, result, "ON Target.Email = Source.Email")
+		assert.Contains(t, result, "WHEN MATCHED THEN UPDATE SET Name = Source.Name, Age = Source.Age")
+		assert.Contains(t, result, "WHEN NOT MATCHED THEN INSERT (Email, Name, Age) VALUES (@Email, @Name, @Age)")
+	})
+
+	t.Run("multiple_conflict_columns", func(t *testing.T) {
+		d, _ := chuck.New(chuck.Postgres)
+		result := UpsertInto(d, "Events", []string{"UserID", "EventDate"}, "UserID", "EventDate", "Score", "Notes")
+		expected := `INSERT INTO "Events" (UserID, EventDate, Score, Notes) VALUES (@UserID, @EventDate, @Score, @Notes) ON CONFLICT (UserID, EventDate) DO UPDATE SET Score = EXCLUDED.Score, Notes = EXCLUDED.Notes`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("single_update_column", func(t *testing.T) {
+		d, _ := chuck.New(chuck.Postgres)
+		result := UpsertInto(d, "Config", []string{"Key"}, "Key", "Value")
+		expected := `INSERT INTO "Config" (Key, Value) VALUES (@Key, @Value) ON CONFLICT (Key) DO UPDATE SET Value = EXCLUDED.Value`
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestUpsertIntoQ(t *testing.T) {
+	t.Run("Postgres", func(t *testing.T) {
+		d, _ := chuck.New(chuck.Postgres)
+		result := UpsertIntoQ(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		expected := `INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name", "Age" = EXCLUDED."Age"`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("SQLite", func(t *testing.T) {
+		d, _ := chuck.New(chuck.SQLite)
+		result := UpsertIntoQ(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		expected := `INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name", "Age" = EXCLUDED."Age"`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("MSSQL", func(t *testing.T) {
+		d, _ := chuck.New(chuck.MSSQL)
+		result := UpsertIntoQ(d, "Users", []string{"Email"}, "Email", "Name", "Age")
+		assert.Contains(t, result, "MERGE [Users] AS Target")
+		assert.Contains(t, result, "USING (VALUES (@Email, @Name, @Age)) AS Source ([Email], [Name], [Age])")
+		assert.Contains(t, result, "ON Target.[Email] = Source.[Email]")
+		assert.Contains(t, result, "WHEN MATCHED THEN UPDATE SET [Name] = Source.[Name], [Age] = Source.[Age]")
+		assert.Contains(t, result, "WHEN NOT MATCHED THEN INSERT ([Email], [Name], [Age]) VALUES (@Email, @Name, @Age)")
+	})
+
+	t.Run("multiple_conflict_columns_MSSQL", func(t *testing.T) {
+		d, _ := chuck.New(chuck.MSSQL)
+		result := UpsertIntoQ(d, "Events", []string{"UserID", "EventDate"}, "UserID", "EventDate", "Score")
+		assert.Contains(t, result, "ON Target.[UserID] = Source.[UserID] AND Target.[EventDate] = Source.[EventDate]")
+		assert.Contains(t, result, "WHEN MATCHED THEN UPDATE SET [Score] = Source.[Score]")
+	})
+}

--- a/mssql.go
+++ b/mssql.go
@@ -109,3 +109,21 @@ func (d MSSQLDialect) InsertOrIgnore(table, columns, values string) string {
 		d.QuoteIdentifier(table), columns, values,
 	)
 }
+
+func (d MSSQLDialect) Upsert(table, columns, values, conflictColumns, updateSet string) string {
+	qt := d.QuoteIdentifier(table)
+
+	// Build the ON clause: Target.key = Source.key for each conflict column
+	conflictParts := strings.Split(conflictColumns, ", ")
+	onParts := make([]string, len(conflictParts))
+	for i, col := range conflictParts {
+		col = strings.TrimSpace(col)
+		onParts[i] = fmt.Sprintf("Target.%s = Source.%s", col, col)
+	}
+	onClause := strings.Join(onParts, " AND ")
+
+	return fmt.Sprintf(
+		"MERGE %s AS Target USING (VALUES (%s)) AS Source (%s) ON %s WHEN MATCHED THEN UPDATE SET %s WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);",
+		qt, values, columns, onClause, updateSet, columns, values,
+	)
+}

--- a/postgres.go
+++ b/postgres.go
@@ -84,3 +84,8 @@ func (PostgresDialect) TableColumnsQuery() string {
 func (d PostgresDialect) InsertOrIgnore(table, columns, values string) string {
 	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT DO NOTHING", d.QuoteIdentifier(table), columns, values)
 }
+
+func (d PostgresDialect) Upsert(table, columns, values, conflictColumns, updateSet string) string {
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s",
+		d.QuoteIdentifier(table), columns, values, conflictColumns, updateSet)
+}

--- a/sqlite.go
+++ b/sqlite.go
@@ -84,3 +84,8 @@ func (SQLiteDialect) TableColumnsQuery() string {
 func (d SQLiteDialect) InsertOrIgnore(table, columns, values string) string {
 	return fmt.Sprintf("INSERT OR IGNORE INTO %s (%s) VALUES (%s)", d.QuoteIdentifier(table), columns, values)
 }
+
+func (d SQLiteDialect) Upsert(table, columns, values, conflictColumns, updateSet string) string {
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s",
+		d.QuoteIdentifier(table), columns, values, conflictColumns, updateSet)
+}


### PR DESCRIPTION
## Summary

- Adds `Upsert` method to the `DDLWriter` interface with dialect-specific implementations:
  - **Postgres/SQLite**: `INSERT INTO ... ON CONFLICT (key) DO UPDATE SET col = EXCLUDED.col`
  - **MSSQL**: `MERGE ... USING ... ON ... WHEN MATCHED THEN UPDATE ... WHEN NOT MATCHED THEN INSERT ...`
- Adds `UpsertInto` and `UpsertIntoQ` helpers in `dbrepo` that accept table name, conflict columns, and all columns, automatically building the correct SET clause per dialect
- Comprehensive tests across all three dialects including multi-column conflict keys

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run ./...`)
- [x] New unit tests cover Postgres, SQLite, and MSSQL for both `UpsertInto` and `UpsertIntoQ`
- [x] Tests cover single and multiple conflict columns
- [x] Example test validates quoted Postgres output
- [x] Dialect consistency test verifies all dialects implement `Upsert`

Closes #9