### PR TITLE
fix: normalize Postgres sequence-backed defaults in drift comparator

### DIFF
--- a/schema/diff.go
+++ b/schema/diff.go
@@ -323,7 +323,10 @@ func splitTypeParams(s string) (base, params string) {
 // normalizeDefault normalizes a default value for comparison. Different databases
 // may wrap defaults differently (e.g., parentheses, quotes). This trims whitespace,
 // removes outer parentheses, and lowercases SQL keywords/functions while preserving
-// the case of string literal contents inside single quotes.
+// the case of string literal contents inside single quotes. Postgres sequence-backed
+// defaults (nextval(...)) canonicalize to the empty string so a declared column with
+// no explicit default matches a live column whose default is the implicit sequence
+// created by SERIAL, BIGSERIAL, or INTEGER PRIMARY KEY.
 func normalizeDefault(s string) string {
 	s = strings.TrimSpace(s)
 	// Strip outer parentheses (common in some databases, e.g., SQLite wraps defaults)
@@ -338,7 +341,16 @@ func normalizeDefault(s string) string {
 			parts[i] = strings.ToLower(parts[i])
 		}
 	}
-	return strings.Join(parts, "'")
+	result := strings.Join(parts, "'")
+	// Postgres sequence-backed defaults canonicalize to the empty string
+	// so a declared column with no explicit default matches a live column
+	// whose default is the implicit sequence created by SERIAL, BIGSERIAL,
+	// or INTEGER PRIMARY KEY. The lowercasing pass above already normalized
+	// "NEXTVAL" / "Nextval" / etc. to lowercase.
+	if strings.HasPrefix(result, "nextval(") && strings.HasSuffix(result, ")") {
+		return ""
+	}
+	return result
 }
 
 // WriteDiffsJSON writes multiple diffs as a JSON array to a file path.

--- a/schema/diff_test.go
+++ b/schema/diff_test.go
@@ -287,6 +287,78 @@ func TestNormalizeDefault(t *testing.T) {
 	}
 }
 
+// TestNormalizeDefaultSequences covers issue #65 item 3: Postgres sequence-
+// backed defaults (nextval(...)) must canonicalize to the empty string so a
+// declared column with no explicit default matches a live column whose
+// default is the implicit sequence created by SERIAL, BIGSERIAL, or INTEGER
+// PRIMARY KEY. Literal string defaults like 'nextval' (inside quotes) must
+// not be collapsed.
+func TestNormalizeDefaultSequences(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "postgres_serial_with_regclass_cast",
+			input:  "nextval('chuck_schema_test_id_seq'::regclass)",
+			expect: "",
+		},
+		{
+			name:   "postgres_qualified_sequence_name",
+			input:  "nextval('public.users_id_seq'::regclass)",
+			expect: "",
+		},
+		{
+			name:   "wrapped_in_outer_parens",
+			input:  "(nextval('seq'::regclass))",
+			expect: "",
+		},
+		{
+			name:   "uppercase_nextval",
+			input:  "NEXTVAL('seq'::regclass)",
+			expect: "",
+		},
+		{
+			name:   "surrounding_whitespace",
+			input:  "  nextval('seq'::regclass)  ",
+			expect: "",
+		},
+		{
+			name:   "no_regclass_cast",
+			input:  "nextval('seq')",
+			expect: "",
+		},
+		{
+			name:   "literal_string_nextval_preserved",
+			input:  "'nextval'",
+			expect: "'nextval'",
+		},
+		{
+			name:   "integer_literal_unchanged",
+			input:  "42",
+			expect: "42",
+		},
+		{
+			name:   "current_timestamp_lowercased",
+			input:  "CURRENT_TIMESTAMP",
+			expect: "current_timestamp",
+		},
+		{
+			name:   "empty_string_unchanged",
+			input:  "",
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeDefault(tt.input)
+			assert.Equal(t, tt.expect, got, "normalizeDefault(%q)", tt.input)
+		})
+	}
+}
+
 func TestDiffSchemaIndexPropertyMismatch(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -577,6 +577,86 @@ func TestValidateImplicitUniqueIndexes(t *testing.T) {
 	}
 }
 
+// TestValidateSequenceBackedDefaults covers issue #65 item 3: the default
+// value comparator must recognize Postgres sequence-backed defaults
+// (nextval(...)) and canonicalize them to the empty string so a declared
+// column with no explicit default matches a live column whose default is
+// the implicit sequence created by SERIAL, BIGSERIAL, or INTEGER PRIMARY
+// KEY. Non-sequence defaults (including literal strings) must continue to
+// flag real drift.
+//
+// Each case builds a *TableDef with one column and a LiveTableSnapshot
+// with the corresponding live column, then calls validateAgainstLiveSnapshot
+// directly to avoid requiring a real database.
+func TestValidateSequenceBackedDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		dialect         chuck.Dialect
+		declaredDefault string
+		liveDefault     string
+		wantDefaultErrs int
+	}{
+		{
+			name:            "postgres: empty declared matches nextval live",
+			dialect:         chuck.PostgresDialect{},
+			declaredDefault: "",
+			liveDefault:     "nextval('table_id_seq'::regclass)",
+			wantDefaultErrs: 0,
+		},
+		{
+			name:            "postgres: explicit zero declared vs nextval live is drift",
+			dialect:         chuck.PostgresDialect{},
+			declaredDefault: "0",
+			liveDefault:     "nextval('table_id_seq'::regclass)",
+			wantDefaultErrs: 1,
+		},
+		{
+			name:            "sqlite: empty declared matches empty live",
+			dialect:         chuck.SQLiteDialect{},
+			declaredDefault: "",
+			liveDefault:     "",
+			wantDefaultErrs: 0,
+		},
+		{
+			name:            "postgres: empty declared vs non-sequence live is drift",
+			dialect:         chuck.PostgresDialect{},
+			declaredDefault: "",
+			liveDefault:     "0",
+			wantDefaultErrs: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			col := Col("id", TypeInt()).NotNull()
+			if tc.declaredDefault != "" {
+				col = col.Default(tc.declaredDefault)
+			}
+			td := NewTable("t").Columns(col)
+
+			live := LiveTableSnapshot{
+				Name: "t",
+				Columns: []LiveColumnSnapshot{
+					{Name: "id", Type: "INTEGER", Nullable: false, Default: tc.liveDefault},
+				},
+			}
+
+			tableName := tc.dialect.NormalizeIdentifier(td.Name)
+			errs := validateAgainstLiveSnapshot(td, tc.dialect, live, tableName)
+
+			var defaultErrs []SchemaError
+			for _, e := range errs {
+				if strings.Contains(e.Message, "default mismatch") {
+					defaultErrs = append(defaultErrs, e)
+				}
+			}
+
+			assert.Len(t, defaultErrs, tc.wantDefaultErrs,
+				"default-mismatch error count: got %v (full errs: %v)", defaultErrs, errs)
+		})
+	}
+}
+
 func TestDeclaredSingleColumnUniques(t *testing.T) {
 	t.Run("ColumnDef.Unique includes column", func(t *testing.T) {
 		td := NewTable("users").Columns(


### PR DESCRIPTION
## Summary

- Recognize `nextval(...)` as a sequence-backed default in `normalizeDefault` and canonicalize it to the empty string so a declared column with no explicit default matches a live column whose default is the implicit sequence created by `SERIAL`, `BIGSERIAL`, or `INTEGER PRIMARY KEY`.
- Pattern matching is engine-agnostic in implementation but Postgres-specific in practice; SQLite and MSSQL live snapshots never produce `nextval(...)` defaults.
- This is the **final item (3 of 4) from #65**. Items 1, 2, and 4 landed in `0a867bc`, `b4e1539`, and `f92322d`. Once this merges, the schema-drift CI suite should go fully green for the first time in months.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l schema/diff.go schema/diff_test.go schema/validate_test.go` (clean)
- [x] `go test ./schema/...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New `TestNormalizeDefaultSequences` unit tests cover the `nextval` recognition, outer-paren stripping, case insensitivity, whitespace, and (critically) the literal-string `'nextval'` preservation guard.
- [x] New `TestValidateSequenceBackedDefaults` integration tests exercise the comparator through `validateAgainstLiveSnapshot` for Postgres (match + two drift regression guards) and SQLite (empty-string regression guard).
- [ ] CI `TestSchemaDriftPostgres/ValidateSchema` and `TestSchemaDriftMSSQL/ValidateSchema` expected to pass.

Fixes #65.