### PR TITLE
feat: structured schema diff and mode-based Ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
     - [Schema Snapshots](#schema-snapshots)
     - [Live Schema Snapshots](#live-schema-snapshots)
     - [Schema Validation](#schema-validation)
+    - [Schema Ensure](#schema-ensure)
+      - [Structured Diffs](#structured-diffs)
   - [Composable SQL Fragments (`dbrepo`)](#composable-sql-fragments-dbrepo)
     - [Building Queries](#building-queries)
     - [WhereBuilder](#wherebuilder)
@@ -465,6 +467,96 @@ Multi-table variant:
 snaps, err := schema.LiveSchemaSnapshot(ctx, db, dialect, "users", "tasks", "statuses")
 ```
 
+For structured, machine-readable drift detection (JSON output, typed diffs), see `DiffSchema` and `DiffAll` in the [Schema Ensure](#schema-ensure) section below.
+
+### Schema Ensure
+
+> grug note: in development, grug want table to appear when grug declare it. in production,
+> grug want loud alarm if table not match declaration. grug not want same behavior in both places.
+> grug has mass enlightenment: same function, different mode.
+
+`Ensure` validates your schema against the live database -- and in development, bootstraps what's missing. Your schema definition is the covenant. Ensure enforces it.
+
+| Mode         | Missing tables      | Drift in existing tables | Makes changes? |
+| ------------ | ------------------- | ------------------------ | -------------- |
+| `ModeStrict` | Error               | Error                    | Never          |
+| `ModeDev`    | Auto-create + seed  | Error                    | Creates only   |
+| `ModeDryRun` | Reports in diff     | Reports in diff          | Never          |
+
+**ModeStrict** -- production. The covenant is law. If the schema doesn't match, you hear about it immediately:
+
+```go
+result, err := schema.Ensure(ctx, db, dialect, tables, schema.WithMode(schema.ModeStrict))
+if err != nil {
+    var ensureErr *schema.EnsureError
+    if errors.As(err, &ensureErr) {
+        for _, d := range ensureErr.Diffs {
+            log.Printf("drift: %s", d.Table)
+        }
+    }
+}
+```
+
+**ModeDev** -- convenience. Tables appear when you declare them. Seed data flows in. But if an existing table has drifted, you still get an error -- the covenant holds for what already exists:
+
+```go
+result, err := schema.Ensure(ctx, db, dialect, tables, schema.WithMode(schema.ModeDev))
+// result.TablesCreated: ["statuses", "tasks"]
+// result.TablesSeeded:  ["statuses"]
+```
+
+Tables are created in foreign-key order automatically. No manual ordering needed.
+
+**ModeDryRun** -- measure twice, cut once. Reports everything, changes nothing. Use before deploying to see exactly what's different:
+
+```go
+result, _ := schema.Ensure(ctx, db, dialect, tables,
+    schema.WithMode(schema.ModeDryRun),
+    schema.WithDiffOutput(os.Stdout),
+)
+for _, d := range result.Diffs {
+    if d.HasDrift {
+        log.Printf("%s has drift", d.Table)
+    }
+}
+```
+
+#### Structured Diffs
+
+The diff is the representation that carries controls. It tells you -- or your CI pipeline, or an agent -- exactly what changed and what to do about it. No migration framework. No up/down files. The diff IS the instruction set.
+
+```go
+diff, err := schema.DiffSchema(ctx, db, dialect, TasksTable)
+// diff.AddedColumns   -- in your code, not in the database
+// diff.RemovedColumns  -- in the database, not in your code
+// diff.ChangedColumns  -- nullability mismatches
+// diff.MissingIndexes  -- declared indexes not found live
+// diff.ExtraIndexes    -- live indexes not in your declaration
+// diff.TableMissing    -- table doesn't exist at all
+// diff.HasDrift        -- true if any of the above are non-empty
+```
+
+Diffs are JSON-serializable. Write them to a file for CI artifacts, pipe them to stdout for review, or feed them to whatever consumes structured data:
+
+```go
+// Write a single diff
+diff.WriteTo(os.Stdout)
+diff.WriteJSON("drift-report.json")
+
+// Write all diffs
+diffs, _ := schema.DiffAll(ctx, db, dialect, UsersTable, TasksTable)
+schema.WriteDiffsTo(diffs, os.Stdout)
+schema.WriteDiffsJSON(diffs, "all-diffs.json")
+
+// Or capture during Ensure
+var buf bytes.Buffer
+schema.Ensure(ctx, db, dialect, tables,
+    schema.WithMode(schema.ModeDryRun),
+    schema.WithDiffOutput(&buf),
+    schema.WithDiffFile("ensure-report.json"),
+)
+```
+
 ## Composable SQL Fragments (`dbrepo`)
 
 The `dbrepo` package provides composable helpers that keep SQL visible. Functions use `@Name` placeholders with `sql.Named()` for dialect-agnostic parameter binding.
@@ -631,23 +723,24 @@ Chuck follows Go's values and the [dothog design philosophy](https://github.com/
 ## Architecture
 
 ```
-  ┌─────────────────────────────────────────────────┐
-  │                  your application                │
-  │                                                 │
-  │  schema.NewTable("Tasks")     dbrepo.NewWhere() │
-  │        │                            │           │
-  └────────┼────────────────────────────┼───────────┘
-           │                            │
-           v                            v
-  ┌─────────────────────────────────────────────────┐
-  │                    chuck                       │
-  │                                                 │
-  │  Dialect interface                              │
-  │  ┌──────────┬──────────┬──────────┐             │
-  │  │TypeMapper│DDLWriter │QueryWriter│             │
-  │  │Identifier│Inspector │          │             │
-  │  └──────────┴──────────┴──────────┘             │
-  └────────┬───────────┬───────────┬────────────────┘
+  ┌─────────────────────────────────────────────────────────┐
+  │                    your application                      │
+  │                                                         │
+  │  schema.NewTable("Tasks")   schema.Ensure()   dbrepo   │
+  │        │                       │                  │     │
+  └────────┼───────────────────────┼──────────────────┼─────┘
+           │                       │                  │
+           v                       v                  v
+  ┌─────────────────────────────────────────────────────────┐
+  │                       chuck                             │
+  │                                                         │
+  │  Dialect interface         Ensure pipeline              │
+  │  ┌──────────┬──────────┐   ┌────────────────────────┐   │
+  │  │TypeMapper│DDLWriter │   │ DiffSchema → SchemaDiff│   │
+  │  │Query     │Identifier│   │ Strict / Dev / DryRun  │   │
+  │  │Writer   │Inspector │   │ JSON diff output       │   │
+  │  └──────────┴──────────┘   └────────────────────────┘   │
+  └────────┬───────────┬───────────┬────────────────────────┘
            │           │           │
       ┌────v────┐ ┌────v────┐ ┌───v─────┐
       │ SQLite  │ │Postgres │ │  MSSQL  │
@@ -656,7 +749,8 @@ Chuck follows Go's values and the [dothog design philosophy](https://github.com/
 
 One schema definition at the top, dialect-specific SQL at the bottom. Chuck
 generates DDL, column lists, seed data, and query fragments for whichever
-engine you're running.
+engine you're running. `Ensure` ties it together: validate in production,
+bootstrap in development, diff before deploying.
 
 ## License
 

--- a/schema/diff.go
+++ b/schema/diff.go
@@ -1,0 +1,183 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// SchemaDiff is a structured diff between a declared schema and a live database.
+// It is JSON-serializable and designed for consumption by developers, agents, and CI tools.
+type SchemaDiff struct {
+	Table          string           `json:"table"`
+	TableMissing   bool             `json:"table_missing,omitempty"`
+	AddedColumns   []ColumnSnapshot `json:"added_columns,omitempty"`
+	RemovedColumns []string         `json:"removed_columns,omitempty"`
+	ChangedColumns []ColumnDiff     `json:"changed_columns,omitempty"`
+	MissingIndexes []IndexSnapshot  `json:"missing_indexes,omitempty"`
+	ExtraIndexes   []string         `json:"extra_indexes,omitempty"`
+	HasDrift       bool             `json:"has_drift"`
+}
+
+// ColumnDiff describes a column that exists in both declared and live schemas
+// but has mismatched properties.
+type ColumnDiff struct {
+	Name            string `json:"name"`
+	DeclaredNotNull bool   `json:"declared_not_null"`
+	LiveNullable    bool   `json:"live_nullable"`
+	DeclaredType    string `json:"declared_type,omitempty"`
+	LiveType        string `json:"live_type,omitempty"`
+}
+
+// DiffSchema compares a declared table against the live database and returns
+// a structured diff. If the table doesn't exist, TableMissing is true.
+func DiffSchema(ctx context.Context, db *sql.DB, d chuck.Dialect, td *TableDef) (*SchemaDiff, error) {
+	tableName := d.NormalizeIdentifier(td.Name)
+	diff := &SchemaDiff{Table: tableName}
+
+	live, err := LiveSnapshot(ctx, db, d, tableName)
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			diff.TableMissing = true
+			diff.HasDrift = true
+			return diff, nil
+		}
+		return nil, err
+	}
+
+	declared := td.Snapshot(d)
+
+	// Build lookup maps
+	liveColMap := make(map[string]LiveColumnSnapshot, len(live.Columns))
+	for _, lc := range live.Columns {
+		liveColMap[lc.Name] = lc
+	}
+
+	declaredColMap := make(map[string]ColumnSnapshot, len(declared.Columns))
+	for _, dc := range declared.Columns {
+		declaredColMap[dc.Name] = dc
+	}
+
+	// Columns in declared but not in live (added)
+	for _, dc := range declared.Columns {
+		if _, ok := liveColMap[dc.Name]; !ok {
+			diff.AddedColumns = append(diff.AddedColumns, dc)
+		}
+	}
+
+	// Columns in live but not in declared (removed)
+	for _, lc := range live.Columns {
+		if _, ok := declaredColMap[lc.Name]; !ok {
+			diff.RemovedColumns = append(diff.RemovedColumns, lc.Name)
+		}
+	}
+
+	// Columns in both but with mismatches
+	for _, dc := range declared.Columns {
+		lc, ok := liveColMap[dc.Name]
+		if !ok {
+			continue
+		}
+		if dc.NotNull != !lc.Nullable {
+			diff.ChangedColumns = append(diff.ChangedColumns, ColumnDiff{
+				Name:            dc.Name,
+				DeclaredNotNull: dc.NotNull,
+				LiveNullable:    lc.Nullable,
+				DeclaredType:    dc.Type,
+				LiveType:        lc.Type,
+			})
+		}
+	}
+
+	// Indexes in declared but not in live
+	liveIndexMap := make(map[string]bool, len(live.Indexes))
+	for _, idx := range live.Indexes {
+		liveIndexMap[idx.Name] = true
+	}
+	for _, idx := range declared.Indexes {
+		if !liveIndexMap[idx.Name] {
+			diff.MissingIndexes = append(diff.MissingIndexes, idx)
+		}
+	}
+
+	// Indexes in live but not in declared
+	declaredIndexMap := make(map[string]bool, len(declared.Indexes))
+	for _, idx := range declared.Indexes {
+		declaredIndexMap[idx.Name] = true
+	}
+	for _, idx := range live.Indexes {
+		if !declaredIndexMap[idx.Name] {
+			diff.ExtraIndexes = append(diff.ExtraIndexes, idx.Name)
+		}
+	}
+
+	diff.HasDrift = len(diff.AddedColumns) > 0 ||
+		len(diff.RemovedColumns) > 0 ||
+		len(diff.ChangedColumns) > 0 ||
+		len(diff.MissingIndexes) > 0 ||
+		len(diff.ExtraIndexes) > 0
+
+	return diff, nil
+}
+
+// DiffAll diffs multiple tables.
+func DiffAll(ctx context.Context, db *sql.DB, d chuck.Dialect, tables ...*TableDef) ([]*SchemaDiff, error) {
+	diffs := make([]*SchemaDiff, 0, len(tables))
+	for _, td := range tables {
+		diff, err := DiffSchema(ctx, db, d, td)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, diff)
+	}
+	return diffs, nil
+}
+
+// WriteTo writes the diff as formatted JSON to an io.Writer.
+func (d *SchemaDiff) WriteTo(w io.Writer) (int64, error) {
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return 0, err
+	}
+	data = append(data, '\n')
+	n, err := w.Write(data)
+	return int64(n), err
+}
+
+// WriteJSON writes the diff as formatted JSON to a file path.
+func (d *SchemaDiff) WriteJSON(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = d.WriteTo(f)
+	return err
+}
+
+// WriteDiffsTo writes multiple diffs as a JSON array to an io.Writer.
+func WriteDiffsTo(diffs []*SchemaDiff, w io.Writer) (int64, error) {
+	data, err := json.MarshalIndent(diffs, "", "  ")
+	if err != nil {
+		return 0, err
+	}
+	data = append(data, '\n')
+	n, err := w.Write(data)
+	return int64(n), err
+}
+
+// WriteDiffsJSON writes multiple diffs as a JSON array to a file path.
+func WriteDiffsJSON(diffs []*SchemaDiff, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = WriteDiffsTo(diffs, f)
+	return err
+}

--- a/schema/diff_test.go
+++ b/schema/diff_test.go
@@ -1,0 +1,273 @@
+package schema
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/catgoose/chuck/driver/sqlite"
+)
+
+func TestDiffSchema(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+			Col("Status", TypeVarchar(50)).NotNull().Default("'active'"),
+		).
+		Indexes(
+			Index("idx_items_name", "Name"),
+		)
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	t.Run("no_drift", func(t *testing.T) {
+		diff, err := DiffSchema(ctx, db, d, table)
+		require.NoError(t, err)
+		assert.False(t, diff.HasDrift)
+		assert.False(t, diff.TableMissing)
+		assert.Empty(t, diff.AddedColumns)
+		assert.Empty(t, diff.RemovedColumns)
+		assert.Empty(t, diff.ChangedColumns)
+		assert.Empty(t, diff.MissingIndexes)
+		assert.Empty(t, diff.ExtraIndexes)
+	})
+
+	t.Run("missing_column", func(t *testing.T) {
+		// Declare a table with an extra column not in DB
+		extra := NewTable("Items").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("Name", TypeString(255)).NotNull(),
+				Col("Status", TypeVarchar(50)).NotNull(),
+				Col("Priority", TypeInt()),
+			)
+
+		diff, err := DiffSchema(ctx, db, d, extra)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		require.Len(t, diff.AddedColumns, 1)
+		assert.Equal(t, "Priority", diff.AddedColumns[0].Name)
+	})
+
+	t.Run("extra_column", func(t *testing.T) {
+		// Declare fewer columns than exist in DB
+		fewer := NewTable("Items").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("Name", TypeString(255)).NotNull(),
+			)
+
+		diff, err := DiffSchema(ctx, db, d, fewer)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		require.Len(t, diff.RemovedColumns, 1)
+		assert.Equal(t, "Status", diff.RemovedColumns[0])
+	})
+
+	t.Run("nullability_mismatch", func(t *testing.T) {
+		// Declare Status as nullable, but it's NOT NULL in the DB
+		mismatch := NewTable("Items").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("Name", TypeString(255)).NotNull(),
+				Col("Status", TypeVarchar(50)),
+			)
+
+		diff, err := DiffSchema(ctx, db, d, mismatch)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		require.Len(t, diff.ChangedColumns, 1)
+		assert.Equal(t, "Status", diff.ChangedColumns[0].Name)
+		assert.False(t, diff.ChangedColumns[0].DeclaredNotNull)
+		assert.False(t, diff.ChangedColumns[0].LiveNullable) // NOT NULL in DB = not nullable
+	})
+
+	t.Run("missing_table", func(t *testing.T) {
+		missing := NewTable("Nonexistent").
+			Columns(AutoIncrCol("ID"))
+
+		diff, err := DiffSchema(ctx, db, d, missing)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		assert.True(t, diff.TableMissing)
+	})
+
+	t.Run("missing_index", func(t *testing.T) {
+		withExtraIndex := NewTable("Items").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("Name", TypeString(255)).NotNull(),
+				Col("Status", TypeVarchar(50)).NotNull(),
+			).
+			Indexes(
+				Index("idx_items_name", "Name"),
+				Index("idx_items_status", "Status"),
+			)
+
+		diff, err := DiffSchema(ctx, db, d, withExtraIndex)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		require.Len(t, diff.MissingIndexes, 1)
+		assert.Equal(t, "idx_items_status", diff.MissingIndexes[0].Name)
+	})
+
+	t.Run("extra_index", func(t *testing.T) {
+		// Declare no indexes, but the DB has one
+		noIndexes := NewTable("Items").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("Name", TypeString(255)).NotNull(),
+				Col("Status", TypeVarchar(50)).NotNull(),
+			)
+
+		diff, err := DiffSchema(ctx, db, d, noIndexes)
+		require.NoError(t, err)
+		assert.True(t, diff.HasDrift)
+		require.Len(t, diff.ExtraIndexes, 1)
+		assert.Equal(t, "idx_items_name", diff.ExtraIndexes[0])
+	})
+}
+
+func TestDiffSchemaWriteTo(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	diff, err := DiffSchema(ctx, db, d, table)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	n, err := diff.WriteTo(&buf)
+	require.NoError(t, err)
+	assert.Greater(t, n, int64(0))
+
+	// Verify it's valid JSON
+	var parsed SchemaDiff
+	err = json.Unmarshal(buf.Bytes(), &parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "Items", parsed.Table)
+	assert.False(t, parsed.HasDrift)
+}
+
+func TestDiffSchemaWriteJSON(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	diff, err := DiffSchema(ctx, db, d, table)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "diff.json")
+	err = diff.WriteJSON(path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var parsed SchemaDiff
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "Items", parsed.Table)
+}
+
+func TestDiffAll(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	users := NewTable("Users").
+		Columns(AutoIncrCol("ID"), Col("Name", TypeString(255)).NotNull())
+	tasks := NewTable("Tasks").
+		Columns(AutoIncrCol("ID"), Col("Title", TypeString(255)).NotNull())
+
+	// Only create Users, not Tasks
+	for _, stmt := range users.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	diffs, err := DiffAll(ctx, db, d, users, tasks)
+	require.NoError(t, err)
+	require.Len(t, diffs, 2)
+
+	// Users should have no drift
+	assert.False(t, diffs[0].HasDrift)
+
+	// Tasks should be missing
+	assert.True(t, diffs[1].HasDrift)
+	assert.True(t, diffs[1].TableMissing)
+}
+
+func TestWriteDiffsTo(t *testing.T) {
+	diffs := []*SchemaDiff{
+		{Table: "Users", HasDrift: false},
+		{Table: "Tasks", TableMissing: true, HasDrift: true},
+	}
+
+	var buf bytes.Buffer
+	n, err := WriteDiffsTo(diffs, &buf)
+	require.NoError(t, err)
+	assert.Greater(t, n, int64(0))
+
+	var parsed []*SchemaDiff
+	err = json.Unmarshal(buf.Bytes(), &parsed)
+	require.NoError(t, err)
+	require.Len(t, parsed, 2)
+	assert.Equal(t, "Users", parsed[0].Table)
+	assert.True(t, parsed[1].TableMissing)
+}
+
+func TestWriteDiffsJSON(t *testing.T) {
+	diffs := []*SchemaDiff{
+		{Table: "Users", HasDrift: false},
+	}
+
+	path := filepath.Join(t.TempDir(), "diffs.json")
+	err := WriteDiffsJSON(diffs, path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var parsed []*SchemaDiff
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	require.Len(t, parsed, 1)
+}

--- a/schema/ensure.go
+++ b/schema/ensure.go
@@ -1,0 +1,250 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// Mode controls how Ensure handles schema state.
+type Mode int
+
+const (
+	// ModeStrict validates only. Any drift or missing tables cause an error.
+	// Use in production.
+	ModeStrict Mode = iota
+
+	// ModeDev creates missing tables and seeds them, but errors on drift
+	// in existing tables. Use in development.
+	ModeDev
+
+	// ModeDryRun reports all drift without making any changes.
+	// Use for pre-deploy checks.
+	ModeDryRun
+)
+
+// String returns the mode name.
+func (m Mode) String() string {
+	switch m {
+	case ModeStrict:
+		return "strict"
+	case ModeDev:
+		return "dev"
+	case ModeDryRun:
+		return "dryrun"
+	default:
+		return fmt.Sprintf("Mode(%d)", int(m))
+	}
+}
+
+// EnsureOption configures Ensure behavior.
+type EnsureOption func(*ensureConfig)
+
+type ensureConfig struct {
+	mode       Mode
+	diffOutput io.Writer
+	diffPath   string
+}
+
+// WithMode sets the ensure mode. Default is ModeStrict.
+func WithMode(m Mode) EnsureOption {
+	return func(c *ensureConfig) {
+		c.mode = m
+	}
+}
+
+// WithDiffOutput writes structured JSON diffs to the given writer when drift is found.
+func WithDiffOutput(w io.Writer) EnsureOption {
+	return func(c *ensureConfig) {
+		c.diffOutput = w
+	}
+}
+
+// WithDiffFile writes structured JSON diffs to the given file path when drift is found.
+func WithDiffFile(path string) EnsureOption {
+	return func(c *ensureConfig) {
+		c.diffPath = path
+	}
+}
+
+// EnsureResult contains the outcome of an Ensure call.
+type EnsureResult struct {
+	// TablesCreated lists tables that were auto-created (ModeDev only).
+	TablesCreated []string
+	// TablesSeeded lists tables that had seed data applied (ModeDev only).
+	TablesSeeded []string
+	// Diffs contains structured diffs for any tables with drift.
+	Diffs []*SchemaDiff
+}
+
+// EnsureError is returned when Ensure detects schema drift.
+type EnsureError struct {
+	Diffs []*SchemaDiff
+}
+
+func (e *EnsureError) Error() string {
+	var parts []string
+	for _, d := range e.Diffs {
+		if d.TableMissing {
+			parts = append(parts, fmt.Sprintf("table %q: missing", d.Table))
+			continue
+		}
+		var issues []string
+		if len(d.AddedColumns) > 0 {
+			names := make([]string, len(d.AddedColumns))
+			for i, c := range d.AddedColumns {
+				names[i] = c.Name
+			}
+			issues = append(issues, fmt.Sprintf("%d missing column(s): %s", len(d.AddedColumns), strings.Join(names, ", ")))
+		}
+		if len(d.RemovedColumns) > 0 {
+			issues = append(issues, fmt.Sprintf("%d extra column(s): %s", len(d.RemovedColumns), strings.Join(d.RemovedColumns, ", ")))
+		}
+		if len(d.ChangedColumns) > 0 {
+			names := make([]string, len(d.ChangedColumns))
+			for i, c := range d.ChangedColumns {
+				names[i] = c.Name
+			}
+			issues = append(issues, fmt.Sprintf("%d changed column(s): %s", len(d.ChangedColumns), strings.Join(names, ", ")))
+		}
+		if len(d.MissingIndexes) > 0 {
+			names := make([]string, len(d.MissingIndexes))
+			for i, idx := range d.MissingIndexes {
+				names[i] = idx.Name
+			}
+			issues = append(issues, fmt.Sprintf("%d missing index(es): %s", len(d.MissingIndexes), strings.Join(names, ", ")))
+		}
+		if len(d.ExtraIndexes) > 0 {
+			issues = append(issues, fmt.Sprintf("%d extra index(es): %s", len(d.ExtraIndexes), strings.Join(d.ExtraIndexes, ", ")))
+		}
+		parts = append(parts, fmt.Sprintf("table %q: %s", d.Table, strings.Join(issues, "; ")))
+	}
+	return fmt.Sprintf("schema drift detected: %s", strings.Join(parts, ", "))
+}
+
+// Ensure validates (and optionally bootstraps) the database schema for all given tables.
+func Ensure(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef, opts ...EnsureOption) (*EnsureResult, error) {
+	cfg := &ensureConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	result := &EnsureResult{}
+
+	switch cfg.mode {
+	case ModeStrict:
+		return ensureStrict(ctx, db, d, tables, cfg, result)
+	case ModeDev:
+		return ensureDev(ctx, db, d, tables, cfg, result)
+	case ModeDryRun:
+		return ensureDryRun(ctx, db, d, tables, cfg, result)
+	default:
+		return nil, fmt.Errorf("unknown ensure mode: %d", int(cfg.mode))
+	}
+}
+
+func ensureStrict(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef, cfg *ensureConfig, result *EnsureResult) (*EnsureResult, error) {
+	var drifted []*SchemaDiff
+	for _, td := range tables {
+		diff, err := DiffSchema(ctx, db, d, td)
+		if err != nil {
+			return nil, err
+		}
+		if diff.HasDrift {
+			drifted = append(drifted, diff)
+		}
+	}
+
+	if len(drifted) > 0 {
+		result.Diffs = drifted
+		writeDiffs(drifted, cfg)
+		return result, &EnsureError{Diffs: drifted}
+	}
+	return result, nil
+}
+
+func ensureDev(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef, cfg *ensureConfig, result *EnsureResult) (*EnsureResult, error) {
+	ordered, err := CreationOrder(tables...)
+	if err != nil {
+		return nil, fmt.Errorf("ensure dev: %w", err)
+	}
+
+	var drifted []*SchemaDiff
+	for _, td := range ordered {
+		tableName := d.NormalizeIdentifier(td.Name)
+
+		// Check if table exists by attempting a diff
+		diff, err := DiffSchema(ctx, db, d, td)
+		if err != nil {
+			return nil, err
+		}
+
+		if diff.TableMissing {
+			// Create the table
+			for _, stmt := range td.CreateIfNotExistsSQL(d) {
+				if _, err := db.ExecContext(ctx, stmt); err != nil {
+					return nil, fmt.Errorf("create table %q: %w", tableName, err)
+				}
+			}
+			result.TablesCreated = append(result.TablesCreated, tableName)
+
+			// Seed the table
+			if td.HasSeedData() {
+				for _, stmt := range td.SeedSQL(d) {
+					if _, err := db.ExecContext(ctx, stmt); err != nil {
+						return nil, fmt.Errorf("seed table %q: %w", tableName, err)
+					}
+				}
+				result.TablesSeeded = append(result.TablesSeeded, tableName)
+			}
+			continue
+		}
+
+		if diff.HasDrift {
+			drifted = append(drifted, diff)
+		}
+	}
+
+	if len(drifted) > 0 {
+		result.Diffs = drifted
+		writeDiffs(drifted, cfg)
+		return result, &EnsureError{Diffs: drifted}
+	}
+	return result, nil
+}
+
+func ensureDryRun(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef, cfg *ensureConfig, result *EnsureResult) (*EnsureResult, error) {
+	for _, td := range tables {
+		diff, err := DiffSchema(ctx, db, d, td)
+		if err != nil {
+			return nil, err
+		}
+		result.Diffs = append(result.Diffs, diff)
+	}
+
+	// Write diffs if any have drift
+	var drifted []*SchemaDiff
+	for _, diff := range result.Diffs {
+		if diff.HasDrift {
+			drifted = append(drifted, diff)
+		}
+	}
+	if len(drifted) > 0 {
+		writeDiffs(drifted, cfg)
+	}
+
+	return result, nil
+}
+
+func writeDiffs(diffs []*SchemaDiff, cfg *ensureConfig) {
+	if cfg.diffOutput != nil {
+		WriteDiffsTo(diffs, cfg.diffOutput) //nolint:errcheck
+	}
+	if cfg.diffPath != "" {
+		WriteDiffsJSON(diffs, cfg.diffPath) //nolint:errcheck
+	}
+}

--- a/schema/ensure_test.go
+++ b/schema/ensure_test.go
@@ -1,0 +1,326 @@
+package schema
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/catgoose/chuck/driver/sqlite"
+)
+
+func TestEnsureModeString(t *testing.T) {
+	assert.Equal(t, "strict", ModeStrict.String())
+	assert.Equal(t, "dev", ModeDev.String())
+	assert.Equal(t, "dryrun", ModeDryRun.String())
+	assert.Equal(t, "Mode(99)", Mode(99).String())
+}
+
+func TestEnsureStrictValidSchema(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	result, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeStrict))
+	require.NoError(t, err)
+	assert.Empty(t, result.Diffs)
+	assert.Empty(t, result.TablesCreated)
+	assert.Empty(t, result.TablesSeeded)
+}
+
+func TestEnsureStrictWithDrift(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	// Create table with 2 columns
+	actual := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+	for _, stmt := range actual.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	// Declare table with 3 columns (drift)
+	declared := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+			Col("Status", TypeVarchar(50)).NotNull(),
+		)
+
+	result, err := Ensure(ctx, db, d, []*TableDef{declared}, WithMode(ModeStrict))
+	require.Error(t, err)
+
+	var ensureErr *EnsureError
+	require.ErrorAs(t, err, &ensureErr)
+	require.Len(t, ensureErr.Diffs, 1)
+	assert.True(t, ensureErr.Diffs[0].HasDrift)
+	assert.Contains(t, err.Error(), "schema drift detected")
+
+	// Result should also contain the diffs
+	require.Len(t, result.Diffs, 1)
+}
+
+func TestEnsureStrictMissingTable(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Missing").
+		Columns(AutoIncrCol("ID"))
+
+	result, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeStrict))
+	require.Error(t, err)
+
+	var ensureErr *EnsureError
+	require.ErrorAs(t, err, &ensureErr)
+	require.Len(t, ensureErr.Diffs, 1)
+	assert.True(t, ensureErr.Diffs[0].TableMissing)
+	assert.NotNil(t, result)
+}
+
+func TestEnsureDevMissingTable(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		).
+		WithSeedRows(
+			SeedRow{"Name": "'default'"},
+		)
+
+	result, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeDev))
+	require.NoError(t, err)
+	assert.Contains(t, result.TablesCreated, "Items")
+	assert.Contains(t, result.TablesSeeded, "Items")
+
+	// Verify the table was actually created
+	var count int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Items").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count) // seed row
+}
+
+func TestEnsureDevExistingTableWithDrift(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	// Create table with 2 columns
+	actual := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+	for _, stmt := range actual.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	// Declare table with 3 columns (drift)
+	declared := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+			Col("Status", TypeVarchar(50)).NotNull(),
+		)
+
+	_, err := Ensure(ctx, db, d, []*TableDef{declared}, WithMode(ModeDev))
+	require.Error(t, err)
+
+	var ensureErr *EnsureError
+	require.ErrorAs(t, err, &ensureErr)
+	assert.Len(t, ensureErr.Diffs, 1)
+}
+
+func TestEnsureDevValidExistingTable(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	result, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeDev))
+	require.NoError(t, err)
+	assert.Empty(t, result.TablesCreated)
+	assert.Empty(t, result.TablesSeeded)
+	assert.Empty(t, result.Diffs)
+}
+
+func TestEnsureDevFKOrder(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	users := NewTable("Users").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+
+	tasks := NewTable("Tasks").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Title", TypeString(255)).NotNull(),
+			Col("UserID", TypeInt()).References("Users", "ID"),
+		)
+
+	// Pass tasks first — Ensure should still create users before tasks
+	result, err := Ensure(ctx, db, d, []*TableDef{tasks, users}, WithMode(ModeDev))
+	require.NoError(t, err)
+	require.Len(t, result.TablesCreated, 2)
+	// Users should be created before Tasks
+	assert.Equal(t, "Users", result.TablesCreated[0])
+	assert.Equal(t, "Tasks", result.TablesCreated[1])
+}
+
+func TestEnsureDryRun(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	existing := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+		)
+	for _, stmt := range existing.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	// Declare Items with extra column + a missing table
+	declared := NewTable("Items").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeString(255)).NotNull(),
+			Col("Status", TypeVarchar(50)),
+		)
+	missing := NewTable("Other").
+		Columns(AutoIncrCol("ID"))
+
+	result, err := Ensure(ctx, db, d, []*TableDef{declared, missing}, WithMode(ModeDryRun))
+	require.NoError(t, err) // DryRun never errors
+
+	// Should have diffs for both tables
+	require.Len(t, result.Diffs, 2)
+	assert.True(t, result.Diffs[0].HasDrift) // Items has drift
+	assert.True(t, result.Diffs[1].HasDrift) // Other is missing
+	assert.True(t, result.Diffs[1].TableMissing)
+
+	// Verify nothing was created
+	var count int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Other'").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestEnsureWithDiffOutput(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Missing").
+		Columns(AutoIncrCol("ID"))
+
+	var buf bytes.Buffer
+	_, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeStrict), WithDiffOutput(&buf))
+	require.Error(t, err)
+
+	// Verify JSON was written
+	assert.Greater(t, buf.Len(), 0)
+	var diffs []*SchemaDiff
+	err = json.Unmarshal(buf.Bytes(), &diffs)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.True(t, diffs[0].TableMissing)
+}
+
+func TestEnsureWithDiffFile(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Missing").
+		Columns(AutoIncrCol("ID"))
+
+	path := filepath.Join(t.TempDir(), "diffs.json")
+	_, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeStrict), WithDiffFile(path))
+	require.Error(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var diffs []*SchemaDiff
+	err = json.Unmarshal(data, &diffs)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.True(t, diffs[0].TableMissing)
+}
+
+func TestEnsureDryRunWithDiffOutput(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Missing").
+		Columns(AutoIncrCol("ID"))
+
+	var buf bytes.Buffer
+	result, err := Ensure(ctx, db, d, []*TableDef{table}, WithMode(ModeDryRun), WithDiffOutput(&buf))
+	require.NoError(t, err)
+	require.Len(t, result.Diffs, 1)
+
+	// DryRun should still write diffs
+	assert.Greater(t, buf.Len(), 0)
+}
+
+func TestEnsureDefaultIsStrict(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := chuck.SQLiteDialect{}
+
+	table := NewTable("Missing").
+		Columns(AutoIncrCol("ID"))
+
+	// No WithMode — should default to ModeStrict
+	_, err := Ensure(ctx, db, d, []*TableDef{table})
+	require.Error(t, err)
+
+	var ensureErr *EnsureError
+	require.ErrorAs(t, err, &ensureErr)
+}


### PR DESCRIPTION
## Summary

- Adds `DiffSchema` and `DiffAll` functions that return structured `SchemaDiff` values (JSON-serializable) for detecting schema drift between declared and live schemas
- Adds `Ensure` function with three modes: `ModeStrict` (validate only, for production), `ModeDev` (auto-create missing tables + seed, for development), `ModeDryRun` (report without changes, for pre-deploy checks)
- Supports writing diffs to `io.Writer` or file path via `WithDiffOutput` and `WithDiffFile` options
- Updates README with Schema Ensure documentation and updated architecture diagram

## Test plan

- [x] `DiffSchema` with matching schema (no drift)
- [x] `DiffSchema` with missing column, extra column, nullability mismatch, missing table, missing/extra indexes
- [x] `WriteTo` produces valid JSON
- [x] `DiffAll` with multiple tables
- [x] `WriteJSON` and `WriteDiffsJSON` write to disk
- [x] `ModeStrict` with valid schema (no error)
- [x] `ModeStrict` with drift and missing table (returns `EnsureError`)
- [x] `ModeDev` auto-creates missing tables with seed data
- [x] `ModeDev` respects FK ordering via `CreationOrder`
- [x] `ModeDev` errors on drift in existing tables
- [x] `ModeDryRun` always succeeds, reports everything
- [x] `WithDiffOutput` and `WithDiffFile` capture JSON in all modes
- [x] All tests use SQLite in-memory (no external deps)

Closes #2