### PR TITLE
fix: validate WhereBuilder overrides and share SQLite URL defaults

### DIFF
--- a/dbrepo/where.go
+++ b/dbrepo/where.go
@@ -118,9 +118,18 @@ func (w *WhereBuilder) HasConditions() bool {
 }
 
 // colName returns the first non-empty override, or the default.
+//
+// Override identifiers are validated against validIdentifier — the same rule
+// Search uses for field names — so callers cannot smuggle arbitrary SQL through
+// the helper override parameters. When the override is present but does not
+// match validIdentifier, colName falls back to the default name. Empty or
+// missing overrides also return the default. Qualified names like
+// "t.deleted_at" are accepted because validIdentifier permits dots.
 func colName(defaultName string, override []string) string {
 	if len(override) > 0 && override[0] != "" {
-		return override[0]
+		if validIdentifier.MatchString(override[0]) {
+			return override[0]
+		}
 	}
 	return defaultName
 }

--- a/dbrepo/where_test.go
+++ b/dbrepo/where_test.go
@@ -162,6 +162,155 @@ func TestWhereTraitFiltersCustomColumns(t *testing.T) {
 	})
 }
 
+func TestWhereTraitFiltersInvalidOverrides(t *testing.T) {
+	// invalidOverrides covers the representative malicious / malformed
+	// inputs the helpers must reject in favor of their default column.
+	invalidOverrides := []string{
+		"Status; DROP TABLE users--",
+		"1bad",
+		"a b",
+		"users.name desc",
+	}
+
+	t.Run("not_deleted_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().NotDeleted(override)
+			assert.Equal(t, "WHERE DeletedAt IS NULL", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("not_deleted_valid_still_works", func(t *testing.T) {
+		w := NewWhere().NotDeleted("deleted_at")
+		assert.Equal(t, "WHERE deleted_at IS NULL", w.String())
+	})
+
+	t.Run("not_expired_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().NotExpired(override)
+			assert.Contains(t, w.String(), "ExpiresAt IS NULL OR ExpiresAt > CURRENT_TIMESTAMP", "override=%q", override)
+		}
+	})
+
+	t.Run("not_expired_valid_still_works", func(t *testing.T) {
+		w := NewWhere().NotExpired("expires_at")
+		assert.Contains(t, w.String(), "expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP")
+	})
+
+	t.Run("has_status_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().HasStatus("active", override)
+			assert.Contains(t, w.String(), "Status = @Status", "override=%q", override)
+			assert.NotContains(t, w.String(), "DROP TABLE", "override=%q", override)
+		}
+	})
+
+	t.Run("has_status_valid_still_works", func(t *testing.T) {
+		w := NewWhere().HasStatus("active", "status")
+		assert.Contains(t, w.String(), "status = @Status")
+	})
+
+	t.Run("is_root_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().IsRoot(override)
+			assert.Equal(t, "WHERE ParentID IS NULL", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("is_root_valid_still_works", func(t *testing.T) {
+		w := NewWhere().IsRoot("parent_id")
+		assert.Equal(t, "WHERE parent_id IS NULL", w.String())
+	})
+
+	t.Run("has_parent_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().HasParent(42, override)
+			assert.Contains(t, w.String(), "ParentID = @ParentID", "override=%q", override)
+			assert.NotContains(t, w.String(), "DROP TABLE", "override=%q", override)
+		}
+	})
+
+	t.Run("has_parent_valid_still_works", func(t *testing.T) {
+		w := NewWhere().HasParent(42, "parent_id")
+		assert.Contains(t, w.String(), "parent_id = @ParentID")
+	})
+
+	t.Run("not_replaced_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().NotReplaced(override)
+			assert.Equal(t, "WHERE ReplacedByID IS NULL", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("not_replaced_valid_still_works", func(t *testing.T) {
+		w := NewWhere().NotReplaced("replaced_by_id")
+		assert.Equal(t, "WHERE replaced_by_id IS NULL", w.String())
+	})
+
+	t.Run("replaced_by_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().ReplacedBy(7, override)
+			assert.Contains(t, w.String(), "ReplacedByID = @ReplacedByID", "override=%q", override)
+			assert.NotContains(t, w.String(), "DROP TABLE", "override=%q", override)
+		}
+	})
+
+	t.Run("replaced_by_valid_still_works", func(t *testing.T) {
+		w := NewWhere().ReplacedBy(7, "replaced_by_id")
+		assert.Contains(t, w.String(), "replaced_by_id = @ReplacedByID")
+	})
+
+	t.Run("not_archived_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().NotArchived(override)
+			assert.Equal(t, "WHERE ArchivedAt IS NULL", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("not_archived_valid_still_works", func(t *testing.T) {
+		w := NewWhere().NotArchived("archived_at")
+		assert.Equal(t, "WHERE archived_at IS NULL", w.String())
+	})
+
+	t.Run("not_archived_bool_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().NotArchivedBool(override)
+			assert.Equal(t, "WHERE NOT archived", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("not_archived_bool_valid_still_works", func(t *testing.T) {
+		w := NewWhere().NotArchivedBool("is_archived")
+		assert.Equal(t, "WHERE NOT is_archived", w.String())
+	})
+
+	t.Run("not_archived_bool_invalid_falls_back_mssql", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().WithDialect(chuck.MSSQLDialect{}).NotArchivedBool(override)
+			assert.Equal(t, "WHERE archived = 0", w.String(), "override=%q", override)
+		}
+	})
+
+	t.Run("has_version_invalid_falls_back", func(t *testing.T) {
+		for _, override := range invalidOverrides {
+			w := NewWhere().HasVersion(3, override)
+			assert.Contains(t, w.String(), "Version = @Version", "override=%q", override)
+			assert.NotContains(t, w.String(), "DROP TABLE", "override=%q", override)
+		}
+	})
+
+	t.Run("has_version_valid_still_works", func(t *testing.T) {
+		w := NewWhere().HasVersion(3, "version")
+		assert.Contains(t, w.String(), "version = @Version")
+	})
+
+	t.Run("qualified_override_still_works", func(t *testing.T) {
+		// validIdentifier permits dots, so dot-qualified names like "t.deleted_at"
+		// should pass through unchanged.
+		w := NewWhere().NotDeleted("t.deleted_at")
+		assert.Equal(t, "WHERE t.deleted_at IS NULL", w.String())
+	})
+}
+
 func TestWhereSearch(t *testing.T) {
 	t.Run("with_search", func(t *testing.T) {
 		w := NewWhere().Search("gobo", "Name", "Email")

--- a/open.go
+++ b/open.go
@@ -88,31 +88,33 @@ func OpenURL(ctx context.Context, dsn string) (*sql.DB, Dialect, error) {
 }
 
 // openSQLiteFromURL opens a SQLite database from a URL path (after stripping the scheme).
-// For :memory: and file paths, it opens a basic connection without the WAL/pool settings
-// that OpenSQLite applies — use OpenSQLite directly for production SQLite connections.
+// It applies the same defaults as OpenSQLite — WAL journal mode, 30s busy timeout,
+// the conservative connection pool, and parent directory creation for file-backed paths —
+// by delegating to openSQLiteWithDefaults.
 func openSQLiteFromURL(ctx context.Context, path string) (*sql.DB, Dialect, error) {
-	db, err := sql.Open("sqlite3", path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open sqlite: %w", err)
-	}
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, nil, fmt.Errorf("ping sqlite: %w", err)
-	}
-	return db, SQLiteDialect{}, nil
+	return openSQLiteWithDefaults(ctx, path)
 }
 
 // OpenSQLite opens a SQLite database at the given path with standard settings:
 // WAL journal mode, 30s busy timeout, and conservative pool settings (1 conn).
 // Returns the raw *sql.DB and the SQLite Dialect.
 func OpenSQLite(ctx context.Context, dbPath string) (*sql.DB, Dialect, error) {
-	if dbPath != ":memory:" {
-		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	return openSQLiteWithDefaults(ctx, dbPath)
+}
+
+// openSQLiteWithDefaults opens a SQLite database at the given path and applies
+// chuck's standard SQLite settings: parent directory creation (skipped for
+// ":memory:"), WAL journal mode, a 30s busy timeout, and a conservative
+// connection pool (one connection). It is shared by OpenSQLite and
+// openSQLiteFromURL so URL-based opens get the same defaults as direct ones.
+func openSQLiteWithDefaults(ctx context.Context, path string) (*sql.DB, Dialect, error) {
+	if path != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return nil, nil, fmt.Errorf("failed to create database directory: %w", err)
 		}
 	}
 
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -192,3 +192,61 @@ func TestOpenSQLiteReturnsDialect(t *testing.T) {
 	assert.Equal(t, "RETURNING id", d.ReturningClause("id"))
 }
 
+func TestOpenURLSQLiteFileAppliesWALMode(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wal_test.db")
+
+	db, _, err := OpenURL(ctx, "sqlite://"+dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var journalMode string
+	err = db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journalMode)
+	require.NoError(t, err)
+	assert.Equal(t, "wal", journalMode)
+}
+
+func TestOpenURLSQLiteFileAppliesBusyTimeout(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "busy_test.db")
+
+	db, _, err := OpenURL(ctx, "sqlite://"+dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var busyTimeout int
+	err = db.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busyTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, 30000, busyTimeout)
+}
+
+func TestOpenURLSQLiteFileAppliesConnectionPool(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "pool_test.db")
+
+	db, _, err := OpenURL(ctx, "sqlite://"+dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	stats := db.Stats()
+	assert.Equal(t, 1, stats.MaxOpenConnections)
+}
+
+func TestOpenURLSQLiteMemoryStillWorks(t *testing.T) {
+	ctx := context.Background()
+	db, d, err := OpenURL(ctx, "sqlite://:memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	assert.Equal(t, SQLite, d.Engine())
+	assert.NoError(t, db.PingContext(ctx))
+
+	var journalMode string
+	err = db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journalMode)
+	require.NoError(t, err)
+	// In-memory databases may report "memory" instead of "wal"
+	assert.Contains(t, []string{"wal", "memory"}, journalMode)
+}


### PR DESCRIPTION
## Summary

- **#61 / `dbrepo/where.go`**: `colName` now validates override column names against `validIdentifier` (the same regex `Search` uses) and falls back to the default when an override is missing, empty, or invalid. All trait helpers (`NotDeleted`, `HasStatus`, `HasParent`, `NotReplaced`, `ReplacedBy`, `NotArchived`, `NotArchivedBool`, `HasVersion`, `IsRoot`, `NotExpired`) inherit this behavior with no signature changes. Dot-qualified names like `t.deleted_at` continue to work because `validIdentifier` permits dots. Raw `And`/`Or` escape hatches are unchanged.
- **#59 / `open.go`**: Extracted a private `openSQLiteWithDefaults` helper that handles parent directory creation (skipped for `:memory:`), `sql.Open`, the conservative connection pool, `PRAGMA journal_mode=WAL`, `PRAGMA busy_timeout=30000`, and `PingContext` with full error wrapping. Both `OpenSQLite` and `openSQLiteFromURL` delegate to it, so URL-based SQLite connections now get the same defaults as direct ones. Public signatures and the URL parsing logic in `OpenURL` are untouched.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass locally)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New `TestWhereTraitFiltersInvalidOverrides` covers each helper with the representative invalid inputs from the plan (`"Status; DROP TABLE users--"`, `"1bad"`, `"a b"`, `"users.name desc"`) plus a positive snake_case spot-check per helper and a `t.deleted_at` qualified-name regression test
- [x] New `TestOpenURLSQLiteFile{AppliesWALMode,AppliesBusyTimeout,AppliesConnectionPool}` and `TestOpenURLSQLiteMemoryStillWorks` exercise the URL path against the same defaults the existing direct-`OpenSQLite` tests assert
- [x] Existing `OpenURL` tests for non-SQLite branches still pass unchanged

Fixes #61
Fixes #59