### PR TITLE
feat: add JOIN composition on SelectBuilder

### DIFF
--- a/dbrepo/select_builder.go
+++ b/dbrepo/select_builder.go
@@ -8,10 +8,18 @@ import (
 	"github.com/catgoose/chuck"
 )
 
+// joinClause represents a single JOIN in a SELECT query.
+type joinClause struct {
+	joinType  string // "JOIN" or "LEFT JOIN"
+	table     string
+	condition string
+}
+
 // SelectBuilder constructs composable SELECT queries with WHERE, ORDER BY, and pagination.
 type SelectBuilder struct {
 	table   string
 	cols    string
+	joins   []joinClause
 	where   *WhereBuilder
 	orderBy string
 	limit   int
@@ -61,14 +69,38 @@ func (s *SelectBuilder) WithDialect(d chuck.Dialect) *SelectBuilder {
 	return s
 }
 
+// Join adds an INNER JOIN clause. The table name is dialect-quoted when a dialect
+// is set; the condition is passed through as raw SQL.
+func (s *SelectBuilder) Join(table, condition string) *SelectBuilder {
+	s.joins = append(s.joins, joinClause{joinType: "JOIN", table: table, condition: condition})
+	return s
+}
+
+// LeftJoin adds a LEFT JOIN clause. The table name is dialect-quoted when a dialect
+// is set; the condition is passed through as raw SQL.
+func (s *SelectBuilder) LeftJoin(table, condition string) *SelectBuilder {
+	s.joins = append(s.joins, joinClause{joinType: "LEFT JOIN", table: table, condition: condition})
+	return s
+}
+
 // Build returns the complete SQL query string and the collected arguments.
 func (s *SelectBuilder) Build() (query string, args []any) {
 	var parts []string
 	tableName := s.table
+	cols := s.cols
 	if s.dialect != nil {
 		tableName = s.dialect.QuoteIdentifier(s.table)
+		cols = quoteDotQualifiedColumns(s.dialect, s.cols)
 	}
-	parts = append(parts, fmt.Sprintf("SELECT %s FROM %s", s.cols, tableName))
+	parts = append(parts, fmt.Sprintf("SELECT %s FROM %s", cols, tableName))
+
+	for _, j := range s.joins {
+		jt := j.table
+		if s.dialect != nil {
+			jt = s.dialect.QuoteIdentifier(j.table)
+		}
+		parts = append(parts, fmt.Sprintf("%s %s ON %s", j.joinType, jt, j.condition))
+	}
 
 	if s.where.HasConditions() {
 		parts = append(parts, s.where.String())
@@ -96,7 +128,7 @@ func (s *SelectBuilder) Build() (query string, args []any) {
 	return strings.Join(parts, " "), args
 }
 
-// CountQuery returns a COUNT(*) query using the same FROM and WHERE clauses.
+// CountQuery returns a COUNT(*) query using the same FROM, JOIN, and WHERE clauses.
 func (s *SelectBuilder) CountQuery() (query string, args []any) {
 	var parts []string
 	tableName := s.table
@@ -105,9 +137,36 @@ func (s *SelectBuilder) CountQuery() (query string, args []any) {
 	}
 	parts = append(parts, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName))
 
+	for _, j := range s.joins {
+		jt := j.table
+		if s.dialect != nil {
+			jt = s.dialect.QuoteIdentifier(j.table)
+		}
+		parts = append(parts, fmt.Sprintf("%s %s ON %s", j.joinType, jt, j.condition))
+	}
+
 	if s.where.HasConditions() {
 		parts = append(parts, s.where.String())
 	}
 
 	return strings.Join(parts, " "), s.where.Args()
+}
+
+// quoteDotQualifiedColumns takes a comma-separated column list and quotes only
+// dot-qualified names (Table.Column) by quoting each part separately.
+// Simple column names are left as-is to preserve backward compatibility.
+func quoteDotQualifiedColumns(d chuck.Identifier, cols string) string {
+	parts := strings.Split(cols, ", ")
+	result := make([]string, len(parts))
+	for i, col := range parts {
+		col = strings.TrimSpace(col)
+		if dotIdx := strings.Index(col, "."); dotIdx >= 0 {
+			table := col[:dotIdx]
+			column := col[dotIdx+1:]
+			result[i] = d.QuoteIdentifier(table) + "." + d.QuoteIdentifier(column)
+		} else {
+			result[i] = col
+		}
+	}
+	return strings.Join(result, ", ")
 }

--- a/dbrepo/select_builder_test.go
+++ b/dbrepo/select_builder_test.go
@@ -83,4 +83,114 @@ func TestSelectBuilder(t *testing.T) {
 			Build()
 		assert.Contains(t, sql, "ORDER BY Name ASC, CreatedAt DESC")
 	})
+
+	t.Run("inner_join_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		sql, args := NewSelect("tasks", "tasks.id", "users.name").
+			Join("users", "tasks.assignee_id = users.id").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT "tasks"."id", "users"."name" FROM "tasks" JOIN "users" ON tasks.assignee_id = users.id`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("inner_join_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		sql, args := NewSelect("Tasks", "Tasks.ID", "Users.Name").
+			Join("Users", "Tasks.AssigneeID = Users.ID").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT "Tasks"."ID", "Users"."Name" FROM "Tasks" JOIN "Users" ON Tasks.AssigneeID = Users.ID`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("inner_join_mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		sql, args := NewSelect("Tasks", "Tasks.ID", "Users.Name").
+			Join("Users", "Tasks.AssigneeID = Users.ID").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT [Tasks].[ID], [Users].[Name] FROM [Tasks] JOIN [Users] ON Tasks.AssigneeID = Users.ID`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("left_join_postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		sql, args := NewSelect("tasks", "tasks.id", "users.name").
+			LeftJoin("users", "tasks.assignee_id = users.id").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT "tasks"."id", "users"."name" FROM "tasks" LEFT JOIN "users" ON tasks.assignee_id = users.id`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("left_join_sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		sql, args := NewSelect("Tasks", "Tasks.ID", "Users.Name").
+			LeftJoin("Users", "Tasks.AssigneeID = Users.ID").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT "Tasks"."ID", "Users"."Name" FROM "Tasks" LEFT JOIN "Users" ON Tasks.AssigneeID = Users.ID`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("left_join_mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		sql, args := NewSelect("Tasks", "Tasks.ID", "Users.Name").
+			LeftJoin("Users", "Tasks.AssigneeID = Users.ID").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT [Tasks].[ID], [Users].[Name] FROM [Tasks] LEFT JOIN [Users] ON Tasks.AssigneeID = Users.ID`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("multiple_joins", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		sql, args := NewSelect("tasks", "tasks.id", "users.name", "projects.title").
+			Join("users", "tasks.assignee_id = users.id").
+			LeftJoin("projects", "tasks.project_id = projects.id").
+			WithDialect(d).
+			Build()
+		assert.Equal(t, `SELECT "tasks"."id", "users"."name", "projects"."title" FROM "tasks" JOIN "users" ON tasks.assignee_id = users.id LEFT JOIN "projects" ON tasks.project_id = projects.id`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("join_with_where_orderby_pagination", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		w := NewWhere().NotDeleted().HasStatus("active")
+		sql, args := NewSelect("tasks", "tasks.id", "users.name").
+			Join("users", "tasks.assignee_id = users.id").
+			Where(w).
+			OrderBy("tasks.created_at DESC").
+			Paginate(20, 40).
+			WithDialect(d).
+			Build()
+		assert.Contains(t, sql, `SELECT "tasks"."id", "users"."name" FROM "tasks"`)
+		assert.Contains(t, sql, `JOIN "users" ON tasks.assignee_id = users.id`)
+		assert.Contains(t, sql, "WHERE DeletedAt IS NULL AND Status = @Status")
+		assert.Contains(t, sql, "ORDER BY tasks.created_at DESC")
+		assert.Contains(t, sql, "LIMIT @Limit OFFSET @Offset")
+		assert.Len(t, args, 3, "should have Status + Offset + Limit args")
+	})
+
+	t.Run("count_query_with_join", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		w := NewWhere().NotDeleted()
+		sql, args := NewSelect("tasks", "tasks.id", "users.name").
+			Join("users", "tasks.assignee_id = users.id").
+			Where(w).
+			WithDialect(d).
+			CountQuery()
+		assert.Equal(t, `SELECT COUNT(*) FROM "tasks" JOIN "users" ON tasks.assignee_id = users.id WHERE DeletedAt IS NULL`, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("dot_qualified_columns_without_dialect", func(t *testing.T) {
+		sql, args := NewSelect("Tasks", "Tasks.ID", "Users.Name").
+			Join("Users", "Tasks.AssigneeID = Users.ID").
+			Build()
+		// Without dialect, columns and tables are not quoted
+		assert.Equal(t, "SELECT Tasks.ID, Users.Name FROM Tasks JOIN Users ON Tasks.AssigneeID = Users.ID", sql)
+		assert.Empty(t, args)
+	})
 }


### PR DESCRIPTION
## Summary

- Add `Join()` and `LeftJoin()` methods to `SelectBuilder` for INNER JOIN and LEFT JOIN support
- JOIN clauses are inserted between FROM and WHERE in generated SQL; table names are dialect-quoted, ON conditions pass through as raw SQL
- Dot-qualified column names (`Table.Column`) are quoted per-part when a dialect is set
- `CountQuery()` includes JOIN clauses for accurate counts across joined tables

## Test plan

- [x] INNER JOIN with Postgres, SQLite, and MSSQL dialects
- [x] LEFT JOIN with Postgres, SQLite, and MSSQL dialects
- [x] Multiple JOINs chained (INNER + LEFT)
- [x] JOIN combined with WHERE, ORDER BY, and Pagination
- [x] CountQuery with JOINs
- [x] Dot-qualified column names with and without dialect
- [x] All existing tests pass (`go test ./...`)

Closes #4