### PR TITLE
fix: reconstruct parameterized MSSQL column types in live snapshot

### DIFF
--- a/schema/live_snapshot.go
+++ b/schema/live_snapshot.go
@@ -78,14 +78,26 @@ func LiveSchemaSnapshot(ctx context.Context, db *sql.DB, d chuck.Dialect, tableN
 }
 
 func queryColumns(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveColumnSnapshot, error) {
+	switch d.Engine() {
+	case chuck.SQLite, chuck.Postgres:
+		return queryColumnsSimple(ctx, db, d, tableName)
+	case chuck.MSSQL:
+		return queryColumnsMSSQL(ctx, db, tableName)
+	default:
+		return nil, fmt.Errorf("unsupported engine: %s", d.Engine())
+	}
+}
+
+// queryColumnsSimple handles engines whose column queries return the shared
+// 4-column shape (name, type, nullable, default) and need no per-column
+// reconstruction work. Used by SQLite and Postgres.
+func queryColumnsSimple(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveColumnSnapshot, error) {
 	var query string
 	switch d.Engine() {
 	case chuck.SQLite:
 		query = `SELECT name, type, CASE WHEN "notnull" = 1 OR pk = 1 THEN 'NO' ELSE 'YES' END AS nullable, COALESCE(dflt_value, '') AS dflt FROM pragma_table_info(?)`
 	case chuck.Postgres:
 		query = postgresColumnQuery
-	case chuck.MSSQL:
-		query = `SELECT COLUMN_NAME, UPPER(DATA_TYPE), IS_NULLABLE, COALESCE(COLUMN_DEFAULT, '') FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @p1 ORDER BY ORDINAL_POSITION`
 	default:
 		return nil, fmt.Errorf("unsupported engine: %s", d.Engine())
 	}
@@ -110,6 +122,71 @@ func queryColumns(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName st
 		})
 	}
 	return cols, rows.Err()
+}
+
+// mssqlColumnQuery selects the metadata needed to reconstruct parameterized
+// MSSQL column type strings. CHARACTER_MAXIMUM_LENGTH is in characters (not
+// bytes) per the SQL Server INFORMATION_SCHEMA.COLUMNS contract, with -1
+// indicating MAX. NUMERIC_PRECISION/NUMERIC_SCALE are populated for numeric
+// types and NULL otherwise. All three are nullable, hence the NullInt64 scans.
+var mssqlColumnQuery = `SELECT COLUMN_NAME, UPPER(DATA_TYPE), IS_NULLABLE, COALESCE(COLUMN_DEFAULT, ''), CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @p1 ORDER BY ORDINAL_POSITION`
+
+// queryColumnsMSSQL queries MSSQL column metadata and rebuilds parameterized
+// type strings (e.g. NVARCHAR(255), DECIMAL(10,2), VARCHAR(MAX)) so live
+// snapshots match the declared types produced by Snapshot().
+func queryColumnsMSSQL(ctx context.Context, db *sql.DB, tableName string) ([]LiveColumnSnapshot, error) {
+	rows, err := db.QueryContext(ctx, mssqlColumnQuery, tableName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var cols []LiveColumnSnapshot
+	for rows.Next() {
+		var (
+			name, dataType, nullable, dflt string
+			charMaxLength                  sql.NullInt64
+			numericPrecision               sql.NullInt64
+			numericScale                   sql.NullInt64
+		)
+		if err := rows.Scan(&name, &dataType, &nullable, &dflt, &charMaxLength, &numericPrecision, &numericScale); err != nil {
+			return nil, err
+		}
+		cols = append(cols, LiveColumnSnapshot{
+			Name:     name,
+			Type:     reconstructMSSQLType(strings.TrimSpace(dataType), charMaxLength, numericPrecision, numericScale),
+			Nullable: strings.EqualFold(nullable, "YES"),
+			Default:  strings.TrimSpace(dflt),
+		})
+	}
+	return cols, rows.Err()
+}
+
+// reconstructMSSQLType rebuilds a parameterized type string from
+// INFORMATION_SCHEMA.COLUMNS metadata. The base dataType is expected to be
+// uppercase. Returns the bare base type when no parameters apply.
+//
+// CHARACTER_MAXIMUM_LENGTH from INFORMATION_SCHEMA.COLUMNS is already
+// expressed in characters (not bytes), so NVARCHAR/NCHAR do not need a
+// byte-to-character conversion. A value of -1 means MAX.
+func reconstructMSSQLType(dataType string, charMaxLength, numericPrecision, numericScale sql.NullInt64) string {
+	switch dataType {
+	case "VARCHAR", "CHAR", "NVARCHAR", "NCHAR", "VARBINARY", "BINARY":
+		if !charMaxLength.Valid {
+			return dataType
+		}
+		if charMaxLength.Int64 == -1 {
+			return fmt.Sprintf("%s(MAX)", dataType)
+		}
+		return fmt.Sprintf("%s(%d)", dataType, charMaxLength.Int64)
+	case "DECIMAL", "NUMERIC":
+		if !numericPrecision.Valid || !numericScale.Valid {
+			return dataType
+		}
+		return fmt.Sprintf("%s(%d,%d)", dataType, numericPrecision.Int64, numericScale.Int64)
+	default:
+		return dataType
+	}
 }
 
 func queryIndexes(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveIndexSnapshot, error) {

--- a/schema/live_snapshot_test.go
+++ b/schema/live_snapshot_test.go
@@ -369,6 +369,71 @@ func TestMSSQLIndexQueryOrdersByKeyOrdinal(t *testing.T) {
 		"MSSQL index query should order by key_ordinal")
 }
 
+func TestReconstructMSSQLType(t *testing.T) {
+	intVal := func(n int64) sql.NullInt64 { return sql.NullInt64{Valid: true, Int64: n} }
+	null := sql.NullInt64{}
+
+	tests := []struct {
+		name             string
+		dataType         string
+		charMaxLength    sql.NullInt64
+		numericPrecision sql.NullInt64
+		numericScale     sql.NullInt64
+		want             string
+	}{
+		// String types
+		{"VARCHAR(255)", "VARCHAR", intVal(255), null, null, "VARCHAR(255)"},
+		{"VARCHAR(MAX)", "VARCHAR", intVal(-1), null, null, "VARCHAR(MAX)"},
+		{"VARCHAR null length", "VARCHAR", null, null, null, "VARCHAR"},
+		{"NVARCHAR(255)", "NVARCHAR", intVal(255), null, null, "NVARCHAR(255)"},
+		{"NVARCHAR(MAX)", "NVARCHAR", intVal(-1), null, null, "NVARCHAR(MAX)"},
+		{"CHAR(10)", "CHAR", intVal(10), null, null, "CHAR(10)"},
+		{"NCHAR(8)", "NCHAR", intVal(8), null, null, "NCHAR(8)"},
+
+		// Binary types
+		{"VARBINARY(100)", "VARBINARY", intVal(100), null, null, "VARBINARY(100)"},
+		{"VARBINARY(MAX)", "VARBINARY", intVal(-1), null, null, "VARBINARY(MAX)"},
+		{"BINARY(16)", "BINARY", intVal(16), null, null, "BINARY(16)"},
+
+		// Numeric types
+		{"DECIMAL(10,2)", "DECIMAL", null, intVal(10), intVal(2), "DECIMAL(10,2)"},
+		{"NUMERIC(18,4)", "NUMERIC", null, intVal(18), intVal(4), "NUMERIC(18,4)"},
+		{"DECIMAL null params", "DECIMAL", null, null, null, "DECIMAL"},
+		{"DECIMAL null scale", "DECIMAL", null, intVal(10), null, "DECIMAL"},
+
+		// Other types — bare base name, no parameters appended
+		{"INT bare", "INT", null, null, null, "INT"},
+		{"INT with stray numeric metadata", "INT", null, intVal(10), intVal(0), "INT"},
+		{"BIGINT bare", "BIGINT", null, null, null, "BIGINT"},
+		{"DATETIME2 bare", "DATETIME2", null, null, null, "DATETIME2"},
+		{"BIT bare", "BIT", null, null, null, "BIT"},
+		{"UNIQUEIDENTIFIER bare", "UNIQUEIDENTIFIER", null, null, null, "UNIQUEIDENTIFIER"},
+		{"FLOAT bare", "FLOAT", null, null, null, "FLOAT"},
+		{"non-string null charMaxLength", "DATE", null, null, null, "DATE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reconstructMSSQLType(tt.dataType, tt.charMaxLength, tt.numericPrecision, tt.numericScale)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMSSQLColumnQuerySelectsReconstructionMetadata(t *testing.T) {
+	// The MSSQL column query must select CHARACTER_MAXIMUM_LENGTH,
+	// NUMERIC_PRECISION, and NUMERIC_SCALE so reconstructMSSQLType can
+	// rebuild parameterized type strings (e.g. NVARCHAR(255), DECIMAL(10,2)).
+	assert.Contains(t, mssqlColumnQuery, "CHARACTER_MAXIMUM_LENGTH",
+		"MSSQL column query should select CHARACTER_MAXIMUM_LENGTH")
+	assert.Contains(t, mssqlColumnQuery, "NUMERIC_PRECISION",
+		"MSSQL column query should select NUMERIC_PRECISION")
+	assert.Contains(t, mssqlColumnQuery, "NUMERIC_SCALE",
+		"MSSQL column query should select NUMERIC_SCALE")
+	assert.Contains(t, mssqlColumnQuery, "INFORMATION_SCHEMA.COLUMNS",
+		"MSSQL column query should read from INFORMATION_SCHEMA.COLUMNS")
+}
+
 func TestLiveSnapshotCompareWithDeclared(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)


### PR DESCRIPTION
## Summary

- Extends the MSSQL `INFORMATION_SCHEMA.COLUMNS` query to also read `CHARACTER_MAXIMUM_LENGTH`, `NUMERIC_PRECISION`, and `NUMERIC_SCALE` so the live snapshot can rebuild parameterized type strings (e.g. `NVARCHAR(255)`, `NVARCHAR(MAX)`, `DECIMAL(10,2)`, `VARBINARY(MAX)`).
- Splits `queryColumns` into engine-specific helpers: `queryColumnsSimple` for SQLite/Postgres (unchanged behavior, same 4-column scan loop) and `queryColumnsMSSQL` for the new 7-column scan plus reconstruction. Mirrors the existing `queryIndexes` dispatch pattern.
- Adds a pure helper `reconstructMSSQLType(dataType, charMaxLength, numericPrecision, numericScale)` that:
  - For `VARCHAR`/`CHAR`/`NVARCHAR`/`NCHAR`/`VARBINARY`/`BINARY`: returns `BASE(n)`, or `BASE(MAX)` when `n == -1`, or bare `BASE` when length is null. `INFORMATION_SCHEMA.CHARACTER_MAXIMUM_LENGTH` is in characters (not bytes), so no `/2` conversion is needed for N-types.
  - For `DECIMAL`/`NUMERIC`: returns `BASE(p,s)` when both are valid, otherwise bare `BASE`.
  - For everything else: returns the bare `dataType`.
- Output casing matches the declared types produced by `MSSQLDialect` (`NVARCHAR(255)`, `DECIMAL(10,2)`, etc.) — the existing query already wraps `DATA_TYPE` in `UPPER(...)`, which is preserved.

This is item 1 of 4 from #65. Out of scope here (still open):

- Item 2: implicit unique-constraint indexes (`UQ__chuck_sc__...`) showing as unexpected
- Item 3: Postgres default normalization
- Item 4: Postgres index column casing

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean for changed files (pre-existing unrelated files in the report are unchanged from main)
- [x] `go test ./schema/... -run TestReconstructMSSQLType` — 22 subtests pass (VARCHAR/NVARCHAR/CHAR/NCHAR with `n`, with `MAX`, with null length; VARBINARY/BINARY same; DECIMAL/NUMERIC with `(p,s)`, with null params; INT/BIGINT/DATETIME2/BIT/UNIQUEIDENTIFIER/FLOAT/DATE bare; INT with stray numeric metadata stays bare)
- [x] `go test ./...` — all packages pass (Postgres/MSSQL integration tests skip without `CHUCK_*_URL` env vars, expected)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI runs `TestSchemaDriftMSSQL` against a live SQL Server. Expected outcome: the three type-mismatch failures (`NVARCHAR(255)`, `VARCHAR(255)`, `NVARCHAR(MAX)`) disappear. The "unexpected index `UQ__chuck_sc__...`" failure remains until #65 item 2 lands. Postgres tests still fail on items 3/4. CI will be red but for fewer reasons; that is the expected, intentional residual.

Part of #65.