### PR TITLE
feat: add IsNull and Concat dialect-aware expression helpers

### DIFF
--- a/chuck.go
+++ b/chuck.go
@@ -64,6 +64,13 @@ type QueryWriter interface {
 	Now() string
 	LastInsertIDQuery() string
 	SupportsLastInsertID() bool
+	// IsNull returns a dialect-specific expression that evaluates to fallback
+	// when col is NULL (e.g. COALESCE, IFNULL, ISNULL).
+	IsNull(col, fallback string) string
+	// Concat returns a dialect-specific concatenation of the given parts.
+	// Parts wrapped in single quotes (string literals) are passed through as-is;
+	// bare identifiers are normalized and quoted.
+	Concat(parts ...string) string
 }
 
 // Identifier handles SQL identifier formatting.
@@ -111,6 +118,11 @@ func QuoteColumns(d Identifier, columns string) string {
 		quoted[i] = d.QuoteIdentifier(d.NormalizeIdentifier(part)) + suffix
 	}
 	return strings.Join(quoted, ", ")
+}
+
+// isStringLiteral reports whether s is a SQL string literal (wrapped in single quotes).
+func isStringLiteral(s string) bool {
+	return len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\''
 }
 
 // New returns a Dialect for the given engine.

--- a/chuck_test.go
+++ b/chuck_test.go
@@ -196,6 +196,16 @@ func TestMSSQLDialect(t *testing.T) {
 		assert.Contains(t, stmt, "WHEN MATCHED THEN UPDATE SET [Name] = Source.[Name]")
 		assert.Contains(t, stmt, "WHEN NOT MATCHED THEN INSERT ([Name], [Email]) VALUES (@Name, @Email)")
 	})
+
+	t.Run("IsNull", func(t *testing.T) {
+		assert.Equal(t, "ISNULL([Col], 'default')", d.IsNull("Col", "'default'"))
+		assert.Equal(t, "ISNULL([Price], 0)", d.IsNull("Price", "0"))
+	})
+
+	t.Run("Concat", func(t *testing.T) {
+		assert.Equal(t, "[First] + [Last]", d.Concat("First", "Last"))
+		assert.Equal(t, "[First] + ' ' + [Last]", d.Concat("First", "' '", "Last"))
+	})
 }
 
 func TestSQLiteDialect(t *testing.T) {
@@ -284,6 +294,16 @@ func TestSQLiteDialect(t *testing.T) {
 	t.Run("Upsert", func(t *testing.T) {
 		stmt := d.Upsert("Users", `"Name", "Email"`, "@Name, @Email", `"Email"`, `"Name" = EXCLUDED."Name"`)
 		assert.Equal(t, `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name"`, stmt)
+	})
+
+	t.Run("IsNull", func(t *testing.T) {
+		assert.Equal(t, `IFNULL("Col", 'default')`, d.IsNull("Col", "'default'"))
+		assert.Equal(t, `IFNULL("Price", 0)`, d.IsNull("Price", "0"))
+	})
+
+	t.Run("Concat", func(t *testing.T) {
+		assert.Equal(t, `"First" || "Last"`, d.Concat("First", "Last"))
+		assert.Equal(t, `"First" || ' ' || "Last"`, d.Concat("First", "' '", "Last"))
 	})
 }
 
@@ -388,6 +408,18 @@ func TestPostgresDialect(t *testing.T) {
 		stmt := d.Upsert("Users", `"Name", "Email"`, "@Name, @Email", `"Email"`, `"Name" = EXCLUDED."Name"`)
 		assert.Equal(t, `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email) ON CONFLICT ("Email") DO UPDATE SET "Name" = EXCLUDED."Name"`, stmt)
 	})
+
+	t.Run("IsNull", func(t *testing.T) {
+		// Postgres normalizes identifiers to snake_case
+		assert.Equal(t, `COALESCE("col", 'default')`, d.IsNull("Col", "'default'"))
+		assert.Equal(t, `COALESCE("price", 0)`, d.IsNull("Price", "0"))
+	})
+
+	t.Run("Concat", func(t *testing.T) {
+		// Postgres normalizes identifiers to snake_case
+		assert.Equal(t, `"first" || "last"`, d.Concat("First", "Last"))
+		assert.Equal(t, `"first" || ' ' || "last"`, d.Concat("First", "' '", "Last"))
+	})
 }
 
 // TestDialectConsistency verifies cross-dialect invariants that all
@@ -424,6 +456,8 @@ func TestDialectConsistency(t *testing.T) {
 			assert.NotEmpty(t, d.CreateIndexIfNotExists("idx", "t", "col"))
 			assert.NotEmpty(t, d.TableExistsQuery())
 			assert.NotEmpty(t, d.TableColumnsQuery())
+			assert.NotEmpty(t, d.IsNull("col", "'fallback'"))
+			assert.NotEmpty(t, d.Concat("a", "b"))
 		})
 
 		t.Run(name+"/last_insert_id_consistency", func(t *testing.T) {

--- a/mssql.go
+++ b/mssql.go
@@ -91,6 +91,22 @@ func (d MSSQLDialect) CreateIndexIfNotExists(indexName, table, columns string) s
 	)
 }
 
+func (d MSSQLDialect) IsNull(col, fallback string) string {
+	return fmt.Sprintf("ISNULL(%s, %s)", d.QuoteIdentifier(d.NormalizeIdentifier(col)), fallback)
+}
+
+func (d MSSQLDialect) Concat(parts ...string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		if isStringLiteral(p) {
+			quoted[i] = p
+		} else {
+			quoted[i] = d.QuoteIdentifier(d.NormalizeIdentifier(p))
+		}
+	}
+	return strings.Join(quoted, " + ")
+}
+
 func (MSSQLDialect) LastInsertIDQuery() string { return "SELECT SCOPE_IDENTITY() AS ID" }
 
 func (MSSQLDialect) SupportsLastInsertID() bool { return false }

--- a/postgres.go
+++ b/postgres.go
@@ -1,6 +1,9 @@
 package chuck
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Compile-time interface checks.
 var (
@@ -68,6 +71,22 @@ func (d PostgresDialect) DropTableIfExists(table string) string {
 func (d PostgresDialect) CreateIndexIfNotExists(indexName, table, columns string) string {
 	return fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)",
 		d.QuoteIdentifier(indexName), d.QuoteIdentifier(table), QuoteColumns(d, columns))
+}
+
+func (d PostgresDialect) IsNull(col, fallback string) string {
+	return fmt.Sprintf("COALESCE(%s, %s)", d.QuoteIdentifier(d.NormalizeIdentifier(col)), fallback)
+}
+
+func (d PostgresDialect) Concat(parts ...string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		if isStringLiteral(p) {
+			quoted[i] = p
+		} else {
+			quoted[i] = d.QuoteIdentifier(d.NormalizeIdentifier(p))
+		}
+	}
+	return strings.Join(quoted, " || ")
 }
 
 func (PostgresDialect) LastInsertIDQuery() string { return "" }

--- a/sqlite.go
+++ b/sqlite.go
@@ -1,6 +1,9 @@
 package chuck
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Compile-time interface checks.
 var (
@@ -67,6 +70,22 @@ func (d SQLiteDialect) DropTableIfExists(table string) string {
 func (d SQLiteDialect) CreateIndexIfNotExists(indexName, table, columns string) string {
 	return fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s(%s)",
 		d.QuoteIdentifier(indexName), d.QuoteIdentifier(table), QuoteColumns(d, columns))
+}
+
+func (d SQLiteDialect) IsNull(col, fallback string) string {
+	return fmt.Sprintf("IFNULL(%s, %s)", d.QuoteIdentifier(d.NormalizeIdentifier(col)), fallback)
+}
+
+func (d SQLiteDialect) Concat(parts ...string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		if isStringLiteral(p) {
+			quoted[i] = p
+		} else {
+			quoted[i] = d.QuoteIdentifier(d.NormalizeIdentifier(p))
+		}
+	}
+	return strings.Join(quoted, " || ")
 }
 
 func (SQLiteDialect) LastInsertIDQuery() string { return "" }


### PR DESCRIPTION
## Summary
- Adds `IsNull(col, fallback)` to `QueryWriter` interface: uses `COALESCE` (Postgres), `IFNULL` (SQLite), `ISNULL` (MSSQL)
- Adds `Concat(parts...)` to `QueryWriter` interface: uses `||` operator (Postgres/SQLite), `+` operator (MSSQL)
- String literals (single-quoted values) pass through as-is; bare identifiers get dialect-normalized and quoted
- Skips `CurrentTimestamp()` since `Now()` already covers that dialect mapping
- Includes tests for all helpers across all 3 dialects plus cross-dialect consistency checks

Closes #15