### PR TITLE
fix: ignore implicit unique-constraint-backed indexes in drift check

### DIFF
--- a/schema/validate.go
+++ b/schema/validate.go
@@ -43,6 +43,14 @@ func ValidateSchema(ctx context.Context, db *sql.DB, d chuck.Dialect, td *TableD
 		return []SchemaError{{Table: tableName, Message: err.Error()}}
 	}
 
+	return validateAgainstLiveSnapshot(td, d, live, tableName)
+}
+
+// validateAgainstLiveSnapshot is the pure comparison core of ValidateSchema:
+// it compares a declared TableDef against an already-fetched LiveTableSnapshot
+// and returns any drift errors. Extracted so the comparator can be unit-tested
+// against crafted live snapshots without requiring a real database.
+func validateAgainstLiveSnapshot(td *TableDef, d chuck.Dialect, live LiveTableSnapshot, tableName string) []SchemaError {
 	declared := td.Snapshot(d)
 
 	var errs []SchemaError
@@ -153,19 +161,56 @@ func ValidateSchema(ctx context.Context, db *sql.DB, d chuck.Dialect, td *TableD
 	for _, idx := range declared.Indexes {
 		declaredIndexMap[idx.Name] = true
 	}
+	implicitUniques := declaredSingleColumnUniques(td)
 	for _, idx := range live.Indexes {
-		if !declaredIndexMap[idx.Name] {
-			errs = append(errs, SchemaError{
-				Table:   tableName,
-				Message: fmt.Sprintf("unexpected index %q (exists in database but not in declaration)", idx.Name),
-			})
+		if declaredIndexMap[idx.Name] {
+			continue
 		}
+		// A live single-column unique index may be the implicit index that
+		// the database created to back a column-level UNIQUE constraint.
+		// Match by column set rather than by name so engine-specific naming
+		// (Postgres "<table>_<col>_key", MSSQL "UQ__<prefix>__<hash>") all work.
+		if idx.Unique && len(idx.Columns) == 1 && idx.Where == "" {
+			if implicitUniques[strings.ToLower(idx.Columns[0])] {
+				continue
+			}
+		}
+		errs = append(errs, SchemaError{
+			Table:   tableName,
+			Message: fmt.Sprintf("unexpected index %q (exists in database but not in declaration)", idx.Name),
+		})
 	}
 
 	if len(errs) == 0 {
 		return nil
 	}
 	return errs
+}
+
+// declaredSingleColumnUniques returns the set of column names (lowercased)
+// that are declared unique via a single-column UNIQUE constraint, either on
+// the ColumnDef itself (via .Unique()) or as a single-column entry in
+// TableDef.UniqueColumns. Composite unique constraints (len > 1) are
+// intentionally excluded — those are handled by the standard index
+// declaration path.
+//
+// The returned map is used to suppress false-positive "unexpected index"
+// errors for the implicit single-column unique indexes that databases
+// automatically create to back column-level UNIQUE constraints (e.g.
+// Postgres "<table>_<col>_key", MSSQL "UQ__<prefix>__<hash>").
+func declaredSingleColumnUniques(td *TableDef) map[string]bool {
+	out := make(map[string]bool)
+	for _, c := range td.cols {
+		if c.unique {
+			out[strings.ToLower(c.name)] = true
+		}
+	}
+	for _, uc := range td.uniqueConstraints {
+		if len(uc.columns) == 1 {
+			out[strings.ToLower(uc.columns[0])] = true
+		}
+	}
+	return out
 }
 
 // ValidateAll validates multiple table definitions against the live database.

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -380,3 +380,241 @@ func TestValidateAll(t *testing.T) {
 		assert.True(t, found, "expected error for missing column 'Missing'")
 	})
 }
+
+// TestValidateImplicitUniqueIndexes covers issue #65 item 2: a single-column
+// unique index that backs a declared column-level UNIQUE constraint must not
+// be reported as an unexpected/extra index, regardless of the engine-specific
+// auto-generated index name (Postgres "<table>_<col>_key", MSSQL
+// "UQ__<prefix>__<hash>", etc.). The matching is done by column set, not by
+// name, with case-insensitive normalization to bridge Postgres lowercasing.
+//
+// These tests exercise the comparator core directly via
+// validateAgainstLiveSnapshot so they do not require a live database (the
+// SQLite live snapshot path filters out implicit unique indexes via the
+// pragma_index_list origin filter, so we need crafted live snapshots to
+// reach the implicit-skip code path).
+func TestValidateImplicitUniqueIndexes(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+
+	// liveUsersBase returns a live snapshot whose columns match a minimal
+	// users table (ID + Email). Tests append index entries on top of this.
+	liveUsersBase := func(extraIndexes ...LiveIndexSnapshot) LiveTableSnapshot {
+		return LiveTableSnapshot{
+			Name: "users",
+			Columns: []LiveColumnSnapshot{
+				{Name: "ID", Type: "INTEGER", Nullable: false},
+				{Name: "Email", Type: "VARCHAR(255)", Nullable: false},
+			},
+			Indexes: extraIndexes,
+		}
+	}
+
+	tests := []struct {
+		name           string
+		declared       *TableDef
+		live           LiveTableSnapshot
+		wantUnexpected []string // index names expected in "unexpected index" errors
+	}{
+		{
+			name: "ColumnDef.Unique() suppresses Postgres-style implicit index",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_key", Columns: []string{"Email"}, Unique: true,
+			}),
+			wantUnexpected: nil,
+		},
+		{
+			name: "single-column UniqueColumns suppresses implicit index",
+			declared: NewTable("users").
+				Columns(
+					AutoIncrCol("ID"),
+					Col("Email", TypeVarchar(255)).NotNull(),
+				).
+				UniqueColumns("Email"),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_key", Columns: []string{"Email"}, Unique: true,
+			}),
+			wantUnexpected: nil,
+		},
+		{
+			name: "multi-column UniqueColumns does NOT suppress single-column live unique",
+			declared: NewTable("users").
+				Columns(
+					AutoIncrCol("ID"),
+					Col("Email", TypeVarchar(255)).NotNull(),
+				).
+				UniqueColumns("Email", "ID"),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_idx", Columns: []string{"Email"}, Unique: true,
+			}),
+			wantUnexpected: []string{"users_email_idx"},
+		},
+		{
+			name: "no declared unique => live unique index is real drift",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_key", Columns: []string{"Email"}, Unique: true,
+			}),
+			wantUnexpected: []string{"users_email_key"},
+		},
+		{
+			name: "declared unique but live multi-column index is reported",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_idx", Columns: []string{"Email", "ID"}, Unique: true,
+			}),
+			wantUnexpected: []string{"users_email_idx"},
+		},
+		{
+			name: "declared unique but live non-unique index is reported",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_idx", Columns: []string{"Email"}, Unique: false,
+			}),
+			wantUnexpected: []string{"users_email_idx"},
+		},
+		{
+			name: "declared unique but live partial unique index is reported",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name:    "users_email_partial",
+				Columns: []string{"Email"},
+				Unique:  true,
+				Where:   "deleted_at IS NULL",
+			}),
+			wantUnexpected: []string{"users_email_partial"},
+		},
+		{
+			name: "MSSQL-style hash-suffixed name with case-insensitive match",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name:    "UQ__users___ABC12345",
+				Columns: []string{"Email"},
+				Unique:  true,
+			}),
+			wantUnexpected: nil,
+		},
+		{
+			name: "Postgres-style lowercase live column matches PascalCase declaration",
+			declared: NewTable("users").Columns(
+				AutoIncrCol("ID"),
+				Col("Email", TypeVarchar(255)).NotNull().Unique(),
+			),
+			live: LiveTableSnapshot{
+				Name: "users",
+				Columns: []LiveColumnSnapshot{
+					{Name: "ID", Type: "INTEGER", Nullable: false},
+					{Name: "Email", Type: "VARCHAR(255)", Nullable: false},
+				},
+				Indexes: []LiveIndexSnapshot{
+					{Name: "users_email_key", Columns: []string{"email"}, Unique: true},
+				},
+			},
+			wantUnexpected: nil,
+		},
+		{
+			name: "explicit declared index with same name does not regress: matched by name path",
+			declared: NewTable("users").
+				Columns(
+					AutoIncrCol("ID"),
+					Col("Email", TypeVarchar(255)).NotNull().Unique(),
+				).
+				Indexes(UniqueIndex("users_email_key", "Email")),
+			live: liveUsersBase(LiveIndexSnapshot{
+				Name: "users_email_key", Columns: []string{"Email"}, Unique: true,
+			}),
+			wantUnexpected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tableName := d.NormalizeIdentifier(tc.declared.Name)
+			errs := validateAgainstLiveSnapshot(tc.declared, d, tc.live, tableName)
+
+			var gotUnexpected []string
+			for _, e := range errs {
+				if strings.HasPrefix(e.Message, "unexpected index ") {
+					gotUnexpected = append(gotUnexpected, e.Message)
+				}
+			}
+
+			if len(tc.wantUnexpected) == 0 {
+				assert.Empty(t, gotUnexpected, "expected no unexpected-index errors, got: %v (full: %v)", gotUnexpected, errs)
+				return
+			}
+			require.Len(t, gotUnexpected, len(tc.wantUnexpected),
+				"unexpected-index error count mismatch: got %v, full errs: %v", gotUnexpected, errs)
+			for _, name := range tc.wantUnexpected {
+				found := false
+				for _, msg := range gotUnexpected {
+					if strings.Contains(msg, `"`+name+`"`) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected unexpected-index error for %q, got: %v", name, gotUnexpected)
+			}
+		})
+	}
+}
+
+func TestDeclaredSingleColumnUniques(t *testing.T) {
+	t.Run("ColumnDef.Unique includes column", func(t *testing.T) {
+		td := NewTable("users").Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull().Unique(),
+		)
+		got := declaredSingleColumnUniques(td)
+		assert.True(t, got["email"])
+		assert.False(t, got["id"])
+	})
+
+	t.Run("single-column UniqueColumns is included", func(t *testing.T) {
+		td := NewTable("users").
+			Columns(AutoIncrCol("ID"), Col("Email", TypeVarchar(255)).NotNull()).
+			UniqueColumns("Email")
+		got := declaredSingleColumnUniques(td)
+		assert.True(t, got["email"])
+	})
+
+	t.Run("multi-column UniqueColumns is excluded", func(t *testing.T) {
+		td := NewTable("users").
+			Columns(
+				AutoIncrCol("ID"),
+				Col("TenantID", TypeInt()).NotNull(),
+				Col("Email", TypeVarchar(255)).NotNull(),
+			).
+			UniqueColumns("TenantID", "Email")
+		got := declaredSingleColumnUniques(td)
+		assert.False(t, got["tenantid"])
+		assert.False(t, got["email"])
+	})
+
+	t.Run("no unique declarations returns empty map", func(t *testing.T) {
+		td := NewTable("users").Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+		)
+		got := declaredSingleColumnUniques(td)
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## Summary

- `ValidateSchema` now suppresses the false-positive *unexpected index* report for the implicit single-column unique indexes that databases create automatically to back column-level UNIQUE constraints.
- Matching is done by **column set** (lowercased), not by name, so `users_email_key` (Postgres), `UQ__users___ABC12345` (MSSQL), and any other engine-specific naming all work without engine-specific code.
- Sources for the implicit-unique set: `ColumnDef.Unique()` and single-column `TableDef.UniqueColumns(...)`. Composite unique constraints are intentionally excluded — they remain the user's responsibility to declare as indexes if needed.
- The comparator core was extracted into a private `validateAgainstLiveSnapshot(td, d, live, tableName)` so the new behavior is unit-testable against crafted live snapshots without requiring a live database (the SQLite live snapshot path filters out implicit unique indexes via `pragma_index_list.origin`, so end-to-end SQLite tests cannot reach the implicit-skip path).
- Edge cases excluded from the implicit match: multi-column live indexes, non-unique live indexes, partial/filtered unique indexes (`WHERE ...`).

Part of #65 — this is item **2 of 4**. Items 3 (Postgres sequence default normalization) and 4 (Postgres index column casing in the general comparator) are still open and intentionally not addressed here.

## Expected CI delta

- `TestSchemaDriftMSSQL/ValidateSchema`: should now pass entirely (the `UQ__chuck_sc__...` line was the only remaining failure after item 1 was merged).
- `TestSchemaDriftPostgres/ValidateSchema`: drops the `chuck_schema_test_email_key` failure but still fails on:
  - `chuck_schema_test.id: default mismatch: declared "", live "nextval(...)"` (item 3)
  - `chuck_schema_test: index "idx_chuck_schema_test_name" columns mismatch: declared "Name", live "name"` (item 4)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./schema/...` (all unit tests pass, including new `TestValidateImplicitUniqueIndexes` and `TestDeclaredSingleColumnUniques`)
- [x] `go test ./...` (full suite green; integration tests skip without DB env vars)
- [x] `golangci-lint run ./...` (0 issues)
- [ ] CI integration tests confirm MSSQL drift suite goes fully green
- [ ] CI integration tests confirm Postgres drift suite drops the email_key failure (still 2 expected failures pending items 3 and 4)