### PR TITLE
feat(schema): first-class schema-qualified table support (#72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cover.out
 cover.html
 *.test
 *.exe
+.agents/

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ schema.Col("Code", schema.TypeVarchar(10)).PrimaryKey().NotNull()
 
 ### Foreign Key References
 
-`References` defines a foreign key. Chain `OnDelete` and `OnUpdate` for referential actions:
+`References` defines a foreign key against an unqualified target. Chain `OnDelete` and `OnUpdate` for referential actions:
 
 ```go
 schema.Col("TaskID", schema.TypeInt()).NotNull().
@@ -238,7 +238,28 @@ schema.Col("AssigneeID", schema.TypeInt()).
     References("Users", "ID").OnDelete("SET NULL").OnUpdate("CASCADE")
 ```
 
+For schema-qualified targets use `ReferencesQualified` (or `ReferencesObject` with a `chuck.ObjectName`):
+
+```go
+schema.Col("AgentID", schema.TypeInt()).NotNull().
+    ReferencesQualified("sg", "SalesAgents", "ID")
+```
+
 Supported actions: `CASCADE`, `SET NULL`, `SET DEFAULT`, `RESTRICT`, `NO ACTION`.
+
+### Schema-Qualified Tables
+
+Tables can declare a schema namespace that is preserved through DDL generation, foreign-key metadata, snapshots, validation, diffing, ensure, and live introspection:
+
+```go
+schema.NewTable("SalesAgents").WithSchema("sg")
+// or equivalently:
+schema.NewQualifiedTable("sg", "SalesAgents")
+```
+
+On MSSQL this renders as `[sg].[SalesAgents]`; on Postgres as `"sg"."sales_agents"` (with the usual identifier normalization). Dependency ordering keys on the fully qualified `(schema, name)` pair, so `sg.SalesAgents` and `cl.SalesAgents` are treated as distinct nodes.
+
+**SQLite fallback.** SQLite has no schema namespace, so the schema component is dropped from emitted SQL. When two declared schema-qualified tables would collapse to the same bare SQLite table name (e.g. `sg.SalesAgents` and `cl.SalesAgents`), `Ensure` and `CheckSchemaCompatibility` fail fast with `ErrSQLiteSchemaCollision` rather than silently merging them.
 
 ### CHECK Constraints
 

--- a/chuck.go
+++ b/chuck.go
@@ -8,6 +8,32 @@ import (
 	"strings"
 )
 
+// ObjectName is a structured database object identity composed of an optional
+// schema and a required name. It is used internally to model schema-qualified
+// tables and foreign-key targets so that dialects can render correctly
+// qualified identifiers without resorting to dotted-string parsing.
+type ObjectName struct {
+	Schema string
+	Name   string
+}
+
+// IsZero reports whether the ObjectName has neither schema nor name set.
+func (o ObjectName) IsZero() bool { return o.Schema == "" && o.Name == "" }
+
+// String returns "schema.name" when a schema is set, otherwise just "name".
+// The output is for logging/diagnostics and is not quoted or normalized.
+func (o ObjectName) String() string {
+	if o.Schema == "" {
+		return o.Name
+	}
+	return o.Schema + "." + o.Name
+}
+
+// Equal reports whether two ObjectNames have the same schema and name.
+func (o ObjectName) Equal(other ObjectName) bool {
+	return o.Schema == other.Schema && o.Name == other.Name
+}
+
 // Engine identifies a database engine.
 type Engine string
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,138 @@
+# Plan: #65 Item 3 — Postgres Sequence Default Normalization
+
+## Objective
+
+Stop reporting Postgres sequence-backed column defaults as drift when the declared side has no explicit default.
+
+This plan covers only item 3 from issue `#65` and is the last remaining piece of #65.
+
+## Problem
+
+`schema/validate.go:101` compares declared and live column defaults via `normalizeDefault` (defined in `schema/diff.go:327`). The current normalization handles whitespace, outer parentheses, and case folding outside quotes — but it does not recognize Postgres sequence-backed defaults.
+
+CI failure shape:
+
+```
+chuck_schema_test.id: default mismatch: declared "", live "nextval('chuck_schema_test_id_seq'::regclass)"
+```
+
+The declared `id` column has no explicit `DEFAULT` clause because the schema DSL treats integer primary keys / SERIAL-style columns as having an implicit sequence default that the dialect handles in DDL generation. Postgres stores the actual `nextval(...)` expression in `information_schema.columns.column_default`, which is what the live snapshot returns. Comparison sees `""` vs `"nextval(...)"` and reports drift.
+
+## Decision
+
+Extend `normalizeDefault` to recognize sequence-backed defaults and canonicalize them to the empty string.
+
+A default value is considered sequence-backed when, after the existing trim / paren-strip / lowercasing, it matches the shape `nextval(...)`. The argument to `nextval` is irrelevant — any call to `nextval` is by definition sequence-backed.
+
+Rationale:
+
+- This is a comparator-local fix consistent with items 2 and 4. No ColumnDef changes, no DSL changes, no dialect changes.
+- The empty-string canonicalization makes a declared `""` match a live `nextval('..._seq'::regclass)` without needing to know whether the user wrote `INTEGER PRIMARY KEY`, `BIGSERIAL`, or anything else.
+- It is semantically correct: a sequence-backed default is the schema package's "no explicit default" state for an autoincrement column.
+- Pattern recognition is engine-agnostic in implementation but Postgres-specific in practice — `nextval` is Postgres syntax, so SQLite and MSSQL live snapshots will never trigger the normalization. No risk to those engines.
+- Identifying sequence-backed defaults purely by syntax (`nextval(...)`) avoids the need to thread engine context through `normalizeDefault`, keeping the change minimal.
+
+## Scope
+
+Modify only `normalizeDefault` in `schema/diff.go` and add tests. Do not touch:
+
+- `ValidateSchema` / `validateAgainstLiveSnapshot` comparator logic
+- `ColumnDef` or any DSL surface
+- Live snapshot queries
+- DDL generation
+- Other normalization helpers (`normalizeType`, `splitTypeParams`)
+
+## Files To Inspect
+
+- `schema/diff.go` (the helper)
+- `schema/diff_test.go` (existing normalizeDefault tests, if any)
+- `schema/validate.go` (the call site, read-only — no edits)
+
+## Matching Rule
+
+After the existing trim / paren-strip / case-folding pass, if the result starts with `nextval(` and ends with `)`, return the empty string.
+
+Apply the check after the existing transforms because:
+
+- The existing case-folding lowercases keywords, so the check should look for `nextval` (lowercase), which is what the existing transform produces.
+- The existing paren-strip handles wrappers like `(nextval(...))` that some Postgres versions emit.
+- Putting the recognition at the end keeps existing behavior unchanged for non-sequence defaults.
+
+## Implementation Plan
+
+1. Read `normalizeDefault` in `schema/diff.go` and confirm the lowercasing transform leaves `nextval` lowercase regardless of the input casing.
+2. Append the sequence-detection branch:
+
+   ```go
+   // Postgres sequence-backed defaults canonicalize to the empty
+   // string so a declared column with no explicit default matches a
+   // live column whose default is the implicit sequence created by
+   // SERIAL / BIGSERIAL / INTEGER PRIMARY KEY.
+   if strings.HasPrefix(s, "nextval(") && strings.HasSuffix(s, ")") {
+       return ""
+   }
+   ```
+
+   Place this after the lowercasing loop and before the final `return`.
+3. Do not change the helper signature.
+4. Do not change call sites.
+
+## Edge Cases
+
+Handle these explicitly:
+
+- bare `nextval('seq'::regclass)` → empty (the failing case)
+- wrapped `(nextval('seq'::regclass))` → empty (paren-stripped first)
+- mixed-case `NEXTVAL('seq'::regclass)` → empty (lowercased first)
+- trailing whitespace → empty (trimmed first)
+- a literal default `'nextval'` (string default that happens to spell `nextval`) → unchanged because the surrounding single quotes are not stripped by the normalizer
+- a non-sequence default like `42` or `CURRENT_TIMESTAMP` → unchanged
+- empty string declared default → unchanged (still empty, still matches a sequence-normalized live default)
+
+## Test Plan
+
+Add to `schema/diff_test.go`. Look for the existing `normalizeDefault` test function — if one exists, extend it; otherwise create `TestNormalizeDefaultSequences`.
+
+Cases:
+
+1. `nextval('chuck_schema_test_id_seq'::regclass)` → `""`
+2. `nextval('public.users_id_seq'::regclass)` → `""`
+3. `(nextval('seq'::regclass))` → `""` (paren-wrapped form)
+4. `NEXTVAL('seq'::regclass)` → `""` (case insensitivity via existing fold)
+5. `  nextval('seq'::regclass)  ` → `""` (whitespace via existing trim)
+6. `nextval('seq')` → `""` (no `::regclass` cast)
+7. `'nextval'` (literal string default) → `'nextval'` (unchanged — quoted)
+8. `42` → `"42"` (unchanged)
+9. `CURRENT_TIMESTAMP` → `current_timestamp` (unchanged from existing case folding)
+10. `""` → `""` (unchanged)
+
+Then add an end-to-end test to `schema/validate_test.go` mirroring the style of `TestValidateImplicitUniqueIndexes` and `TestValidateIndexColumnNormalization`:
+
+11. Postgres dialect, declared column with `Default: ""`, live column with `Default: "nextval('table_id_seq'::regclass)"` → no drift reported
+12. Postgres dialect, declared column with `Default: "0"`, live column with `Default: "nextval(...)"` → drift IS reported (the user explicitly wanted `0`, not a sequence)
+13. SQLite dialect, declared column with `Default: ""`, live column with `Default: ""` → no drift (regression guard, sequence path not engaged)
+
+Use `validateAgainstLiveSnapshot` directly with crafted fixtures for tests 11–13.
+
+## Acceptance Criteria
+
+- `TestSchemaDriftPostgres/ValidateSchema` passes — no drift errors on the `id` column.
+- `TestSchemaDriftMSSQL/ValidateSchema` continues to pass.
+- The full schema integration test suite is fully green in CI.
+- `normalizeDefault` continues to behave identically for all non-sequence defaults.
+- Item 3 of #65 is closed by this PR. Issue #65 itself can be closed once CI confirms green.
+
+## Risks
+
+- Over-broad pattern recognition could mask real drift. Mitigation: the pattern requires `nextval(` literally as the leading token, which is a Postgres-specific built-in function name. No realistic non-sequence default should match this pattern.
+- A user who explicitly declares `DEFAULT nextval('custom_seq')` and expects strict comparison against a different sequence name would lose that strictness. This is a deliberate trade-off — both sides normalize to empty, so they match. The plan accepts this because the schema DSL does not currently expose a way to declare a specific sequence name as a default, so this scenario is not reachable through the supported API.
+
+## Execution Order
+
+1. Inspect `normalizeDefault` and verify the lowercasing transform output for `nextval`.
+2. Implement the pattern check.
+3. Add unit tests for `normalizeDefault`.
+4. Add end-to-end tests via `validateAgainstLiveSnapshot`.
+5. Run `go test ./schema/...` locally.
+6. Push and verify the full integration test suite goes green in CI.
+7. Close #65 once CI is green (parent will handle).

--- a/plans/plan-001-implement-issue-72-schema-qualified-table-support.md
+++ b/plans/plan-001-implement-issue-72-schema-qualified-table-support.md
@@ -1,0 +1,100 @@
+# Implement issue 72 schema-qualified table support
+
+## Source
+
+- GitHub issue `#72`: schema-qualified table support, updated on 2026-05-11 to narrow scope to the schema/DDL/introspection layer.
+- GitHub issue `#73`: `dbrepo` support for schema-qualified table references is explicitly out of scope for this plan.
+- Relevant code paths today:
+  - `schema/table.go`
+  - `schema/column.go`
+  - `schema/index.go`
+  - `schema/snapshot.go`
+  - `schema/live_snapshot.go`
+  - `schema/ensure.go`
+  - `schema/validate.go`
+  - `schema/diff.go`
+  - `schema/order.go`
+  - `postgres.go`
+  - `mssql.go`
+  - `sqlite.go`
+  - schema and dialect tests under `schema/*_test.go`, `chuck_test.go`, and integration coverage where available
+
+## Objective
+
+- Implement first-class schema-qualified table identity for the `schema` package and dialect inspection layer without breaking existing unqualified callers.
+- Keep schema and table as structured metadata through DDL generation, foreign-key metadata, snapshots, validation, diffing, ensure, and live introspection.
+- Match the updated issue direction: do not implement this as a dotted-string shortcut, and do not pull `dbrepo` into this plan.
+
+## Scope
+
+- Add a structured object-name representation used internally for declared tables and foreign-key targets.
+- Extend `TableDef` with schema-aware identity and provide an additive public API such as `WithSchema`, plus any thin constructor/helper that is clearly useful and does not muddy the model.
+- Replace raw string-based table rendering paths with one shared helper for normalized and quoted table references.
+- Update DDL generation for create, drop, indexes, seed SQL, and foreign keys to render qualified names correctly for Postgres and MSSQL.
+- Update snapshot and live-snapshot representations so schema-qualified identity is preserved as structured data rather than only as one combined name string.
+- Update schema ensure/validate/diff/live introspection to inspect the correct object by schema and table, not by table name alone.
+- Update dependency ordering to key relationships by fully qualified identity so duplicate table names in different schemas work correctly.
+- Implement SQLite fallback behavior from the issue: ignore schema in emitted SQL but fail fast if multiple declared tables collapse to the same bare SQLite table name.
+- Add or revise unit/integration tests and minimal README/package examples needed to document the supported API and SQLite limitation.
+
+## Non-Goals
+
+- Do not implement `dbrepo` `FROM`/`JOIN`/alias/column-reference support here; that belongs to `#73`.
+- Do not accept or normalize dotted-string table names as the primary implementation model.
+- Do not redesign the library into a migration framework or broaden scope beyond schema declarations and dialect inspection.
+- Do not make avoidable breaking API changes for existing unqualified table definitions.
+
+## Constraints
+
+- Preserve backward compatibility for existing callers that only use `TableDef.Name`-style unqualified declarations.
+- Prefer additive API and helper changes over a breaking `Dialect` interface redesign; if dialect inspection needs a new shape, keep it narrowly scoped and defensible.
+- Use one internal qualified-name helper path consistently so table rendering logic does not fork across DDL, seed SQL, snapshots, and inspectors.
+- Foreign-key metadata must point at structured object identity, not a raw referenced-table string.
+- Dependency ordering must compare self-references and parent/child edges using fully qualified identity.
+- SQLite behavior must be explicit and safe. Ignoring schema is acceptable; silent name collisions are not.
+- Keep snapshot/live-snapshot output coherent for consumers: schema/table split should remain inspectable rather than being recombined into an opaque string.
+- Philosophy source is absent in this repo status output, so skip philosophy-specific steps unless a source appears during execution.
+
+## Validation
+
+Respect repo-local `.agents/tmux-skills*.json` for tests/commits.
+
+- `workflow.tests` is `optional`, so run the targeted tests that directly cover touched packages and note any broader suites intentionally skipped.
+- Minimum validation target:
+  - `go test . ./schema`
+- If shared root helpers or cross-package behavior are changed more broadly than expected, expand to:
+  - `go test ./...`
+- If external-engine env vars are available during execution, run the relevant Postgres and MSSQL schema/integration tests that cover qualified-name introspection. If not available, report that engine validation was skipped.
+- `workflow.commit_policy` is `ask`, so do not commit unless the human explicitly requests it after review.
+- `workflow.archaeology_check` is `required`: begin implementation with a quick code-path audit of every single-string table identity use before editing.
+
+## Stages
+
+- [ ] Stage 001: Re-read `#72` and confirm the narrowed boundary against `#73`, then audit all current single-string table identity flows and settle the internal structured-name model plus additive public API surface.
+- [ ] Stage 002: Implement structured schema-aware table and foreign-key identity plus shared qualified-name rendering helpers across `schema` DDL, seeds, indexes, and declared snapshots.
+- [ ] Stage 003: Update dialect inspection, live snapshot, ensure, validate, diff, and dependency ordering to operate on schema-qualified identity, including SQLite collision detection.
+- [ ] Stage 004: Add or revise tests and docs, run the chosen validation set, and report any remaining API tradeoffs or follow-up work that still belongs in `#73`.
+
+## Completion
+
+Respect repo-local `workflow.commit_policy`:
+
+- `feature_branch`: work on a feature branch, commit explicit files, then wake
+  Codex with the commit SHA.
+- `ask`: do not commit unless explicitly asked; wake Codex with a short label
+  and include changed files, validation, and risks in your reply.
+- `never`: do not commit.
+
+## Escalate If
+
+- A correct implementation appears to require a breaking public API change rather than additive fields/helpers.
+- Dialect inspection cannot distinguish schema-qualified objects cleanly without a larger interface redesign than this issue warrants.
+- Snapshot or JSON compatibility expectations are unclear enough that preserving both backward compatibility and structured schema metadata is not obvious.
+- SQLite fallback semantics become ambiguous for existing tests or examples.
+- Live Postgres/MSSQL behavior contradicts the issue assumptions during validation and the mismatch cannot be resolved with a localized fix.
+
+## Completion Signal
+
+Wake Codex with `tmux-skills-compact-and-review codex` after reporting changed
+files, validation performed or skipped, commit SHA when applicable, and any
+unresolved risks.

--- a/schema/column.go
+++ b/schema/column.go
@@ -86,7 +86,7 @@ type ColumnDef struct {
 	mutable    bool
 	defaultVal string
 	defaultFn  func(chuck.Dialect) string
-	refTable   string
+	refObject  chuck.ObjectName
 	refColumn  string
 	onDelete   string
 	onUpdate   string
@@ -153,11 +153,34 @@ func (c ColumnDef) Immutable() ColumnDef { c.mutable = false; return c }
 // Mutable marks the column as mutable (included in UPDATE column lists).
 func (c ColumnDef) Mutable() ColumnDef { c.mutable = true; return c }
 
-// References adds a foreign key reference to another table's column.
+// References adds a foreign key reference to another table's column. The
+// referenced table is treated as unqualified; for schema-qualified targets
+// use ReferencesObject.
 func (c ColumnDef) References(table, column string) ColumnDef {
-	c.refTable = table
+	c.refObject = chuck.ObjectName{Name: table}
 	c.refColumn = column
 	return c
+}
+
+// ReferencesObject adds a foreign key reference to a schema-qualified target.
+func (c ColumnDef) ReferencesObject(target chuck.ObjectName, column string) ColumnDef {
+	c.refObject = target
+	c.refColumn = column
+	return c
+}
+
+// ReferencesQualified is a convenience for ReferencesObject taking schema and
+// table as separate strings.
+func (c ColumnDef) ReferencesQualified(schema, table, column string) ColumnDef {
+	c.refObject = chuck.ObjectName{Schema: schema, Name: table}
+	c.refColumn = column
+	return c
+}
+
+// RefTarget returns the structured foreign-key target, or a zero ObjectName
+// when the column has no reference set.
+func (c ColumnDef) RefTarget() chuck.ObjectName {
+	return c.refObject
 }
 
 // OnDelete sets the referential action for DELETE (e.g. "CASCADE", "SET NULL").
@@ -199,10 +222,8 @@ func (c ColumnDef) ddl(d chuck.Dialect) string {
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", c.defaultVal))
 	}
 
-	if c.refTable != "" && c.refColumn != "" {
-		ref := fmt.Sprintf("REFERENCES %s(%s)",
-			d.QuoteIdentifier(d.NormalizeIdentifier(c.refTable)),
-			d.QuoteIdentifier(d.NormalizeIdentifier(c.refColumn)))
+	if c.refObject.Name != "" && c.refColumn != "" {
+		ref := "REFERENCES " + renderFKReference(d, c.refObject, c.refColumn)
 		if c.onDelete != "" {
 			ref += " ON DELETE " + c.onDelete
 		}

--- a/schema/diff.go
+++ b/schema/diff.go
@@ -13,7 +13,12 @@ import (
 
 // SchemaDiff is a structured diff between a declared schema and a live database.
 // It is JSON-serializable and designed for consumption by developers, agents, and CI tools.
+//
+// Table is the display-form qualified name ("schema.name" when schema is set,
+// otherwise just "name"). Schema is the dialect-normalized schema component
+// when the table is schema-qualified.
 type SchemaDiff struct {
+	Schema         string           `json:"schema,omitempty"`
 	Table          string           `json:"table"`
 	TableMissing   bool             `json:"table_missing,omitempty"`
 	AddedColumns   []ColumnSnapshot `json:"added_columns,omitempty"`
@@ -60,10 +65,14 @@ type ColumnDiff struct {
 // It does not currently detect drift in column-level unique constraints,
 // primary keys, foreign keys, or CHECK constraints.
 func DiffSchema(ctx context.Context, db *sql.DB, d chuck.Dialect, td *TableDef) (*SchemaDiff, error) {
-	tableName := d.NormalizeIdentifier(td.Name)
-	diff := &SchemaDiff{Table: tableName}
+	schema, name := normalizedObject(d, td.Object())
+	displayName := name
+	if schema != "" {
+		displayName = schema + "." + name
+	}
+	diff := &SchemaDiff{Schema: schema, Table: displayName}
 
-	live, err := LiveSnapshot(ctx, db, d, tableName)
+	live, err := LiveSnapshotObject(ctx, db, d, td.Object())
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") {
 			diff.TableMissing = true

--- a/schema/ensure.go
+++ b/schema/ensure.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -140,6 +141,10 @@ func Ensure(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef
 		opt(cfg)
 	}
 
+	if err := CheckSchemaCompatibility(d, tables); err != nil {
+		return nil, err
+	}
+
 	result := &EnsureResult{}
 
 	switch cfg.mode {
@@ -152,6 +157,38 @@ func Ensure(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef
 	default:
 		return nil, fmt.Errorf("unknown ensure mode: %d", int(cfg.mode))
 	}
+}
+
+// ErrSQLiteSchemaCollision is returned when two declared schema-qualified
+// tables collapse to the same bare SQLite table name. SQLite has no schema
+// namespace, so chuck refuses to emit ambiguous DDL rather than silently
+// merging the declarations.
+var ErrSQLiteSchemaCollision = errors.New("sqlite: schema-qualified tables collapse to duplicate bare names")
+
+// CheckSchemaCompatibility validates that the given declared tables can be
+// represented on the target dialect. The only current check is SQLite's
+// collision guard: when multiple schema-qualified declarations would resolve
+// to the same bare table name on SQLite, return ErrSQLiteSchemaCollision so
+// the caller fails fast instead of producing duplicate DDL.
+func CheckSchemaCompatibility(d chuck.Dialect, tables []*TableDef) error {
+	if d.Engine() != chuck.SQLite {
+		return nil
+	}
+	seen := make(map[string][]string, len(tables))
+	for _, t := range tables {
+		bare := d.NormalizeIdentifier(t.Name)
+		seen[bare] = append(seen[bare], t.Object().String())
+	}
+	var clashes []string
+	for bare, sources := range seen {
+		if len(sources) > 1 {
+			clashes = append(clashes, fmt.Sprintf("%s <- [%s]", bare, strings.Join(sources, ", ")))
+		}
+	}
+	if len(clashes) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrSQLiteSchemaCollision, strings.Join(clashes, "; "))
 }
 
 func ensureStrict(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef, cfg *ensureConfig, result *EnsureResult) (*EnsureResult, error) {
@@ -182,7 +219,7 @@ func ensureDev(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*Table
 
 	var drifted []*SchemaDiff
 	for _, td := range ordered {
-		tableName := d.NormalizeIdentifier(td.Name)
+		displayName := displayQualifiedName(d, td.Object())
 
 		// Check if table exists by attempting a diff
 		diff, err := DiffSchema(ctx, db, d, td)
@@ -194,19 +231,19 @@ func ensureDev(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*Table
 			// Create the table
 			for _, stmt := range td.CreateIfNotExistsSQL(d) {
 				if _, err := db.ExecContext(ctx, stmt); err != nil {
-					return nil, fmt.Errorf("create table %q: %w", tableName, err)
+					return nil, fmt.Errorf("create table %q: %w", displayName, err)
 				}
 			}
-			result.TablesCreated = append(result.TablesCreated, tableName)
+			result.TablesCreated = append(result.TablesCreated, displayName)
 
 			// Seed the table
 			if td.HasSeedData() {
 				for _, stmt := range td.SeedSQL(d) {
 					if _, err := db.ExecContext(ctx, stmt); err != nil {
-						return nil, fmt.Errorf("seed table %q: %w", tableName, err)
+						return nil, fmt.Errorf("seed table %q: %w", displayName, err)
 					}
 				}
-				result.TablesSeeded = append(result.TablesSeeded, tableName)
+				result.TablesSeeded = append(result.TablesSeeded, displayName)
 			}
 			continue
 		}

--- a/schema/index.go
+++ b/schema/index.go
@@ -42,42 +42,43 @@ func (idx IndexDef) Where(condition string) IndexDef {
 }
 
 // ddlIfNotExists renders the CREATE INDEX IF NOT EXISTS statement for the given
-// dialect and table name.
-func (idx IndexDef) ddlIfNotExists(d chuck.Dialect, tableName string) string {
-	return idx.renderDDL(d, tableName, true)
+// dialect and table object.
+func (idx IndexDef) ddlIfNotExists(d chuck.Dialect, table chuck.ObjectName) string {
+	return idx.renderDDL(d, table, true)
 }
 
-// ddl renders the CREATE INDEX statement for the given dialect and table name.
-func (idx IndexDef) ddl(d chuck.Dialect, tableName string) string {
-	return idx.renderDDL(d, tableName, false)
+// ddl renders the CREATE INDEX statement for the given dialect and table object.
+func (idx IndexDef) ddl(d chuck.Dialect, table chuck.ObjectName) string {
+	return idx.renderDDL(d, table, false)
 }
 
-func (idx IndexDef) renderDDL(d chuck.Dialect, tableName string, ifNotExists bool) string {
-	// For plain indexes (no unique, no where), delegate to the dialect's existing method
-	// to preserve backward compatibility with the original DDL output.
-	if !idx.unique && idx.where == "" {
+func (idx IndexDef) renderDDL(d chuck.Dialect, table chuck.ObjectName, ifNotExists bool) string {
+	// Unqualified plain index can route through the dialect helper to preserve
+	// existing byte-identical output for callers that have snapshot expectations.
+	if (table.Schema == "" || d.Engine() == chuck.SQLite) && !idx.unique && idx.where == "" {
+		bare := d.NormalizeIdentifier(table.Name)
 		if ifNotExists {
-			return d.CreateIndexIfNotExists(idx.name, tableName, idx.columns)
+			return d.CreateIndexIfNotExists(idx.name, bare, idx.columns)
 		}
-		return idx.buildCreateIndex(d, tableName, false)
+		return idx.buildStandardIndex(d, table, false)
 	}
 
-	return idx.buildCreateIndex(d, tableName, ifNotExists)
+	return idx.buildCreateIndex(d, table, ifNotExists)
 }
 
 // buildCreateIndex builds the full CREATE INDEX statement with support for
 // UNIQUE and WHERE clauses across all dialects.
-func (idx IndexDef) buildCreateIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+func (idx IndexDef) buildCreateIndex(d chuck.Dialect, table chuck.ObjectName, ifNotExists bool) string {
 	switch d.Engine() {
 	case chuck.MSSQL:
-		return idx.buildMSSQLIndex(d, tableName, ifNotExists)
+		return idx.buildMSSQLIndex(d, table, ifNotExists)
 	default:
-		return idx.buildStandardIndex(d, tableName, ifNotExists)
+		return idx.buildStandardIndex(d, table, ifNotExists)
 	}
 }
 
 // buildStandardIndex generates CREATE INDEX for Postgres and SQLite.
-func (idx IndexDef) buildStandardIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+func (idx IndexDef) buildStandardIndex(d chuck.Dialect, table chuck.ObjectName, ifNotExists bool) string {
 	s := "CREATE "
 	if idx.unique {
 		s += "UNIQUE "
@@ -88,7 +89,7 @@ func (idx IndexDef) buildStandardIndex(d chuck.Dialect, tableName string, ifNotE
 	}
 	s += fmt.Sprintf("%s ON %s(%s)",
 		d.QuoteIdentifier(idx.name),
-		d.QuoteIdentifier(tableName),
+		qualifyTable(d, table),
 		chuck.QuoteColumns(d, idx.columns),
 	)
 	if idx.where != "" {
@@ -99,9 +100,9 @@ func (idx IndexDef) buildStandardIndex(d chuck.Dialect, tableName string, ifNotE
 
 // buildMSSQLIndex generates CREATE INDEX for MSSQL, using the IF NOT EXISTS
 // pattern with sys.indexes.
-func (idx IndexDef) buildMSSQLIndex(d chuck.Dialect, tableName string, ifNotExists bool) string {
+func (idx IndexDef) buildMSSQLIndex(d chuck.Dialect, table chuck.ObjectName, ifNotExists bool) string {
 	qi := d.QuoteIdentifier(idx.name)
-	qt := d.QuoteIdentifier(tableName)
+	qt := qualifyTable(d, table)
 
 	create := "CREATE "
 	if idx.unique {
@@ -116,10 +117,17 @@ func (idx IndexDef) buildMSSQLIndex(d chuck.Dialect, tableName string, ifNotExis
 		return create
 	}
 
-	// Wrap in IF NOT EXISTS check using sys.indexes
+	// Wrap in IF NOT EXISTS check using sys.indexes; OBJECT_ID takes the
+	// schema-qualified object literal so the right table is matched even
+	// when the same bare name exists under multiple schemas.
+	schema, name := normalizedObject(d, table)
+	objArg := name
+	if schema != "" {
+		objArg = schema + "." + name
+	}
 	return fmt.Sprintf(
 		"IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = N'%s' AND object_id = OBJECT_ID(N'%s')) %s",
-		escapeQuote(idx.name), escapeQuote(tableName), create,
+		escapeQuote(idx.name), escapeQuote(objArg), create,
 	)
 }
 

--- a/schema/live_snapshot.go
+++ b/schema/live_snapshot.go
@@ -28,47 +28,56 @@ type LiveIndexSnapshot struct {
 // LiveTableSnapshot describes a table's actual schema as read from a live database.
 // Compare against TableSnapshot (from Snapshot()) to detect schema drift.
 type LiveTableSnapshot struct {
+	Schema  string               `json:"schema,omitempty"`
 	Name    string               `json:"name"`
 	Columns []LiveColumnSnapshot `json:"columns"`
 	Indexes []LiveIndexSnapshot  `json:"indexes,omitempty"`
 }
 
-// LiveSnapshot queries the database and returns the actual schema for a table.
-// The result can be compared against a declared Snapshot() to detect drift.
-func LiveSnapshot(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) (LiveTableSnapshot, error) {
-	snap := LiveTableSnapshot{Name: tableName}
+// Object returns the structured ObjectName captured in the live snapshot.
+func (s LiveTableSnapshot) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: s.Schema, Name: s.Name}
+}
 
-	// Check table exists
-	var exists interface{}
-	if err := db.QueryRowContext(ctx, d.TableExistsQuery(), tableName).Scan(&exists); err != nil {
-		if err == sql.ErrNoRows {
-			return snap, fmt.Errorf("table %q does not exist", tableName)
-		}
-		return snap, fmt.Errorf("check table %q: %w", tableName, err)
+// LiveSnapshot queries the database and returns the actual schema for an
+// unqualified table. Equivalent to LiveSnapshotObject with no schema; kept
+// for back-compat.
+func LiveSnapshot(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) (LiveTableSnapshot, error) {
+	return LiveSnapshotObject(ctx, db, d, chuck.ObjectName{Name: tableName})
+}
+
+// LiveSnapshotObject queries the database and returns the actual schema for a
+// schema-qualified table. SQLite ignores any schema component; Postgres
+// defaults to "public" and MSSQL defaults to "dbo" when target.Schema is "".
+func LiveSnapshotObject(ctx context.Context, db *sql.DB, d chuck.Dialect, target chuck.ObjectName) (LiveTableSnapshot, error) {
+	schema, name := normalizedObject(d, target)
+	snap := LiveTableSnapshot{Schema: schema, Name: name}
+	inspectSchema := resolveSchemaForInspection(d, target)
+
+	if err := checkTableExists(ctx, db, d, inspectSchema, name); err != nil {
+		return snap, err
 	}
 
-	// Query column details
-	cols, err := queryColumns(ctx, db, d, tableName)
+	cols, err := queryColumns(ctx, db, d, inspectSchema, name)
 	if err != nil {
-		return snap, fmt.Errorf("query columns for %q: %w", tableName, err)
+		return snap, fmt.Errorf("query columns for %q: %w", target.String(), err)
 	}
 	snap.Columns = cols
 
-	// Query indexes
-	indexes, err := queryIndexes(ctx, db, d, tableName)
+	indexes, err := queryIndexes(ctx, db, d, inspectSchema, name)
 	if err != nil {
-		return snap, fmt.Errorf("query indexes for %q: %w", tableName, err)
+		return snap, fmt.Errorf("query indexes for %q: %w", target.String(), err)
 	}
 	snap.Indexes = indexes
 
 	return snap, nil
 }
 
-// LiveSchemaSnapshot queries the database for all listed tables and returns their live schemas.
+// LiveSchemaSnapshot queries the database for all listed unqualified tables.
 func LiveSchemaSnapshot(ctx context.Context, db *sql.DB, d chuck.Dialect, tableNames ...string) ([]LiveTableSnapshot, error) {
 	snaps := make([]LiveTableSnapshot, 0, len(tableNames))
 	for _, name := range tableNames {
-		snap, err := LiveSnapshot(ctx, db, d, name)
+		snap, err := LiveSnapshotObject(ctx, db, d, chuck.ObjectName{Name: name})
 		if err != nil {
 			return nil, err
 		}
@@ -77,12 +86,65 @@ func LiveSchemaSnapshot(ctx context.Context, db *sql.DB, d chuck.Dialect, tableN
 	return snaps, nil
 }
 
-func queryColumns(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveColumnSnapshot, error) {
+// LiveSchemaSnapshotObjects queries the database for all listed schema-qualified
+// tables. Use this when any table needs schema-aware introspection.
+func LiveSchemaSnapshotObjects(ctx context.Context, db *sql.DB, d chuck.Dialect, targets ...chuck.ObjectName) ([]LiveTableSnapshot, error) {
+	snaps := make([]LiveTableSnapshot, 0, len(targets))
+	for _, t := range targets {
+		snap, err := LiveSnapshotObject(ctx, db, d, t)
+		if err != nil {
+			return nil, err
+		}
+		snaps = append(snaps, snap)
+	}
+	return snaps, nil
+}
+
+// checkTableExists runs the engine-appropriate existence probe for a (schema,
+// name) pair. SQLite ignores schema.
+func checkTableExists(ctx context.Context, db *sql.DB, d chuck.Dialect, schema, name string) error {
+	var (
+		query string
+		args  []any
+	)
+	switch d.Engine() {
+	case chuck.SQLite:
+		query = "SELECT name FROM sqlite_master WHERE type='table' AND name=?"
+		args = []any{name}
+	case chuck.Postgres:
+		query = "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2"
+		args = []any{schema, name}
+	case chuck.MSSQL:
+		objArg := name
+		if schema != "" {
+			objArg = schema + "." + name
+		}
+		query = "SELECT name FROM sys.objects WHERE object_id = OBJECT_ID(@p1) AND type = 'U'"
+		args = []any{objArg}
+	default:
+		return fmt.Errorf("unsupported engine: %s", d.Engine())
+	}
+
+	var exists any
+	display := name
+	if schema != "" {
+		display = schema + "." + name
+	}
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&exists); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("table %q does not exist", display)
+		}
+		return fmt.Errorf("check table %q: %w", display, err)
+	}
+	return nil
+}
+
+func queryColumns(ctx context.Context, db *sql.DB, d chuck.Dialect, schema, name string) ([]LiveColumnSnapshot, error) {
 	switch d.Engine() {
 	case chuck.SQLite, chuck.Postgres:
-		return queryColumnsSimple(ctx, db, d, tableName)
+		return queryColumnsSimple(ctx, db, d, schema, name)
 	case chuck.MSSQL:
-		return queryColumnsMSSQL(ctx, db, tableName)
+		return queryColumnsMSSQL(ctx, db, schema, name)
 	default:
 		return nil, fmt.Errorf("unsupported engine: %s", d.Engine())
 	}
@@ -91,18 +153,23 @@ func queryColumns(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName st
 // queryColumnsSimple handles engines whose column queries return the shared
 // 4-column shape (name, type, nullable, default) and need no per-column
 // reconstruction work. Used by SQLite and Postgres.
-func queryColumnsSimple(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveColumnSnapshot, error) {
-	var query string
+func queryColumnsSimple(ctx context.Context, db *sql.DB, d chuck.Dialect, schema, name string) ([]LiveColumnSnapshot, error) {
+	var (
+		query string
+		args  []any
+	)
 	switch d.Engine() {
 	case chuck.SQLite:
 		query = `SELECT name, type, CASE WHEN "notnull" = 1 OR pk = 1 THEN 'NO' ELSE 'YES' END AS nullable, COALESCE(dflt_value, '') AS dflt FROM pragma_table_info(?)`
+		args = []any{name}
 	case chuck.Postgres:
 		query = postgresColumnQuery
+		args = []any{schema, name}
 	default:
 		return nil, fmt.Errorf("unsupported engine: %s", d.Engine())
 	}
 
-	rows, err := db.QueryContext(ctx, query, tableName)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -129,13 +196,13 @@ func queryColumnsSimple(ctx context.Context, db *sql.DB, d chuck.Dialect, tableN
 // bytes) per the SQL Server INFORMATION_SCHEMA.COLUMNS contract, with -1
 // indicating MAX. NUMERIC_PRECISION/NUMERIC_SCALE are populated for numeric
 // types and NULL otherwise. All three are nullable, hence the NullInt64 scans.
-var mssqlColumnQuery = `SELECT COLUMN_NAME, UPPER(DATA_TYPE), IS_NULLABLE, COALESCE(COLUMN_DEFAULT, ''), CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @p1 ORDER BY ORDINAL_POSITION`
+var mssqlColumnQuery = `SELECT COLUMN_NAME, UPPER(DATA_TYPE), IS_NULLABLE, COALESCE(COLUMN_DEFAULT, ''), CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2 ORDER BY ORDINAL_POSITION`
 
 // queryColumnsMSSQL queries MSSQL column metadata and rebuilds parameterized
 // type strings (e.g. NVARCHAR(255), DECIMAL(10,2), VARCHAR(MAX)) so live
 // snapshots match the declared types produced by Snapshot().
-func queryColumnsMSSQL(ctx context.Context, db *sql.DB, tableName string) ([]LiveColumnSnapshot, error) {
-	rows, err := db.QueryContext(ctx, mssqlColumnQuery, tableName)
+func queryColumnsMSSQL(ctx context.Context, db *sql.DB, schema, tableName string) ([]LiveColumnSnapshot, error) {
+	rows, err := db.QueryContext(ctx, mssqlColumnQuery, schema, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -189,14 +256,14 @@ func reconstructMSSQLType(dataType string, charMaxLength, numericPrecision, nume
 	}
 }
 
-func queryIndexes(ctx context.Context, db *sql.DB, d chuck.Dialect, tableName string) ([]LiveIndexSnapshot, error) {
+func queryIndexes(ctx context.Context, db *sql.DB, d chuck.Dialect, schema, tableName string) ([]LiveIndexSnapshot, error) {
 	switch d.Engine() {
 	case chuck.SQLite:
 		return queryIndexesSQLite(ctx, db, tableName)
 	case chuck.Postgres:
-		return queryIndexesPostgres(ctx, db, tableName)
+		return queryIndexesPostgres(ctx, db, schema, tableName)
 	case chuck.MSSQL:
-		return queryIndexesMSSQL(ctx, db, tableName)
+		return queryIndexesMSSQL(ctx, db, schema, tableName)
 	default:
 		return nil, fmt.Errorf("unsupported engine: %s", d.Engine())
 	}
@@ -283,10 +350,10 @@ func extractSQLiteWhere(createSQL string) string {
 	return strings.TrimSpace(createSQL[idx+7:])
 }
 
-func queryIndexesPostgres(ctx context.Context, db *sql.DB, tableName string) ([]LiveIndexSnapshot, error) {
+func queryIndexesPostgres(ctx context.Context, db *sql.DB, schema, tableName string) ([]LiveIndexSnapshot, error) {
 	query := postgresIndexQuery
 
-	rows, err := db.QueryContext(ctx, query, tableName)
+	rows, err := db.QueryContext(ctx, query, schema, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -312,11 +379,13 @@ func queryIndexesPostgres(ctx context.Context, db *sql.DB, tableName string) ([]
 	return indexes, rows.Err()
 }
 
-// postgresColumnQuery is the query used to retrieve column metadata from Postgres.
+// postgresColumnQuery retrieves column metadata for a (schema, table) pair.
+// The schema and table name are passed as parameters $1 and $2 respectively
+// so the same query works for any namespace, not just public.
 // Exported at package level for testability.
-var postgresColumnQuery = `SELECT c.column_name, UPPER(format_type(a.atttypid, a.atttypmod)), c.is_nullable, COALESCE(c.column_default, '') FROM information_schema.columns c JOIN pg_attribute a ON a.attname = c.column_name JOIN pg_class t ON t.relname = c.table_name AND t.oid = a.attrelid JOIN pg_namespace n ON n.oid = t.relnamespace AND n.nspname = 'public' WHERE c.table_schema = 'public' AND c.table_name = $1 AND a.attnum > 0 AND NOT a.attisdropped ORDER BY c.ordinal_position`
+var postgresColumnQuery = `SELECT c.column_name, UPPER(format_type(a.atttypid, a.atttypmod)), c.is_nullable, COALESCE(c.column_default, '') FROM information_schema.columns c JOIN pg_attribute a ON a.attname = c.column_name JOIN pg_class t ON t.relname = c.table_name AND t.oid = a.attrelid JOIN pg_namespace n ON n.oid = t.relnamespace AND n.nspname = c.table_schema WHERE c.table_schema = $1 AND c.table_name = $2 AND a.attnum > 0 AND NOT a.attisdropped ORDER BY c.ordinal_position`
 
-// postgresIndexQuery is the query used to retrieve index metadata from Postgres.
+// postgresIndexQuery retrieves index metadata for a (schema, table) pair.
 // Exported at package level for testability.
 var postgresIndexQuery = `
 		SELECT
@@ -331,11 +400,12 @@ var postgresIndexQuery = `
 		FROM pg_index ix
 		JOIN pg_class t ON t.oid = ix.indrelid
 		JOIN pg_class i ON i.oid = ix.indexrelid
-		JOIN pg_namespace n ON n.oid = t.relnamespace AND n.nspname = 'public'
-		WHERE t.relname = $1 AND NOT ix.indisprimary`
+		JOIN pg_namespace n ON n.oid = t.relnamespace AND n.nspname = $1
+		WHERE t.relname = $2 AND NOT ix.indisprimary`
 
-// mssqlIndexQuery is the query used to retrieve index metadata from MSSQL.
-// Exported at package level for testability.
+// mssqlIndexQuery retrieves index metadata for a schema-qualified object via
+// OBJECT_ID, which accepts the literal "[schema].[name]" pattern. Exported at
+// package level for testability.
 var mssqlIndexQuery = `
 	SELECT
 		si.name,
@@ -355,8 +425,12 @@ var mssqlIndexQuery = `
 	AND si.is_primary_key = 0
 	AND si.name IS NOT NULL`
 
-func queryIndexesMSSQL(ctx context.Context, db *sql.DB, tableName string) ([]LiveIndexSnapshot, error) {
-	rows, err := db.QueryContext(ctx, mssqlIndexQuery, tableName)
+func queryIndexesMSSQL(ctx context.Context, db *sql.DB, schema, tableName string) ([]LiveIndexSnapshot, error) {
+	objArg := tableName
+	if schema != "" {
+		objArg = schema + "." + tableName
+	}
+	rows, err := db.QueryContext(ctx, mssqlIndexQuery, objArg)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +472,11 @@ func splitAndTrim(s, sep string) []string {
 // in the same format as SnapshotString for easy side-by-side comparison.
 func (s LiveTableSnapshot) String() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "TABLE %s\n", s.Name)
+	if s.Schema != "" {
+		fmt.Fprintf(&b, "TABLE %s.%s\n", s.Schema, s.Name)
+	} else {
+		fmt.Fprintf(&b, "TABLE %s\n", s.Name)
+	}
 
 	for _, c := range s.Columns {
 		var parts []string

--- a/schema/live_snapshot_test.go
+++ b/schema/live_snapshot_test.go
@@ -333,26 +333,28 @@ func TestLiveSnapshotPartialIndex(t *testing.T) {
 	assert.Equal(t, "Status = 'open'", snap.Indexes[0].Where)
 }
 
-func TestPostgresColumnQueryScopesToPublicSchema(t *testing.T) {
-	// The Postgres column query must join pg_namespace to constrain
-	// pg_class lookups to the public schema, preventing cross-schema matches.
+func TestPostgresColumnQueryScopesBySchema(t *testing.T) {
+	// The Postgres column query must join pg_namespace and constrain by the
+	// schema parameter so cross-schema matches do not occur. Schema is now
+	// passed as a bound parameter ($1) rather than hardcoded, so qualified
+	// tables in non-public schemas can be inspected.
 	assert.Contains(t, postgresColumnQuery, "pg_namespace",
 		"Postgres column query should reference pg_namespace")
 	assert.Contains(t, postgresColumnQuery, "n.oid = t.relnamespace",
 		"Postgres column query should join pg_namespace on relnamespace")
-	assert.Contains(t, postgresColumnQuery, "n.nspname = 'public'",
-		"Postgres column query should constrain to public schema")
+	assert.Contains(t, postgresColumnQuery, "c.table_schema = $1",
+		"Postgres column query should constrain by the schema parameter")
 }
 
-func TestPostgresIndexQueryScopesToPublicSchema(t *testing.T) {
-	// The Postgres index query must join pg_namespace to constrain
-	// pg_class lookups to the public schema, preventing cross-schema matches.
+func TestPostgresIndexQueryScopesBySchema(t *testing.T) {
+	// The Postgres index query must join pg_namespace and constrain by the
+	// schema parameter so cross-schema matches do not occur.
 	assert.Contains(t, postgresIndexQuery, "pg_namespace",
 		"Postgres index query should reference pg_namespace")
 	assert.Contains(t, postgresIndexQuery, "n.oid = t.relnamespace",
 		"Postgres index query should join pg_namespace on relnamespace")
-	assert.Contains(t, postgresIndexQuery, "n.nspname = 'public'",
-		"Postgres index query should constrain to public schema")
+	assert.Contains(t, postgresIndexQuery, "n.nspname = $1",
+		"Postgres index query should constrain by the schema parameter")
 }
 
 func TestMSSQLIndexQueryExcludesIncludedColumns(t *testing.T) {

--- a/schema/order.go
+++ b/schema/order.go
@@ -4,12 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/catgoose/chuck"
 )
 
 // CreationOrder returns tables sorted so that foreign key dependencies are
 // satisfied: parents appear before children. Self-referential foreign keys
 // (a table referencing itself) are allowed and do not constitute a cycle.
 // Tables with no FK dependencies may appear in any stable order.
+//
+// Dependency ordering keys on fully qualified identity (schema + name) so two
+// declared tables with the same bare name but different schemas (e.g.
+// sg.SalesAgents and cl.SalesAgents) are treated as distinct.
 func CreationOrder(tables ...*TableDef) ([]*TableDef, error) {
 	return topoSort(tables, false)
 }
@@ -20,58 +26,61 @@ func DropOrder(tables ...*TableDef) ([]*TableDef, error) {
 	return topoSort(tables, true)
 }
 
-// topoSort performs a topological sort using Kahn's algorithm.
-// If reverse is true, the result is reversed (drop order).
+// topoSort performs a topological sort using Kahn's algorithm. Tables are
+// keyed by their fully qualified ObjectName so that schema-qualified
+// duplicates of the same bare table name resolve to distinct nodes.
 func topoSort(tables []*TableDef, reverse bool) ([]*TableDef, error) {
-	// Build a name -> table index.
-	byName := make(map[string]*TableDef, len(tables))
-	for _, t := range tables {
-		byName[t.Name] = t
+	byKey := make(map[string]*TableDef, len(tables))
+	keys := make([]string, len(tables))
+	for i, t := range tables {
+		k := objectKey(t.Object())
+		byKey[k] = t
+		keys[i] = k
 	}
 
-	// Build adjacency: edges go from dependency (parent) -> dependent (child).
-	// inDegree counts how many parents each table has.
+	// Build edges and in-degrees keyed by qualified identity. Foreign-key
+	// targets without an explicit schema can match either a same-schema
+	// declared table or an unqualified declared table — pick the more
+	// specific match first so multi-schema graphs resolve correctly.
 	inDegree := make(map[string]int, len(tables))
-	// children[parent] = list of child table names
 	children := make(map[string][]string, len(tables))
 
-	for _, t := range tables {
-		if _, ok := inDegree[t.Name]; !ok {
-			inDegree[t.Name] = 0
+	for i, t := range tables {
+		key := keys[i]
+		if _, ok := inDegree[key]; !ok {
+			inDegree[key] = 0
 		}
 		for _, col := range t.cols {
-			ref := col.refTable
-			if ref == "" {
+			target := col.refObject
+			if target.Name == "" {
 				continue
 			}
-			// Skip self-references — not a real dependency edge.
-			if ref == t.Name {
+			refKey := resolveRefKey(byKey, t, target)
+			if refKey == "" {
 				continue
 			}
-			// Only count references to tables in the input set.
-			if _, ok := byName[ref]; !ok {
+			if refKey == key {
 				continue
 			}
-			inDegree[t.Name]++
-			children[ref] = append(children[ref], t.Name)
+			inDegree[key]++
+			children[refKey] = append(children[refKey], key)
 		}
 	}
 
-	// Seed queue with tables that have no dependencies.
 	var queue []string
-	for _, t := range tables {
-		if inDegree[t.Name] == 0 {
-			queue = append(queue, t.Name)
+	for _, k := range keys {
+		if inDegree[k] == 0 {
+			queue = append(queue, k)
 		}
 	}
 
 	var sorted []*TableDef
 	for len(queue) > 0 {
-		name := queue[0]
+		k := queue[0]
 		queue = queue[1:]
-		sorted = append(sorted, byName[name])
+		sorted = append(sorted, byKey[k])
 
-		for _, child := range children[name] {
+		for _, child := range children[k] {
 			inDegree[child]--
 			if inDegree[child] == 0 {
 				queue = append(queue, child)
@@ -80,11 +89,10 @@ func topoSort(tables []*TableDef, reverse bool) ([]*TableDef, error) {
 	}
 
 	if len(sorted) != len(tables) {
-		// Find tables involved in the cycle for a useful error message.
 		var cycled []string
-		for _, t := range tables {
-			if inDegree[t.Name] > 0 {
-				cycled = append(cycled, t.Name)
+		for _, k := range keys {
+			if inDegree[k] > 0 {
+				cycled = append(cycled, k)
 			}
 		}
 		return nil, fmt.Errorf("%w: %s", ErrCyclicDependency, strings.Join(cycled, ", "))
@@ -97,6 +105,32 @@ func topoSort(tables []*TableDef, reverse bool) ([]*TableDef, error) {
 	}
 
 	return sorted, nil
+}
+
+// resolveRefKey returns the byKey lookup key that target resolves to within
+// the declared set, or "" if the target is not in the set. When the target
+// has no explicit schema, the search first tries the parent table's schema
+// (intra-schema reference), then falls back to an unqualified declaration.
+func resolveRefKey(byKey map[string]*TableDef, parent *TableDef, target chuck.ObjectName) string {
+	if target.Schema != "" {
+		k := objectKey(target)
+		if _, ok := byKey[k]; ok {
+			return k
+		}
+		return ""
+	}
+	// No explicit schema: prefer same-schema target, then unqualified.
+	if parent.schema != "" {
+		k := objectKey(chuck.ObjectName{Schema: parent.schema, Name: target.Name})
+		if _, ok := byKey[k]; ok {
+			return k
+		}
+	}
+	k := objectKey(target)
+	if _, ok := byKey[k]; ok {
+		return k
+	}
+	return ""
 }
 
 // ErrCyclicDependency is returned when tables have circular foreign key references.

--- a/schema/qualified.go
+++ b/schema/qualified.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/catgoose/chuck"
 )
@@ -42,16 +41,6 @@ func objectKey(o chuck.ObjectName) string {
 		return o.Name
 	}
 	return o.Schema + "." + o.Name
-}
-
-// objectKeyFor returns a dialect-normalized stable lookup key. Two ObjectNames
-// that normalize to the same identifier for the given dialect share a key.
-func objectKeyFor(d chuck.Dialect, o chuck.ObjectName) string {
-	schema, name := normalizedObject(d, o)
-	if schema == "" {
-		return name
-	}
-	return schema + "." + name
 }
 
 // createTableSQL renders a CREATE TABLE statement for the given object.
@@ -147,17 +136,4 @@ func resolveSchemaForInspection(d chuck.Dialect, o chuck.ObjectName) string {
 	default:
 		return ""
 	}
-}
-
-// trimQuoted strips leading/trailing whitespace from each comma-separated
-// segment of a column list and returns the cleaned segments.
-func trimColumnList(columns string) []string {
-	parts := strings.Split(columns, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
 }

--- a/schema/qualified.go
+++ b/schema/qualified.go
@@ -1,0 +1,163 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// qualifyTable returns the dialect-rendered, quoted, fully-qualified table
+// identifier for the given ObjectName. Both the schema and name components are
+// normalized via the dialect before being quoted. SQLite ignores any schema
+// component because SQLite has no first-class schema namespace (see the issue
+// #72 SQLite fallback semantics).
+//
+// This is the single helper that DDL, seed SQL, and snapshot/inspection paths
+// share so qualified-name rendering does not fork across the codebase.
+func qualifyTable(d chuck.Dialect, o chuck.ObjectName) string {
+	name := d.NormalizeIdentifier(o.Name)
+	if o.Schema == "" || d.Engine() == chuck.SQLite {
+		return d.QuoteIdentifier(name)
+	}
+	schema := d.NormalizeIdentifier(o.Schema)
+	return d.QuoteIdentifier(schema) + "." + d.QuoteIdentifier(name)
+}
+
+// normalizedObject returns the dialect-normalized schema and name for the
+// given ObjectName. The returned schema is empty when the engine does not
+// support schemas (SQLite) or when the ObjectName has no schema set.
+func normalizedObject(d chuck.Dialect, o chuck.ObjectName) (schema, name string) {
+	name = d.NormalizeIdentifier(o.Name)
+	if o.Schema == "" || d.Engine() == chuck.SQLite {
+		return "", name
+	}
+	return d.NormalizeIdentifier(o.Schema), name
+}
+
+// objectKey returns a stable lookup key for an ObjectName. Used to key maps
+// and detect duplicate identity across schema-qualified definitions.
+func objectKey(o chuck.ObjectName) string {
+	if o.Schema == "" {
+		return o.Name
+	}
+	return o.Schema + "." + o.Name
+}
+
+// objectKeyFor returns a dialect-normalized stable lookup key. Two ObjectNames
+// that normalize to the same identifier for the given dialect share a key.
+func objectKeyFor(d chuck.Dialect, o chuck.ObjectName) string {
+	schema, name := normalizedObject(d, o)
+	if schema == "" {
+		return name
+	}
+	return schema + "." + name
+}
+
+// createTableSQL renders a CREATE TABLE statement for the given object.
+func createTableSQL(d chuck.Dialect, o chuck.ObjectName, body string) string {
+	return fmt.Sprintf("\n\t\tCREATE TABLE %s (\n%s\n\t\t)", qualifyTable(d, o), body)
+}
+
+// createTableIfNotExistsSQL renders a CREATE TABLE IF NOT EXISTS statement for
+// the given object. For unqualified objects it delegates to the dialect so
+// existing output remains byte-identical; for schema-qualified objects it
+// emits an engine-appropriate template using qualifyTable.
+func createTableIfNotExistsSQL(d chuck.Dialect, o chuck.ObjectName, body string) string {
+	if o.Schema == "" || d.Engine() == chuck.SQLite {
+		return d.CreateTableIfNotExists(d.NormalizeIdentifier(o.Name), body)
+	}
+	qt := qualifyTable(d, o)
+	switch d.Engine() {
+	case chuck.MSSQL:
+		schema := d.NormalizeIdentifier(o.Schema)
+		name := d.NormalizeIdentifier(o.Name)
+		objArg := fmt.Sprintf("[%s].[%s]", schema, name)
+		return fmt.Sprintf(
+			"IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'%s') AND type in (N'U')) BEGIN CREATE TABLE %s (\n%s\n\t\t) END",
+			escapeQuote(objArg), qt, body,
+		)
+	default:
+		return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", qt, body)
+	}
+}
+
+// dropTableIfExistsSQL renders a DROP TABLE IF EXISTS statement for the given
+// object. Unqualified objects delegate to the dialect helper.
+func dropTableIfExistsSQL(d chuck.Dialect, o chuck.ObjectName) string {
+	if o.Schema == "" || d.Engine() == chuck.SQLite {
+		return d.DropTableIfExists(d.NormalizeIdentifier(o.Name))
+	}
+	qt := qualifyTable(d, o)
+	switch d.Engine() {
+	case chuck.MSSQL:
+		schema := d.NormalizeIdentifier(o.Schema)
+		name := d.NormalizeIdentifier(o.Name)
+		objArg := fmt.Sprintf("[%s].[%s]", schema, name)
+		return fmt.Sprintf(
+			"IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'%s') AND type in (N'U')) BEGIN DROP TABLE %s; END",
+			escapeQuote(objArg), qt,
+		)
+	default:
+		return fmt.Sprintf("DROP TABLE IF EXISTS %s", qt)
+	}
+}
+
+// insertOrIgnoreSQL renders an INSERT OR IGNORE / INSERT ... ON CONFLICT DO
+// NOTHING / TRY-CATCH-INSERT statement for the given object. Unqualified
+// objects delegate to the dialect helper to preserve existing behavior.
+func insertOrIgnoreSQL(d chuck.Dialect, o chuck.ObjectName, columns, values string) string {
+	if o.Schema == "" || d.Engine() == chuck.SQLite {
+		return d.InsertOrIgnore(d.NormalizeIdentifier(o.Name), columns, values)
+	}
+	qt := qualifyTable(d, o)
+	switch d.Engine() {
+	case chuck.Postgres:
+		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT DO NOTHING", qt, columns, values)
+	case chuck.MSSQL:
+		return fmt.Sprintf(
+			"BEGIN TRY INSERT INTO %s (%s) VALUES (%s) END TRY BEGIN CATCH IF ERROR_NUMBER() <> 2627 AND ERROR_NUMBER() <> 2601 THROW END CATCH",
+			qt, columns, values,
+		)
+	default:
+		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", qt, columns, values)
+	}
+}
+
+// renderFKReference renders a REFERENCES clause body for the given FK target.
+// Returns "schema.table(col)" with both pieces properly quoted.
+func renderFKReference(d chuck.Dialect, target chuck.ObjectName, column string) string {
+	return fmt.Sprintf("%s(%s)", qualifyTable(d, target), d.QuoteIdentifier(d.NormalizeIdentifier(column)))
+}
+
+// resolveSchemaForInspection returns the schema name that should be used when
+// querying the live database for the given object. Defaults are applied per
+// engine ("public" for Postgres, "dbo" for MSSQL) when the ObjectName has no
+// explicit schema; SQLite returns an empty string.
+func resolveSchemaForInspection(d chuck.Dialect, o chuck.ObjectName) string {
+	schema, _ := normalizedObject(d, o)
+	if schema != "" {
+		return schema
+	}
+	switch d.Engine() {
+	case chuck.Postgres:
+		return "public"
+	case chuck.MSSQL:
+		return "dbo"
+	default:
+		return ""
+	}
+}
+
+// trimQuoted strips leading/trailing whitespace from each comma-separated
+// segment of a column list and returns the cleaned segments.
+func trimColumnList(columns string) []string {
+	parts := strings.Split(columns, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/schema/qualified_test.go
+++ b/schema/qualified_test.go
@@ -1,0 +1,279 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableDef_WithSchema_Object(t *testing.T) {
+	td := NewTable("SalesAgents").WithSchema("sg")
+	assert.Equal(t, "sg", td.Schema())
+	assert.Equal(t, chuck.ObjectName{Schema: "sg", Name: "SalesAgents"}, td.Object())
+}
+
+func TestNewQualifiedTable_Equivalence(t *testing.T) {
+	a := NewQualifiedTable("sg", "SalesAgents")
+	b := NewTable("SalesAgents").WithSchema("sg")
+	assert.Equal(t, a.Object(), b.Object())
+}
+
+func TestQualifiedNameFor_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents")
+	assert.Equal(t, "[sg].[SalesAgents]", td.QualifiedNameFor(d))
+}
+
+func TestQualifiedNameFor_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewQualifiedTable("App", "SalesAgents")
+	// Postgres normalizes camelCase to snake_case.
+	assert.Equal(t, `"app"."sales_agents"`, td.QualifiedNameFor(d))
+}
+
+func TestQualifiedNameFor_SQLite_DropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents")
+	// SQLite has no schema namespace; the schema component must be dropped.
+	assert.Equal(t, `"SalesAgents"`, td.QualifiedNameFor(d))
+}
+
+func TestQualifiedNameFor_Unqualified_BackCompat(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewTable("Users")
+	assert.Equal(t, "[Users]", td.QualifiedNameFor(d))
+}
+
+func TestCreateSQL_QualifiedMSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	stmts := td.CreateSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], "CREATE TABLE [sg].[SalesAgents]")
+}
+
+func TestCreateIfNotExistsSQL_QualifiedMSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	stmts := td.CreateIfNotExistsSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], "OBJECT_ID(N'[sg].[SalesAgents]')",
+		"MSSQL existence probe should use the schema-qualified object literal")
+	assert.Contains(t, stmts[0], "CREATE TABLE [sg].[SalesAgents]")
+}
+
+func TestCreateIfNotExistsSQL_QualifiedPostgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	stmts := td.CreateIfNotExistsSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], `CREATE TABLE IF NOT EXISTS "sg"."sales_agents"`)
+}
+
+func TestDropSQL_QualifiedMSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents")
+	got := td.DropSQL(d)
+	assert.Contains(t, got, "OBJECT_ID(N'[sg].[SalesAgents]')")
+	assert.Contains(t, got, "DROP TABLE [sg].[SalesAgents]")
+}
+
+func TestDropSQL_QualifiedPostgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents")
+	assert.Equal(t, `DROP TABLE IF EXISTS "sg"."sales_agents"`, td.DropSQL(d))
+}
+
+func TestSeedSQL_QualifiedMSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "Lookup").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+		).
+		WithSeedRows(SeedRow{"Name": "'alpha'"})
+	stmts := td.SeedSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], "INSERT INTO [sg].[Lookup]")
+}
+
+func TestSeedSQL_QualifiedPostgres_OnConflictDoNothing(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewQualifiedTable("sg", "Lookup").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Name", TypeVarchar(50)).NotNull(),
+		).
+		WithSeedRows(SeedRow{"Name": "'alpha'"})
+	stmts := td.SeedSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], `INSERT INTO "sg"."lookup"`)
+	assert.Contains(t, stmts[0], "ON CONFLICT DO NOTHING")
+}
+
+func TestForeignKey_QualifiedReference_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "Goals").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("AgentID", TypeInt()).NotNull().
+				ReferencesQualified("sg", "SalesAgents", "ID"),
+		)
+	stmts := td.CreateSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], "REFERENCES [sg].[SalesAgents]([ID])")
+}
+
+func TestForeignKey_QualifiedReference_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewQualifiedTable("sg", "Goals").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("AgentID", TypeInt()).NotNull().
+				ReferencesQualified("sg", "SalesAgents", "ID"),
+		)
+	stmts := td.CreateSQL(d)
+	require.NotEmpty(t, stmts)
+	assert.Contains(t, stmts[0], `REFERENCES "sg"."sales_agents"("id")`)
+}
+
+func TestForeignKey_UnqualifiedBackCompat(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	td := NewTable("Goals").Columns(
+		AutoIncrCol("ID"),
+		Col("AgentID", TypeInt()).References("SalesAgents", "ID"),
+	)
+	stmts := td.CreateSQL(d)
+	require.NotEmpty(t, stmts)
+	// No schema prefix when target is unqualified.
+	assert.Contains(t, stmts[0], `REFERENCES "sales_agents"("id")`)
+	assert.NotContains(t, stmts[0], `"public"."sales_agents"`)
+}
+
+func TestSnapshot_PreservesSchema(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").
+		Columns(AutoIncrCol("ID"))
+	snap := td.Snapshot(d)
+	assert.Equal(t, "sg", snap.Schema)
+	assert.Equal(t, "SalesAgents", snap.Name)
+	assert.Equal(t, chuck.ObjectName{Schema: "sg", Name: "SalesAgents"}, snap.Object())
+}
+
+func TestSnapshot_FK_StructuredTarget(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "Goals").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("AgentID", TypeInt()).ReferencesQualified("sg", "SalesAgents", "ID"),
+		)
+	snap := td.Snapshot(d)
+	require.Len(t, snap.Columns, 2)
+	fkCol := snap.Columns[1]
+	assert.Equal(t, "sg", fkCol.RefSchema)
+	assert.Equal(t, "SalesAgents", fkCol.RefTable)
+	assert.Equal(t, "ID", fkCol.RefColumn)
+}
+
+func TestSnapshot_SQLite_FlattensSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	snap := td.Snapshot(d)
+	assert.Empty(t, snap.Schema, "SQLite snapshot must not carry a schema component")
+	assert.Equal(t, "SalesAgents", snap.Name)
+}
+
+func TestSnapshotString_QualifiedHeader(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	s := td.SnapshotString(d)
+	assert.True(t, strings.HasPrefix(s, "TABLE sg.SalesAgents\n"),
+		"SnapshotString should render the qualified TABLE header; got %q", s)
+}
+
+func TestCreationOrder_QualifiedDuplicateBareNames(t *testing.T) {
+	// sg.SalesAgents and cl.SalesAgents must be treated as distinct nodes.
+	sgAgents := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	clAgents := NewQualifiedTable("cl", "SalesAgents").Columns(AutoIncrCol("ID"))
+	sgGoals := NewQualifiedTable("sg", "Goals").Columns(
+		AutoIncrCol("ID"),
+		Col("AgentID", TypeInt()).ReferencesQualified("sg", "SalesAgents", "ID"),
+	)
+	clGoals := NewQualifiedTable("cl", "Goals").Columns(
+		AutoIncrCol("ID"),
+		Col("AgentID", TypeInt()).ReferencesQualified("cl", "SalesAgents", "ID"),
+	)
+	sorted, err := CreationOrder(clGoals, sgGoals, clAgents, sgAgents)
+	require.NoError(t, err)
+	require.Len(t, sorted, 4)
+
+	pos := make(map[string]int, 4)
+	for i, t := range sorted {
+		pos[t.Object().String()] = i
+	}
+	assert.Less(t, pos["sg.SalesAgents"], pos["sg.Goals"])
+	assert.Less(t, pos["cl.SalesAgents"], pos["cl.Goals"])
+}
+
+func TestCreationOrder_QualifiedFKDoesNotCrossSchemas(t *testing.T) {
+	// sg.Goals references sg.SalesAgents and must NOT pick cl.SalesAgents
+	// even though the bare name matches.
+	sgAgents := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	clAgents := NewQualifiedTable("cl", "SalesAgents").Columns(AutoIncrCol("ID"))
+	sgGoals := NewQualifiedTable("sg", "Goals").Columns(
+		AutoIncrCol("ID"),
+		Col("AgentID", TypeInt()).ReferencesQualified("sg", "SalesAgents", "ID"),
+	)
+	sorted, err := CreationOrder(sgGoals, clAgents, sgAgents)
+	require.NoError(t, err)
+	require.Len(t, sorted, 3)
+	pos := make(map[string]int, 3)
+	for i, t := range sorted {
+		pos[t.Object().String()] = i
+	}
+	assert.Less(t, pos["sg.SalesAgents"], pos["sg.Goals"])
+}
+
+func TestCheckSchemaCompatibility_SQLiteCollision(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	a := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	b := NewQualifiedTable("cl", "SalesAgents").Columns(AutoIncrCol("ID"))
+	err := CheckSchemaCompatibility(d, []*TableDef{a, b})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSQLiteSchemaCollision),
+		"expected ErrSQLiteSchemaCollision; got %v", err)
+	assert.Contains(t, err.Error(), "SalesAgents")
+}
+
+func TestCheckSchemaCompatibility_SQLite_NoCollision(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	a := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	b := NewQualifiedTable("cl", "SalesGoals").Columns(AutoIncrCol("ID"))
+	c := NewTable("Users").Columns(AutoIncrCol("ID"))
+	assert.NoError(t, CheckSchemaCompatibility(d, []*TableDef{a, b, c}))
+}
+
+func TestCheckSchemaCompatibility_NonSQLite_NoCollisionCheck(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	a := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	b := NewQualifiedTable("cl", "SalesAgents").Columns(AutoIncrCol("ID"))
+	// MSSQL distinguishes them by schema, so the collision check must not fire.
+	assert.NoError(t, CheckSchemaCompatibility(d, []*TableDef{a, b}))
+}
+
+func TestQualifiedIndex_MSSQL_UsesQualifiedObjectID(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	td := NewQualifiedTable("sg", "SalesAgents").
+		Columns(AutoIncrCol("ID"), Col("Name", TypeVarchar(50))).
+		Indexes(Index("idx_sg_agents_name", "Name"))
+	stmts := td.CreateIfNotExistsSQL(d)
+	require.Len(t, stmts, 2)
+	idxStmt := stmts[1]
+	assert.Contains(t, idxStmt, "OBJECT_ID(N'sg.SalesAgents')",
+		"MSSQL index probe should target schema-qualified OBJECT_ID")
+	assert.Contains(t, idxStmt, "ON [sg].[SalesAgents]")
+}

--- a/schema/seed_values.go
+++ b/schema/seed_values.go
@@ -97,8 +97,7 @@ func (t *TableDef) seedValuesSQL(d chuck.Dialect) []string {
 		if len(cols) == 0 {
 			continue
 		}
-		stmts = append(stmts, d.InsertOrIgnore(
-			d.NormalizeIdentifier(t.Name),
+		stmts = append(stmts, insertOrIgnoreSQL(d, t.Object(),
 			strings.Join(cols, ", "),
 			strings.Join(vals, ", "),
 		))

--- a/schema/snapshot.go
+++ b/schema/snapshot.go
@@ -17,6 +17,7 @@ type ColumnSnapshot struct {
 	AutoIncr   bool   `json:"auto_increment,omitempty"`
 	Mutable    bool   `json:"mutable"`
 	Default    string `json:"default,omitempty"`
+	RefSchema  string `json:"references_schema,omitempty"`
 	RefTable   string `json:"references_table,omitempty"`
 	RefColumn  string `json:"references_column,omitempty"`
 	OnDelete   string `json:"on_delete,omitempty"`
@@ -33,23 +34,36 @@ type IndexSnapshot struct {
 }
 
 // TableSnapshot describes a table's full resolved schema for a given dialect.
+//
+// Schema is the dialect-normalized schema namespace when the table is
+// schema-qualified, or "" otherwise. Name is always the bare table name
+// (without schema prefix) for back-compat with consumers that only inspect
+// Name. Use Object() for structured access to (schema, name).
 type TableSnapshot struct {
-	Name              string             `json:"name"`
-	Columns           []ColumnSnapshot   `json:"columns"`
-	Indexes           []IndexSnapshot    `json:"indexes,omitempty"`
-	UniqueConstraints [][]string         `json:"unique_constraints,omitempty"`
-	HasSoftDelete     bool               `json:"has_soft_delete,omitempty"`
-	HasVersion        bool               `json:"has_version,omitempty"`
-	HasExpiry         bool               `json:"has_expiry,omitempty"`
-	HasArchive        bool               `json:"has_archive,omitempty"`
+	Schema            string           `json:"schema,omitempty"`
+	Name              string           `json:"name"`
+	Columns           []ColumnSnapshot `json:"columns"`
+	Indexes           []IndexSnapshot  `json:"indexes,omitempty"`
+	UniqueConstraints [][]string       `json:"unique_constraints,omitempty"`
+	HasSoftDelete     bool             `json:"has_soft_delete,omitempty"`
+	HasVersion        bool             `json:"has_version,omitempty"`
+	HasExpiry         bool             `json:"has_expiry,omitempty"`
+	HasArchive        bool             `json:"has_archive,omitempty"`
+}
+
+// Object returns the structured ObjectName captured in the snapshot.
+func (s TableSnapshot) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: s.Schema, Name: s.Name}
 }
 
 // Snapshot returns a structured, dialect-resolved representation of the table schema.
 // The output is useful for diffing against a live database or serializing to JSON
 // for CI validation.
 func (t *TableDef) Snapshot(d chuck.Dialect) TableSnapshot {
+	schema, name := normalizedObject(d, t.Object())
 	snap := TableSnapshot{
-		Name:          d.NormalizeIdentifier(t.Name),
+		Schema:        schema,
+		Name:          name,
 		HasSoftDelete: t.hasSoftDelete,
 		HasVersion:    t.hasVersion,
 		HasExpiry:     t.hasExpiry,
@@ -71,8 +85,10 @@ func (t *TableDef) Snapshot(d chuck.Dialect) TableSnapshot {
 		} else if c.defaultVal != "" {
 			cs.Default = c.defaultVal
 		}
-		if c.refTable != "" {
-			cs.RefTable = d.NormalizeIdentifier(c.refTable)
+		if c.refObject.Name != "" {
+			refSchema, refName := normalizedObject(d, c.refObject)
+			cs.RefSchema = refSchema
+			cs.RefTable = refName
 			cs.RefColumn = d.NormalizeIdentifier(c.refColumn)
 			cs.OnDelete = c.onDelete
 			cs.OnUpdate = c.onUpdate
@@ -108,7 +124,11 @@ func (t *TableDef) SnapshotString(d chuck.Dialect) string {
 	snap := t.Snapshot(d)
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "TABLE %s\n", snap.Name)
+	if snap.Schema != "" {
+		fmt.Fprintf(&b, "TABLE %s.%s\n", snap.Schema, snap.Name)
+	} else {
+		fmt.Fprintf(&b, "TABLE %s\n", snap.Name)
+	}
 
 	for _, c := range snap.Columns {
 		var parts []string
@@ -130,7 +150,11 @@ func (t *TableDef) SnapshotString(d chuck.Dialect) string {
 			parts = append(parts, "DEFAULT "+c.Default)
 		}
 		if c.RefTable != "" {
-			ref := fmt.Sprintf("REFERENCES %s(%s)", c.RefTable, c.RefColumn)
+			target := c.RefTable
+			if c.RefSchema != "" {
+				target = c.RefSchema + "." + c.RefTable
+			}
+			ref := fmt.Sprintf("REFERENCES %s(%s)", target, c.RefColumn)
 			if c.OnDelete != "" {
 				ref += " ON DELETE " + c.OnDelete
 			}

--- a/schema/table.go
+++ b/schema/table.go
@@ -29,8 +29,15 @@ func (uc UniqueConstraint) ddl(d chuck.Dialect) string {
 type SeedRow map[string]string
 
 // TableDef defines a table schema.
+//
+// Schema-qualified tables: an optional schema namespace can be set with
+// WithSchema. The schema is preserved as structured metadata (not parsed from
+// a dotted string) through DDL generation, foreign-key metadata, snapshots,
+// validation, diffing, ensure, and live introspection. SQLite ignores the
+// schema component because SQLite has no equivalent namespace.
 type TableDef struct {
 	Name              string
+	schema            string
 	cols              []ColumnDef
 	indexes           []IndexDef
 	uniqueConstraints []UniqueConstraint
@@ -47,9 +54,43 @@ func NewTable(name string) *TableDef {
 	return &TableDef{Name: name}
 }
 
-// TableNameFor returns the table name normalized for the given dialect.
+// NewQualifiedTable creates a new table definition with an explicit schema.
+// Equivalent to NewTable(name).WithSchema(schema).
+func NewQualifiedTable(schema, name string) *TableDef {
+	return &TableDef{Name: name, schema: schema}
+}
+
+// WithSchema sets the schema namespace for the table. SQLite ignores this
+// because it has no schema namespace; other dialects render qualified
+// identifiers like "schema"."table" or [schema].[table].
+func (t *TableDef) WithSchema(schema string) *TableDef {
+	t.schema = schema
+	return t
+}
+
+// Schema returns the declared schema namespace for the table, or "" if none.
+func (t *TableDef) Schema() string {
+	return t.schema
+}
+
+// Object returns the structured ObjectName for the table, combining schema
+// and name.
+func (t *TableDef) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: t.schema, Name: t.Name}
+}
+
+// TableNameFor returns the bare table name normalized for the given dialect.
+// Callers that need a qualified, quoted identifier should use QualifiedNameFor
+// instead.
 func (t *TableDef) TableNameFor(d chuck.Dialect) string {
 	return d.NormalizeIdentifier(t.Name)
+}
+
+// QualifiedNameFor returns the dialect-rendered, quoted, schema-qualified
+// table identifier (e.g. [sg].[SalesAgents] on MSSQL, "sg"."sales_agents" on
+// Postgres). On SQLite the schema component is dropped.
+func (t *TableDef) QualifiedNameFor(d chuck.Dialect) string {
+	return qualifyTable(d, t.Object())
 }
 
 // Columns appends column definitions.
@@ -186,8 +227,7 @@ func (t *TableDef) SeedSQL(d chuck.Dialect) []string {
 		if len(cols) == 0 {
 			continue
 		}
-		stmts = append(stmts, d.InsertOrIgnore(
-			d.NormalizeIdentifier(t.Name),
+		stmts = append(stmts, insertOrIgnoreSQL(d, t.Object(),
 			strings.Join(cols, ", "),
 			strings.Join(vals, ", "),
 		))
@@ -293,30 +333,25 @@ func (t *TableDef) columnBody(d chuck.Dialect) string {
 
 // CreateSQL returns the CREATE TABLE statement followed by CREATE INDEX statements.
 func (t *TableDef) CreateSQL(d chuck.Dialect) []string {
-	tableName := d.NormalizeIdentifier(t.Name)
-	create := fmt.Sprintf("\n\t\tCREATE TABLE %s (\n%s\n\t\t)",
-		d.QuoteIdentifier(tableName), t.columnBody(d))
-
-	stmts := []string{create}
+	obj := t.Object()
+	stmts := []string{createTableSQL(d, obj, t.columnBody(d))}
 	for _, idx := range t.indexes {
-		stmts = append(stmts, idx.ddl(d, tableName))
+		stmts = append(stmts, idx.ddl(d, obj))
 	}
 	return stmts
 }
 
 // CreateIfNotExistsSQL returns CREATE TABLE IF NOT EXISTS followed by CREATE INDEX IF NOT EXISTS statements.
 func (t *TableDef) CreateIfNotExistsSQL(d chuck.Dialect) []string {
-	tableName := d.NormalizeIdentifier(t.Name)
-	create := d.CreateTableIfNotExists(tableName, t.columnBody(d))
-
-	stmts := []string{create}
+	obj := t.Object()
+	stmts := []string{createTableIfNotExistsSQL(d, obj, t.columnBody(d))}
 	for _, idx := range t.indexes {
-		stmts = append(stmts, idx.ddlIfNotExists(d, tableName))
+		stmts = append(stmts, idx.ddlIfNotExists(d, obj))
 	}
 	return stmts
 }
 
 // DropSQL returns the DROP TABLE statement for the given dialect.
 func (t *TableDef) DropSQL(d chuck.Dialect) string {
-	return d.DropTableIfExists(d.NormalizeIdentifier(t.Name))
+	return dropTableIfExistsSQL(d, t.Object())
 }

--- a/schema/validate.go
+++ b/schema/validate.go
@@ -37,14 +37,25 @@ func (e SchemaError) Error() string {
 //
 // Returns nil if the live schema matches the declaration.
 func ValidateSchema(ctx context.Context, db *sql.DB, d chuck.Dialect, td *TableDef) []SchemaError {
-	tableName := d.NormalizeIdentifier(td.Name)
+	displayName := displayQualifiedName(d, td.Object())
 
-	live, err := LiveSnapshot(ctx, db, d, tableName)
+	live, err := LiveSnapshotObject(ctx, db, d, td.Object())
 	if err != nil {
-		return []SchemaError{{Table: tableName, Message: err.Error()}}
+		return []SchemaError{{Table: displayName, Message: err.Error()}}
 	}
 
-	return validateAgainstLiveSnapshot(td, d, live, tableName)
+	return validateAgainstLiveSnapshot(td, d, live, displayName)
+}
+
+// displayQualifiedName returns a human-readable "schema.name" string for use
+// in error messages and diff Table fields. SQLite-flattened identifiers omit
+// the schema. Bare unqualified tables render as just the name.
+func displayQualifiedName(d chuck.Dialect, o chuck.ObjectName) string {
+	schema, name := normalizedObject(d, o)
+	if schema == "" {
+		return name
+	}
+	return schema + "." + name
 }
 
 // validateAgainstLiveSnapshot is the pure comparison core of ValidateSchema:


### PR DESCRIPTION
## Summary

- Adds `chuck.ObjectName{Schema, Name}` as the structured identity for tables and FK targets so schema-qualified declarations like `sg.SalesAgents` render correctly without dotted-string parsing.
- `TableDef.WithSchema` / `NewQualifiedTable` / `Object` / `QualifiedNameFor` surface the new identity; existing unqualified callers keep working unchanged.
- `ColumnDef.ReferencesQualified` and `ReferencesObject` preserve structured FK targets through DDL and snapshots.
- Shared `schema/qualified.go` helpers drive create/drop/seed/index rendering, dependency ordering keys on fully qualified identity, and `LiveSnapshotObject` / `ValidateSchema` / `DiffSchema` / `Ensure` thread the structured identity end-to-end.
- SQLite fallback drops schema in emitted SQL; `CheckSchemaCompatibility` fails fast with `ErrSQLiteSchemaCollision` when bare names would collide.
- README documents `WithSchema`, `ReferencesQualified`, and the SQLite fallback semantics.

Closes #72. dbrepo `FROM` / `JOIN` / column qualification stays out of scope; that work belongs to #73.

## Test plan

- [x] `go test ./...` (chuck, schema, dbrepo)
- [x] 26 new unit tests covering qualified DDL (MSSQL, Postgres, SQLite), FK rendering for qualified targets with unqualified back-compat, snapshot schema preservation, dependency ordering across duplicate bare names, schema-aware FK resolution, and the SQLite collision guard
- [ ] External Postgres / MSSQL integration tests — skipped: no engine env vars wired during this run