### PR TITLE
feat: unique and partial index support

### DIFF
--- a/schema/index.go
+++ b/schema/index.go
@@ -1,12 +1,137 @@
 package schema
 
+import (
+	"fmt"
+
+	"github.com/catgoose/chuck"
+)
+
 // IndexDef defines a table index.
 type IndexDef struct {
 	name    string
 	columns string
+	unique  bool
+	where   string
 }
 
 // Index creates a new index definition.
 func Index(name, columns string) IndexDef {
 	return IndexDef{name: name, columns: columns}
+}
+
+// UniqueIndex creates a unique index definition.
+func UniqueIndex(name, columns string) IndexDef {
+	return IndexDef{name: name, columns: columns, unique: true}
+}
+
+// PartialIndex creates a partial (filtered) index definition with a WHERE clause.
+func PartialIndex(name, columns string) IndexDef {
+	return IndexDef{name: name, columns: columns}
+}
+
+// UniquePartialIndex creates a unique partial (filtered) index definition.
+func UniquePartialIndex(name, columns string) IndexDef {
+	return IndexDef{name: name, columns: columns, unique: true}
+}
+
+// Where sets a filter condition on the index, making it a partial (filtered) index.
+// This returns a new IndexDef with the WHERE clause applied.
+func (idx IndexDef) Where(condition string) IndexDef {
+	idx.where = condition
+	return idx
+}
+
+// ddlIfNotExists renders the CREATE INDEX IF NOT EXISTS statement for the given
+// dialect and table name.
+func (idx IndexDef) ddlIfNotExists(d chuck.Dialect, tableName string) string {
+	return idx.renderDDL(d, tableName, true)
+}
+
+// ddl renders the CREATE INDEX statement for the given dialect and table name.
+func (idx IndexDef) ddl(d chuck.Dialect, tableName string) string {
+	return idx.renderDDL(d, tableName, false)
+}
+
+func (idx IndexDef) renderDDL(d chuck.Dialect, tableName string, ifNotExists bool) string {
+	// For plain indexes (no unique, no where), delegate to the dialect's existing method
+	// to preserve backward compatibility with the original DDL output.
+	if !idx.unique && idx.where == "" {
+		if ifNotExists {
+			return d.CreateIndexIfNotExists(idx.name, tableName, idx.columns)
+		}
+		return idx.buildCreateIndex(d, tableName, false)
+	}
+
+	return idx.buildCreateIndex(d, tableName, ifNotExists)
+}
+
+// buildCreateIndex builds the full CREATE INDEX statement with support for
+// UNIQUE and WHERE clauses across all dialects.
+func (idx IndexDef) buildCreateIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+	switch d.Engine() {
+	case chuck.MSSQL:
+		return idx.buildMSSQLIndex(d, tableName, ifNotExists)
+	default:
+		return idx.buildStandardIndex(d, tableName, ifNotExists)
+	}
+}
+
+// buildStandardIndex generates CREATE INDEX for Postgres and SQLite.
+func (idx IndexDef) buildStandardIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+	s := "CREATE "
+	if idx.unique {
+		s += "UNIQUE "
+	}
+	s += "INDEX "
+	if ifNotExists {
+		s += "IF NOT EXISTS "
+	}
+	s += fmt.Sprintf("%s ON %s(%s)",
+		d.QuoteIdentifier(idx.name),
+		d.QuoteIdentifier(tableName),
+		chuck.QuoteColumns(d, idx.columns),
+	)
+	if idx.where != "" {
+		s += " WHERE " + idx.where
+	}
+	return s
+}
+
+// buildMSSQLIndex generates CREATE INDEX for MSSQL, using the IF NOT EXISTS
+// pattern with sys.indexes.
+func (idx IndexDef) buildMSSQLIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+	qi := d.QuoteIdentifier(idx.name)
+	qt := d.QuoteIdentifier(tableName)
+
+	create := "CREATE "
+	if idx.unique {
+		create += "UNIQUE "
+	}
+	create += fmt.Sprintf("INDEX %s ON %s(%s)", qi, qt, chuck.QuoteColumns(d, idx.columns))
+	if idx.where != "" {
+		create += " WHERE " + idx.where
+	}
+
+	if !ifNotExists {
+		return create
+	}
+
+	// Wrap in IF NOT EXISTS check using sys.indexes
+	return fmt.Sprintf(
+		"IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = N'%s' AND object_id = OBJECT_ID(N'%s')) %s",
+		escapeQuote(idx.name), escapeQuote(tableName), create,
+	)
+}
+
+// escapeQuote doubles single quotes for safe embedding in SQL string literals.
+func escapeQuote(s string) string {
+	result := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			result = append(result, '\'', '\'')
+		} else {
+			result = append(result, s[i])
+		}
+	}
+	return string(result)
 }

--- a/schema/snapshot.go
+++ b/schema/snapshot.go
@@ -28,6 +28,8 @@ type ColumnSnapshot struct {
 type IndexSnapshot struct {
 	Name    string `json:"name"`
 	Columns string `json:"columns"`
+	Unique  bool   `json:"unique,omitempty"`
+	Where   string `json:"where,omitempty"`
 }
 
 // TableSnapshot describes a table's full resolved schema for a given dialect.
@@ -83,6 +85,8 @@ func (t *TableDef) Snapshot(d chuck.Dialect) TableSnapshot {
 		snap.Indexes = append(snap.Indexes, IndexSnapshot{
 			Name:    idx.name,
 			Columns: idx.columns,
+			Unique:  idx.unique,
+			Where:   idx.where,
 		})
 	}
 
@@ -144,7 +148,15 @@ func (t *TableDef) SnapshotString(d chuck.Dialect) string {
 	}
 
 	for _, idx := range snap.Indexes {
-		fmt.Fprintf(&b, "  INDEX %s ON (%s)\n", idx.Name, idx.Columns)
+		prefix := "INDEX"
+		if idx.Unique {
+			prefix = "UNIQUE INDEX"
+		}
+		if idx.Where != "" {
+			fmt.Fprintf(&b, "  %s %s ON (%s) WHERE %s\n", prefix, idx.Name, idx.Columns, idx.Where)
+		} else {
+			fmt.Fprintf(&b, "  %s %s ON (%s)\n", prefix, idx.Name, idx.Columns)
+		}
 	}
 
 	for _, uc := range snap.UniqueConstraints {

--- a/schema/snapshot_test.go
+++ b/schema/snapshot_test.go
@@ -178,6 +178,156 @@ func TestSnapshotCheck(t *testing.T) {
 	})
 }
 
+func TestSnapshotUniqueIndex(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+		).
+		Indexes(
+			UniqueIndex("idx_users_email", "Email"),
+		)
+
+	t.Run("struct_fields", func(t *testing.T) {
+		snap := table.Snapshot(chuck.PostgresDialect{})
+		require.Len(t, snap.Indexes, 1)
+		assert.Equal(t, "idx_users_email", snap.Indexes[0].Name)
+		assert.Equal(t, "Email", snap.Indexes[0].Columns)
+		assert.True(t, snap.Indexes[0].Unique)
+		assert.Empty(t, snap.Indexes[0].Where)
+	})
+
+	t.Run("json_round_trip", func(t *testing.T) {
+		snap := table.Snapshot(chuck.SQLiteDialect{})
+		data, err := json.MarshalIndent(snap, "", "  ")
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"unique": true`)
+
+		var decoded TableSnapshot
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Len(t, decoded.Indexes, 1)
+		assert.True(t, decoded.Indexes[0].Unique)
+		assert.Empty(t, decoded.Indexes[0].Where)
+	})
+
+	t.Run("snapshot_string", func(t *testing.T) {
+		s := table.SnapshotString(chuck.PostgresDialect{})
+		assert.Contains(t, s, "UNIQUE INDEX idx_users_email ON (Email)")
+	})
+}
+
+func TestSnapshotPartialIndex(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			PartialIndex("idx_active_users", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	t.Run("struct_fields", func(t *testing.T) {
+		snap := table.Snapshot(chuck.PostgresDialect{})
+		require.Len(t, snap.Indexes, 1)
+		assert.Equal(t, "idx_active_users", snap.Indexes[0].Name)
+		assert.False(t, snap.Indexes[0].Unique)
+		assert.Equal(t, "DeletedAt IS NULL", snap.Indexes[0].Where)
+	})
+
+	t.Run("json_round_trip", func(t *testing.T) {
+		snap := table.Snapshot(chuck.SQLiteDialect{})
+		data, err := json.MarshalIndent(snap, "", "  ")
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"where": "DeletedAt IS NULL"`)
+
+		var decoded TableSnapshot
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Len(t, decoded.Indexes, 1)
+		assert.False(t, decoded.Indexes[0].Unique)
+		assert.Equal(t, "DeletedAt IS NULL", decoded.Indexes[0].Where)
+	})
+
+	t.Run("snapshot_string", func(t *testing.T) {
+		s := table.SnapshotString(chuck.PostgresDialect{})
+		assert.Contains(t, s, "INDEX idx_active_users ON (Email) WHERE DeletedAt IS NULL")
+		assert.NotContains(t, s, "UNIQUE INDEX idx_active_users")
+	})
+}
+
+func TestSnapshotUniquePartialIndex(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			UniquePartialIndex("idx_users_email_active", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	t.Run("struct_fields", func(t *testing.T) {
+		snap := table.Snapshot(chuck.PostgresDialect{})
+		require.Len(t, snap.Indexes, 1)
+		idx := snap.Indexes[0]
+		assert.Equal(t, "idx_users_email_active", idx.Name)
+		assert.True(t, idx.Unique)
+		assert.Equal(t, "DeletedAt IS NULL", idx.Where)
+	})
+
+	t.Run("json_round_trip", func(t *testing.T) {
+		snap := table.Snapshot(chuck.SQLiteDialect{})
+		data, err := json.MarshalIndent(snap, "", "  ")
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"unique": true`)
+		assert.Contains(t, string(data), `"where": "DeletedAt IS NULL"`)
+
+		var decoded TableSnapshot
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Len(t, decoded.Indexes, 1)
+		assert.True(t, decoded.Indexes[0].Unique)
+		assert.Equal(t, "DeletedAt IS NULL", decoded.Indexes[0].Where)
+	})
+
+	t.Run("snapshot_string", func(t *testing.T) {
+		s := table.SnapshotString(chuck.PostgresDialect{})
+		assert.Contains(t, s, "UNIQUE INDEX idx_users_email_active ON (Email) WHERE DeletedAt IS NULL")
+	})
+}
+
+func TestSnapshotMixedIndexes(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("Name", TypeString(255)),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			Index("idx_users_name", "Name"),
+			UniqueIndex("idx_users_email", "Email"),
+			UniquePartialIndex("idx_users_email_active", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	snap := table.Snapshot(chuck.PostgresDialect{})
+	require.Len(t, snap.Indexes, 3)
+
+	// Plain index
+	assert.Equal(t, "idx_users_name", snap.Indexes[0].Name)
+	assert.False(t, snap.Indexes[0].Unique)
+	assert.Empty(t, snap.Indexes[0].Where)
+
+	// Unique index
+	assert.Equal(t, "idx_users_email", snap.Indexes[1].Name)
+	assert.True(t, snap.Indexes[1].Unique)
+	assert.Empty(t, snap.Indexes[1].Where)
+
+	// Unique partial index
+	assert.Equal(t, "idx_users_email_active", snap.Indexes[2].Name)
+	assert.True(t, snap.Indexes[2].Unique)
+	assert.Equal(t, "DeletedAt IS NULL", snap.Indexes[2].Where)
+}
+
 func TestSchemaSnapshot(t *testing.T) {
 	users := NewTable("Users").
 		Columns(AutoIncrCol("ID"))

--- a/schema/table.go
+++ b/schema/table.go
@@ -299,7 +299,7 @@ func (t *TableDef) CreateSQL(d chuck.Dialect) []string {
 
 	stmts := []string{create}
 	for _, idx := range t.indexes {
-		stmts = append(stmts, d.CreateIndexIfNotExists(idx.name, tableName, idx.columns))
+		stmts = append(stmts, idx.ddl(d, tableName))
 	}
 	return stmts
 }
@@ -311,7 +311,7 @@ func (t *TableDef) CreateIfNotExistsSQL(d chuck.Dialect) []string {
 
 	stmts := []string{create}
 	for _, idx := range t.indexes {
-		stmts = append(stmts, d.CreateIndexIfNotExists(idx.name, tableName, idx.columns))
+		stmts = append(stmts, idx.ddlIfNotExists(d, tableName))
 	}
 	return stmts
 }

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -540,6 +540,138 @@ func TestCreateSQL(t *testing.T) {
 	})
 }
 
+func TestUniqueIndexDDL(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+		).
+		Indexes(
+			UniqueIndex("idx_users_email", "Email"),
+		)
+
+	t.Run("postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_email" ON "users"("email")`, stmts[1])
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_email" ON "Users"("Email")`, stmts[1])
+	})
+
+	t.Run("mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[1], "IF NOT EXISTS")
+		assert.Contains(t, stmts[1], "CREATE UNIQUE INDEX [idx_users_email] ON [Users]([Email])")
+	})
+}
+
+func TestPartialIndexDDL(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			PartialIndex("idx_active_users", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	t.Run("postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE INDEX IF NOT EXISTS "idx_active_users" ON "users"("email") WHERE DeletedAt IS NULL`, stmts[1])
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE INDEX IF NOT EXISTS "idx_active_users" ON "Users"("Email") WHERE DeletedAt IS NULL`, stmts[1])
+	})
+
+	t.Run("mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[1], "IF NOT EXISTS")
+		assert.Contains(t, stmts[1], "CREATE INDEX [idx_active_users] ON [Users]([Email]) WHERE DeletedAt IS NULL")
+	})
+}
+
+func TestUniquePartialIndexDDL(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			UniquePartialIndex("idx_users_email_active", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	t.Run("postgres", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_email_active" ON "users"("email") WHERE DeletedAt IS NULL`, stmts[1])
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Equal(t, `CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_email_active" ON "Users"("Email") WHERE DeletedAt IS NULL`, stmts[1])
+	})
+
+	t.Run("mssql", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		stmts := table.CreateIfNotExistsSQL(d)
+		require.Len(t, stmts, 2)
+		assert.Contains(t, stmts[1], "IF NOT EXISTS")
+		assert.Contains(t, stmts[1], "CREATE UNIQUE INDEX [idx_users_email_active] ON [Users]([Email]) WHERE DeletedAt IS NULL")
+	})
+}
+
+func TestCreateSQLWithUniqueAndPartialIndexes(t *testing.T) {
+	table := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("DeletedAt", TypeTimestamp()),
+		).
+		Indexes(
+			Index("idx_users_email", "Email"),
+			UniqueIndex("idx_users_email_uniq", "Email"),
+			UniquePartialIndex("idx_users_email_active", "Email").Where("DeletedAt IS NULL"),
+		)
+
+	d := chuck.SQLiteDialect{}
+	stmts := table.CreateSQL(d)
+	require.Len(t, stmts, 4) // CREATE TABLE + 3 indexes
+
+	// Plain index (no IF NOT EXISTS in CreateSQL)
+	assert.Contains(t, stmts[1], `"idx_users_email"`)
+	assert.NotContains(t, stmts[1], "UNIQUE")
+
+	// Unique index
+	assert.Contains(t, stmts[2], "CREATE UNIQUE INDEX")
+	assert.Contains(t, stmts[2], `"idx_users_email_uniq"`)
+
+	// Unique partial index
+	assert.Contains(t, stmts[3], "CREATE UNIQUE INDEX")
+	assert.Contains(t, stmts[3], `"idx_users_email_active"`)
+	assert.Contains(t, stmts[3], "WHERE DeletedAt IS NULL")
+}
+
 func TestTypeFuncs(t *testing.T) {
 	d := chuck.PostgresDialect{}
 


### PR DESCRIPTION
## Summary
- Extends `IndexDef` with `unique` and `where` fields, adding `UniqueIndex`, `PartialIndex`, `UniquePartialIndex` constructors and a `Where()` method
- Generates correct `CREATE [UNIQUE] INDEX ... [WHERE ...]` DDL for Postgres, SQLite, and MSSQL (filtered indexes)
- `IndexSnapshot` now includes `Unique` and `Where` fields; `SnapshotString` renders them in human-readable output
- Plain indexes still delegate to the dialect's `CreateIndexIfNotExists` for full backward compatibility

## Test plan
- [x] `TestUniqueIndexDDL` — unique index DDL for all 3 dialects
- [x] `TestPartialIndexDDL` — partial/filtered index DDL for all 3 dialects
- [x] `TestUniquePartialIndexDDL` — combined unique + partial for all 3 dialects
- [x] `TestCreateSQLWithUniqueAndPartialIndexes` — integration with `CreateSQL` output
- [x] `TestSnapshotUniqueIndex` — snapshot struct, JSON round-trip, snapshot string
- [x] `TestSnapshotPartialIndex` — snapshot struct, JSON round-trip, snapshot string
- [x] `TestSnapshotUniquePartialIndex` — snapshot struct, JSON round-trip, snapshot string
- [x] `TestSnapshotMixedIndexes` — mixed plain/unique/partial in one table
- [x] All existing tests pass unchanged

Closes #7