### PR TITLE
feat(dbrepo): first-class schema-qualified table references (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,23 @@ dbrepo.SetClauseQ(d, "Name", "Email")           // `"name" = @Name, "email" = @E
 dbrepo.InsertIntoQ(d, "Users", "Name", "Email") // `INSERT INTO "users" ("name", "email") VALUES (@Name, @Email)`
 ```
 
+Schema-qualified table names (`schema.table`) are rendered with each part quoted separately. SQLite drops the schema component because it has no schema namespace:
+
+```go
+dbrepo.InsertIntoQ(mssql, "sg.SalesAgents", "Name")
+// INSERT INTO [sg].[SalesAgents] ([Name]) VALUES (@Name)
+
+dbrepo.NewSelect("sg.SalesAgents", "ID", "Name").WithDialect(pg).Build()
+// SELECT ID, Name FROM "sg"."sales_agents"
+
+dbrepo.NewSelect("Tasks", "Tasks.ID").
+    Join("sg.SalesAgents sa", "sa.ID = Tasks.AgentID").
+    WithDialect(mssql).Build()
+// SELECT [Tasks].[ID] FROM [Tasks] JOIN [sg].[SalesAgents] sa ON sa.ID = Tasks.AgentID
+```
+
+`SelectBuilder` column lists also accept three-part `schema.table.column` references; bare names and expressions (anything with whitespace or parentheses) pass through unquoted.
+
 Convert a map to deterministic named args for use with `db.ExecContext`:
 
 ```go

--- a/chuck.go
+++ b/chuck.go
@@ -34,6 +34,53 @@ func (o ObjectName) Equal(other ObjectName) bool {
 	return o.Schema == other.Schema && o.Name == other.Name
 }
 
+// ParseObjectName splits a "schema.table" string into a structured
+// ObjectName. Inputs without a dot (or those that contain whitespace or
+// parentheses, which signal aliases or derived tables) are treated as
+// unqualified. Leading and trailing whitespace are trimmed.
+//
+// Examples:
+//
+//	ParseObjectName("Users")           -> {Name: "Users"}
+//	ParseObjectName("sg.SalesAgents")  -> {Schema: "sg", Name: "SalesAgents"}
+//	ParseObjectName(" sg . agents ")   -> {Schema: "sg", Name: "agents"}
+//	ParseObjectName("(SELECT 1)")      -> {Name: "(SELECT 1)"} // passthrough
+func ParseObjectName(s string) ObjectName {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ObjectName{}
+	}
+	// Anything with whitespace or parens is not a plain "schema.table" — leave
+	// for the caller to pass through unchanged.
+	if strings.ContainsAny(s, " \t()") {
+		return ObjectName{Name: s}
+	}
+	idx := strings.Index(s, ".")
+	if idx <= 0 || idx == len(s)-1 {
+		return ObjectName{Name: s}
+	}
+	return ObjectName{
+		Schema: strings.TrimSpace(s[:idx]),
+		Name:   strings.TrimSpace(s[idx+1:]),
+	}
+}
+
+// QualifyTable returns the dialect-rendered, quoted, fully-qualified table
+// identifier for the given ObjectName. Both schema and name components are
+// normalized via the dialect before being quoted. SQLite drops any schema
+// component because it has no first-class schema namespace.
+//
+// This is the canonical helper shared by the schema DSL and dbrepo so that
+// qualified-name rendering does not fork across the codebase.
+func QualifyTable(d Dialect, o ObjectName) string {
+	name := d.NormalizeIdentifier(o.Name)
+	if o.Schema == "" || d.Engine() == SQLite {
+		return d.QuoteIdentifier(name)
+	}
+	schema := d.NormalizeIdentifier(o.Schema)
+	return d.QuoteIdentifier(schema) + "." + d.QuoteIdentifier(name)
+}
+
 // Engine identifies a database engine.
 type Engine string
 

--- a/dbrepo/delete_builder.go
+++ b/dbrepo/delete_builder.go
@@ -47,7 +47,7 @@ func (d *DeleteBuilder) Build() (query string, args []any) {
 
 	tableName := d.table
 	if d.dialect != nil {
-		tableName = d.dialect.QuoteIdentifier(d.dialect.NormalizeIdentifier(d.table))
+		tableName = quoteTable(d.dialect, d.table)
 	}
 
 	parts = append(parts, fmt.Sprintf("DELETE FROM %s", tableName))

--- a/dbrepo/fragments.go
+++ b/dbrepo/fragments.go
@@ -84,13 +84,17 @@ func SetClauseQ(d chuck.Identifier, cols ...string) string {
 }
 
 // InsertIntoQ builds a full INSERT INTO … VALUES … statement with dialect quoting.
+// Schema-qualified table names ("sg.SalesAgents") are rendered with each part
+// quoted separately when d is a chuck.Dialect; SQLite drops the schema.
 //
 //	InsertIntoQ(d, "Users", "Name", "Email") =>
 //	  `INSERT INTO "users" ("name", "email") VALUES (@Name, @Email)` (Postgres)
 //	  `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email)` (SQLite)
+//	InsertIntoQ(mssql, "sg.SalesAgents", "Name") =>
+//	  `INSERT INTO [sg].[SalesAgents] ([Name]) VALUES (@Name)`
 func InsertIntoQ(d chuck.Identifier, table string, cols ...string) string {
 	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-		d.QuoteIdentifier(d.NormalizeIdentifier(table)), ColumnsQ(d, cols...), Placeholders(cols...))
+		quoteTableIdent(d, table), ColumnsQ(d, cols...), Placeholders(cols...))
 }
 
 // BulkInsertInto builds a multi-row INSERT INTO … VALUES … statement with
@@ -111,7 +115,7 @@ func InsertIntoQ(d chuck.Identifier, table string, cols ...string) string {
 //	BulkInsertInto(pgDialect, "users", []string{"name", "email"}, 3)
 //	// => INSERT INTO "users" ("name", "email") VALUES ($1, $2), ($3, $4), ($5, $6)
 func BulkInsertInto(d chuck.Dialect, table string, cols []string, rowCount int) string {
-	quotedTable := d.QuoteIdentifier(d.NormalizeIdentifier(table))
+	quotedTable := quoteTable(d, table)
 	quotedCols := make([]string, len(cols))
 	for i, c := range cols {
 		quotedCols[i] = d.QuoteIdentifier(d.NormalizeIdentifier(c))
@@ -143,10 +147,19 @@ func BulkInsertInto(d chuck.Dialect, table string, cols []string, rowCount int) 
 func UpsertInto(d chuck.Dialect, table string, conflictCols []string, cols ...string) string {
 	updateCols := nonConflictCols(cols, conflictCols)
 	updateSet := upsertSetClause(d, updateCols)
-	return d.Upsert(table, Columns(cols...), Placeholders(cols...), Columns(conflictCols...), updateSet)
+	on := chuck.ParseObjectName(strings.TrimSpace(table))
+	if on.Schema == "" {
+		return d.Upsert(table, Columns(cols...), Placeholders(cols...), Columns(conflictCols...), updateSet)
+	}
+	if d.Engine() == chuck.SQLite {
+		return d.Upsert(on.Name, Columns(cols...), Placeholders(cols...), Columns(conflictCols...), updateSet)
+	}
+	return renderQualifiedUpsert(d, on, Columns(cols...), Placeholders(cols...), Columns(conflictCols...), updateSet)
 }
 
 // UpsertIntoQ builds a dialect-aware UPSERT statement with identifier quoting.
+// Schema-qualified table names ("sg.SalesAgents") are rendered with each part
+// quoted separately; SQLite drops the schema component.
 //
 //	UpsertIntoQ(pgDialect, "Users", []string{"Email"}, "Email", "Name", "Age") =>
 //	  INSERT INTO "Users" ("Email", "Name", "Age") VALUES (@Email, @Name, @Age)
@@ -154,7 +167,67 @@ func UpsertInto(d chuck.Dialect, table string, conflictCols []string, cols ...st
 func UpsertIntoQ(d chuck.Dialect, table string, conflictCols []string, cols ...string) string {
 	updateCols := nonConflictCols(cols, conflictCols)
 	updateSet := upsertSetClauseQ(d, updateCols)
-	return d.Upsert(d.NormalizeIdentifier(table), ColumnsQ(d, cols...), Placeholders(cols...), ColumnsQ(d, conflictCols...), updateSet)
+	on := chuck.ParseObjectName(strings.TrimSpace(table))
+	if on.Schema == "" {
+		return d.Upsert(d.NormalizeIdentifier(table), ColumnsQ(d, cols...), Placeholders(cols...), ColumnsQ(d, conflictCols...), updateSet)
+	}
+	if d.Engine() == chuck.SQLite {
+		return d.Upsert(d.NormalizeIdentifier(on.Name), ColumnsQ(d, cols...), Placeholders(cols...), ColumnsQ(d, conflictCols...), updateSet)
+	}
+	return renderQualifiedUpsert(d, on, ColumnsQ(d, cols...), Placeholders(cols...), ColumnsQ(d, conflictCols...), updateSet)
+}
+
+// renderQualifiedUpsert builds an UPSERT statement for a schema-qualified
+// target. Reproduces the dialect's own Upsert template using a pre-rendered
+// schema.table token so qualified names render with each part quoted
+// separately (e.g. [sg].[Agents] on MSSQL).
+func renderQualifiedUpsert(d chuck.Dialect, target chuck.ObjectName, columns, values, conflictColumns, updateSet string) string {
+	qt := chuck.QualifyTable(d, target)
+	switch d.Engine() {
+	case chuck.Postgres:
+		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s",
+			qt, columns, values, conflictColumns, updateSet)
+	case chuck.MSSQL:
+		parts := strings.Split(conflictColumns, ", ")
+		onParts := make([]string, len(parts))
+		for i, col := range parts {
+			col = strings.TrimSpace(col)
+			onParts[i] = fmt.Sprintf("Target.%s = Source.%s", col, col)
+		}
+		onClause := strings.Join(onParts, " AND ")
+		return fmt.Sprintf(
+			"MERGE %s AS Target USING (VALUES (%s)) AS Source (%s) ON %s WHEN MATCHED THEN UPDATE SET %s WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);",
+			qt, values, columns, onClause, updateSet, columns, values,
+		)
+	default:
+		return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s",
+			qt, columns, values, conflictColumns, updateSet)
+	}
+}
+
+// quoteTableIdent applies dialect identifier quoting to a possibly
+// schema-qualified table name. Accepts chuck.Identifier so it works with the
+// existing InsertInto* signatures; if the identifier is also a Dialect the
+// engine-aware path (SQLite schema drop) kicks in.
+func quoteTableIdent(d chuck.Identifier, table string) string {
+	trimmed := strings.TrimSpace(table)
+	if trimmed == "" {
+		return table
+	}
+	if strings.ContainsAny(trimmed, " \t()") {
+		return table
+	}
+	on := chuck.ParseObjectName(trimmed)
+	if dialect, ok := d.(chuck.Dialect); ok {
+		return chuck.QualifyTable(dialect, on)
+	}
+	// Non-Dialect Identifier: fall back to per-part quoting without engine-
+	// aware schema handling. SQLite passes through as a Dialect, so we only
+	// reach this branch from synthetic Identifier-only callers/tests.
+	if on.Schema == "" {
+		return d.QuoteIdentifier(d.NormalizeIdentifier(on.Name))
+	}
+	return d.QuoteIdentifier(d.NormalizeIdentifier(on.Schema)) + "." + d.QuoteIdentifier(d.NormalizeIdentifier(on.Name))
 }
 
 // nonConflictCols returns columns from cols that are not in conflictCols.

--- a/dbrepo/qualified.go
+++ b/dbrepo/qualified.go
@@ -1,0 +1,66 @@
+package dbrepo
+
+import (
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// quoteTable renders a possibly schema-qualified table identifier through the
+// dialect's normalization and quoting. The input may be unqualified ("Users")
+// or qualified ("sg.SalesAgents"); whitespace or parentheses signal the input
+// is something exotic (alias form or derived table) and are returned
+// untouched.
+//
+// SQLite drops the schema component because it has no schema namespace.
+func quoteTable(d chuck.Dialect, table string) string {
+	trimmed := strings.TrimSpace(table)
+	if trimmed == "" {
+		return table
+	}
+	if strings.ContainsAny(trimmed, " \t()") {
+		return table
+	}
+	return chuck.QualifyTable(d, chuck.ParseObjectName(trimmed))
+}
+
+// quoteQualifiedColumn renders a possibly qualified column reference. The
+// supported shapes are:
+//
+//   - "col"                  -> "col" (passthrough; preserves back-compat)
+//   - "table.col"            -> quoted "table"."col"
+//   - "schema.table.col"     -> quoted "schema"."table"."col"
+//
+// Tokens with whitespace or parentheses (expressions, function calls, derived
+// references) are returned verbatim so callers can mix raw SQL into column
+// lists without dbrepo trying to parse it.
+func quoteQualifiedColumn(d chuck.Identifier, col string) string {
+	col = strings.TrimSpace(col)
+	if col == "" {
+		return col
+	}
+	if strings.ContainsAny(col, " \t()") {
+		return col
+	}
+	parts := strings.Split(col, ".")
+	// Reject empty segments — leave the raw form for the caller.
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			return col
+		}
+	}
+	switch len(parts) {
+	case 1:
+		// Bare column name: passthrough preserves prior unquoted behavior so
+		// existing callers using "Name" or "Tasks.ID" do not regress.
+		return col
+	case 2, 3:
+		out := make([]string, len(parts))
+		for i, p := range parts {
+			out[i] = d.QuoteIdentifier(d.NormalizeIdentifier(strings.TrimSpace(p)))
+		}
+		return strings.Join(out, ".")
+	default:
+		return col
+	}
+}

--- a/dbrepo/qualified_test.go
+++ b/dbrepo/qualified_test.go
@@ -1,0 +1,271 @@
+package dbrepo
+
+import (
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseObjectName_Helper(t *testing.T) {
+	cases := []struct {
+		in   string
+		want chuck.ObjectName
+	}{
+		{"Users", chuck.ObjectName{Name: "Users"}},
+		{"sg.SalesAgents", chuck.ObjectName{Schema: "sg", Name: "SalesAgents"}},
+		{" sg.agents ", chuck.ObjectName{Schema: "sg", Name: "agents"}},
+		{"", chuck.ObjectName{}},
+		{".trailing", chuck.ObjectName{Name: ".trailing"}},
+		{"leading.", chuck.ObjectName{Name: "leading."}},
+		{"(SELECT 1) sub", chuck.ObjectName{Name: "(SELECT 1) sub"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, chuck.ParseObjectName(tc.in))
+		})
+	}
+}
+
+func TestSelectBuilder_QualifiedFrom_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "ID", "Name").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, "SELECT ID, Name FROM [sg].[SalesAgents]", sql)
+}
+
+func TestSelectBuilder_QualifiedFrom_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "ID", "Name").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT ID, Name FROM "sg"."sales_agents"`, sql)
+}
+
+func TestSelectBuilder_QualifiedFrom_SQLite_DropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT ID FROM "SalesAgents"`, sql,
+		"SQLite has no schema namespace; the schema prefix must be dropped")
+}
+
+func TestSelectBuilder_QualifiedJoin_MSSQL_NoAlias(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("Tasks", "Tasks.ID").
+		Join("sg.SalesAgents", "Tasks.AgentID = sg.SalesAgents.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT [Tasks].[ID] FROM [Tasks] JOIN [sg].[SalesAgents] ON Tasks.AgentID = sg.SalesAgents.ID`,
+		sql,
+	)
+}
+
+func TestSelectBuilder_QualifiedJoin_MSSQL_WithAlias(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("Tasks", "Tasks.ID", "sa.Name").
+		Join("sg.SalesAgents sa", "sa.ID = Tasks.AgentID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT [Tasks].[ID], [sa].[Name] FROM [Tasks] JOIN [sg].[SalesAgents] sa ON sa.ID = Tasks.AgentID`,
+		sql,
+	)
+}
+
+func TestSelectBuilder_QualifiedJoin_MSSQL_AsAlias(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("Tasks", "Tasks.ID").
+		Join("sg.SalesAgents AS sa", "sa.ID = Tasks.AgentID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT [Tasks].[ID] FROM [Tasks] JOIN [sg].[SalesAgents] AS sa ON sa.ID = Tasks.AgentID`,
+		sql,
+	)
+}
+
+func TestSelectBuilder_QualifiedJoin_Postgres_AsAlias(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("Tasks", "Tasks.ID").
+		Join("sg.SalesAgents AS sa", "sa.ID = Tasks.AgentID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT "tasks"."id" FROM "tasks" JOIN "sg"."sales_agents" AS sa ON sa.ID = Tasks.AgentID`,
+		sql,
+	)
+}
+
+func TestSelectBuilder_ThreePartColumnRef_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "sg.SalesAgents.ID", "sg.SalesAgents.Name").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		"SELECT [sg].[SalesAgents].[ID], [sg].[SalesAgents].[Name] FROM [sg].[SalesAgents]",
+		sql,
+	)
+}
+
+func TestSelectBuilder_ThreePartColumnRef_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "sg.SalesAgents.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT "sg"."sales_agents"."id" FROM "sg"."sales_agents"`,
+		sql,
+	)
+}
+
+func TestSelectBuilder_CountQuery_QualifiedFrom(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("sg.SalesAgents", "ID").
+		WithDialect(d).
+		CountQuery()
+	assert.Equal(t, "SELECT COUNT(*) FROM [sg].[SalesAgents]", sql)
+}
+
+func TestSelectBuilder_CountQuery_QualifiedJoin(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("Tasks", "Tasks.ID").
+		Join("sg.SalesAgents sa", "sa.ID = Tasks.AgentID").
+		WithDialect(d).
+		CountQuery()
+	assert.Equal(t,
+		`SELECT COUNT(*) FROM "tasks" JOIN "sg"."sales_agents" sa ON sa.ID = Tasks.AgentID`,
+		sql,
+	)
+}
+
+func TestUpdateBuilder_QualifiedTable_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	w := NewWhere().And("ID = @ID")
+	sql, _ := NewUpdate("sg.SalesAgents", "Name").
+		Where(w).
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		"UPDATE [sg].[SalesAgents] SET [Name] = @Name WHERE ID = @ID",
+		sql,
+	)
+}
+
+func TestUpdateBuilder_QualifiedTable_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	w := NewWhere().And("ID = @ID")
+	sql, _ := NewUpdate("sg.SalesAgents", "Name").
+		Where(w).
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`UPDATE "sg"."sales_agents" SET "name" = @Name WHERE ID = @ID`,
+		sql,
+	)
+}
+
+func TestDeleteBuilder_QualifiedTable_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	w := NewWhere().And("ID = @ID")
+	sql, _ := NewDelete("sg.SalesAgents").
+		Where(w).
+		WithDialect(d).
+		Build()
+	assert.Equal(t, "DELETE FROM [sg].[SalesAgents] WHERE ID = @ID", sql)
+}
+
+func TestInsertIntoQ_QualifiedTable_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	got := InsertIntoQ(d, "sg.SalesAgents", "Name", "Email")
+	assert.Equal(t,
+		"INSERT INTO [sg].[SalesAgents] ([Name], [Email]) VALUES (@Name, @Email)",
+		got,
+	)
+}
+
+func TestInsertIntoQ_QualifiedTable_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	got := InsertIntoQ(d, "sg.SalesAgents", "Name", "Email")
+	assert.Equal(t,
+		`INSERT INTO "sg"."sales_agents" ("name", "email") VALUES (@Name, @Email)`,
+		got,
+	)
+}
+
+func TestInsertIntoQ_QualifiedTable_SQLite_DropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	got := InsertIntoQ(d, "sg.SalesAgents", "Name")
+	assert.Equal(t,
+		`INSERT INTO "SalesAgents" ("Name") VALUES (@Name)`,
+		got,
+	)
+}
+
+func TestBulkInsertInto_QualifiedTable_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	got := BulkInsertInto(d, "sg.SalesAgents", []string{"Name", "Email"}, 2)
+	assert.Equal(t,
+		`INSERT INTO "sg"."sales_agents" ("name", "email") VALUES ($1, $2), ($3, $4)`,
+		got,
+	)
+}
+
+func TestUpsertIntoQ_QualifiedTable_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	got := UpsertIntoQ(d, "sg.SalesAgents", []string{"Email"}, "Email", "Name")
+	assert.Equal(t,
+		`INSERT INTO "sg"."sales_agents" ("email", "name") VALUES (@Email, @Name) ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name"`,
+		got,
+	)
+}
+
+func TestUpsertIntoQ_QualifiedTable_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	got := UpsertIntoQ(d, "sg.SalesAgents", []string{"Email"}, "Email", "Name")
+	assert.Contains(t, got, "MERGE [sg].[SalesAgents] AS Target")
+	assert.Contains(t, got, "Target.[Email] = Source.[Email]")
+}
+
+func TestUpsertIntoQ_QualifiedTable_SQLite_DropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	got := UpsertIntoQ(d, "sg.SalesAgents", []string{"Email"}, "Email", "Name")
+	assert.Contains(t, got, `INSERT INTO "SalesAgents"`)
+	assert.NotContains(t, got, "sg.")
+}
+
+func TestSelectBuilder_DerivedTablePassthrough(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	// Derived-table targets contain parentheses and must be passed through
+	// unchanged; the builder does not attempt to parse subqueries.
+	sql, _ := NewSelect("(SELECT 1) sub", "ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT ID FROM (SELECT 1) sub`, sql)
+}
+
+func TestSelectBuilder_RawJoinPassthrough(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	// Raw subquery join targets must be passed through unchanged.
+	sql, _ := NewSelect("Tasks", "Tasks.ID").
+		Join("(SELECT id FROM users) u", "u.id = Tasks.UserID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t,
+		`SELECT "tasks"."id" FROM "tasks" JOIN (SELECT id FROM users) u ON u.id = Tasks.UserID`,
+		sql,
+	)
+}
+
+func TestQuoteQualifiedColumn_Passthrough(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	// Bare column names stay unquoted to preserve back-compat with callers
+	// that pass raw expressions.
+	assert.Equal(t, "Name", quoteQualifiedColumn(d, "Name"))
+	// Expression-like inputs are returned verbatim.
+	assert.Equal(t, "COUNT(*)", quoteQualifiedColumn(d, "COUNT(*)"))
+	assert.Equal(t, "a + b", quoteQualifiedColumn(d, "a + b"))
+}

--- a/dbrepo/qualified_test.go
+++ b/dbrepo/qualified_test.go
@@ -237,6 +237,55 @@ func TestUpsertIntoQ_QualifiedTable_SQLite_DropsSchema(t *testing.T) {
 	assert.NotContains(t, got, "sg.")
 }
 
+func TestSelectBuilder_AliasedFrom_MSSQL_SpaceAlias(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("sg.SalesAgents sa", "sa.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, "SELECT [sa].[ID] FROM [sg].[SalesAgents] sa", sql)
+}
+
+func TestSelectBuilder_AliasedFrom_Postgres_AsAlias(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("sg.SalesAgents AS sa", "sa.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT "sa"."id" FROM "sg"."sales_agents" AS sa`, sql)
+}
+
+func TestSelectBuilder_AliasedFrom_Postgres_Unqualified(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	sql, _ := NewSelect("Users u", "u.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT "u"."id" FROM "users" u`, sql)
+}
+
+func TestSelectBuilder_AliasedFrom_SQLite_AsAlias(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	sql, _ := NewSelect("Users AS u", "u.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT "u"."ID" FROM "Users" AS u`, sql)
+}
+
+func TestSelectBuilder_AliasedFrom_SQLite_QualifiedDropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	// SQLite has no schema; the schema component must be dropped, alias preserved.
+	sql, _ := NewSelect("sg.SalesAgents sa", "sa.ID").
+		WithDialect(d).
+		Build()
+	assert.Equal(t, `SELECT "sa"."ID" FROM "SalesAgents" sa`, sql)
+}
+
+func TestSelectBuilder_CountQuery_AliasedFrom_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	sql, _ := NewSelect("sg.SalesAgents sa", "sa.ID").
+		WithDialect(d).
+		CountQuery()
+	assert.Equal(t, "SELECT COUNT(*) FROM [sg].[SalesAgents] sa", sql)
+}
+
 func TestSelectBuilder_DerivedTablePassthrough(t *testing.T) {
 	d := chuck.PostgresDialect{}
 	// Derived-table targets contain parentheses and must be passed through

--- a/dbrepo/select_builder.go
+++ b/dbrepo/select_builder.go
@@ -89,7 +89,7 @@ func (s *SelectBuilder) Build() (query string, args []any) {
 	tableName := s.table
 	cols := s.cols
 	if s.dialect != nil {
-		tableName = quoteTable(s.dialect, s.table)
+		tableName = quoteJoinTarget(s.dialect, s.table)
 		cols = quoteDotQualifiedColumns(s.dialect, s.cols)
 	}
 	parts = append(parts, fmt.Sprintf("SELECT %s FROM %s", cols, tableName))
@@ -133,7 +133,7 @@ func (s *SelectBuilder) CountQuery() (query string, args []any) {
 	var parts []string
 	tableName := s.table
 	if s.dialect != nil {
-		tableName = quoteTable(s.dialect, s.table)
+		tableName = quoteJoinTarget(s.dialect, s.table)
 	}
 	parts = append(parts, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName))
 

--- a/dbrepo/select_builder.go
+++ b/dbrepo/select_builder.go
@@ -89,7 +89,7 @@ func (s *SelectBuilder) Build() (query string, args []any) {
 	tableName := s.table
 	cols := s.cols
 	if s.dialect != nil {
-		tableName = s.dialect.QuoteIdentifier(s.dialect.NormalizeIdentifier(s.table))
+		tableName = quoteTable(s.dialect, s.table)
 		cols = quoteDotQualifiedColumns(s.dialect, s.cols)
 	}
 	parts = append(parts, fmt.Sprintf("SELECT %s FROM %s", cols, tableName))
@@ -133,7 +133,7 @@ func (s *SelectBuilder) CountQuery() (query string, args []any) {
 	var parts []string
 	tableName := s.table
 	if s.dialect != nil {
-		tableName = s.dialect.QuoteIdentifier(s.dialect.NormalizeIdentifier(s.table))
+		tableName = quoteTable(s.dialect, s.table)
 	}
 	parts = append(parts, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName))
 
@@ -152,25 +152,22 @@ func (s *SelectBuilder) CountQuery() (query string, args []any) {
 	return strings.Join(parts, " "), s.where.Args()
 }
 
-// quoteDotQualifiedColumns takes a comma-separated column list and quotes only
-// dot-qualified names (Table.Column) by quoting each part separately.
-// Simple column names are left as-is to preserve backward compatibility.
+// quoteDotQualifiedColumns takes a comma-separated column list and quotes
+// dot-qualified names by quoting each part separately:
+//
+//   - "Name"               -> "Name" (passthrough; preserves back-compat)
+//   - "Table.Column"       -> quoted Table.Column
+//   - "Schema.Table.Column" -> quoted Schema.Table.Column
 //
 // The input is split on "," (not ", ") and each token is whitespace-trimmed so
 // that variations like "u.ID,v.Name", "u.ID,  v.Name", and "u.ID , v.Name" all
-// parse the same way. Output is always rejoined with ", " for consistency.
+// parse the same way. Tokens with whitespace or parentheses (expressions,
+// derived references) are returned verbatim. Output is rejoined with ", ".
 func quoteDotQualifiedColumns(d chuck.Identifier, cols string) string {
 	parts := strings.Split(cols, ",")
 	result := make([]string, len(parts))
 	for i, col := range parts {
-		col = strings.TrimSpace(col)
-		if dotIdx := strings.Index(col, "."); dotIdx >= 0 {
-			table := col[:dotIdx]
-			column := col[dotIdx+1:]
-			result[i] = d.QuoteIdentifier(d.NormalizeIdentifier(table)) + "." + d.QuoteIdentifier(d.NormalizeIdentifier(column))
-		} else {
-			result[i] = col
-		}
+		result[i] = quoteQualifiedColumn(d, col)
 	}
 	return strings.Join(result, ", ")
 }
@@ -179,11 +176,17 @@ func quoteDotQualifiedColumns(d chuck.Identifier, cols string) string {
 // identifier and an optional alias.
 //
 // Supported shapes:
-//   - "Users"        -> base="Users", alias="",  asForm=false
-//   - "Users u"      -> base="Users", alias="u", asForm=false
-//   - "Orders AS o"  -> base="Orders", alias="o", asForm=true (AS preserved in
-//     the original case from the input)
-//   - "Orders as o"  -> base="Orders", alias="o", asForm=true
+//   - "Users"                 -> base="Users", alias="",  asForm=false
+//   - "Users u"               -> base="Users", alias="u", asForm=false
+//   - "Orders AS o"           -> base="Orders", alias="o", asForm=true
+//   - "Orders as o"           -> base="Orders", alias="o", asForm=true
+//   - "sg.SalesAgents"        -> base="sg.SalesAgents", alias="", asForm=false
+//   - "sg.SalesAgents sa"     -> base="sg.SalesAgents", alias="sa"
+//   - "sg.SalesAgents AS sa"  -> base="sg.SalesAgents", alias="sa", asForm=true
+//
+// Schema-qualified bases ("schema.table") are returned as a single token in
+// base; callers should pass that token through quoteTable to render the
+// dialect-correct quoted form.
 //
 // Ambiguous or unsupported shapes (empty input, anything containing
 // parentheses such as derived tables/subqueries, or expressions with more
@@ -216,9 +219,11 @@ func parseJoinTarget(s string) (base, alias, asKeyword string) {
 }
 
 // quoteJoinTarget applies dialect quoting to a JOIN target while preserving
-// any alias tokens unchanged. Only the base table identifier is normalized
-// and quoted; aliases (with or without the AS keyword) are emitted literally
-// so callers can match them in ON/WHERE clauses without surprise casing.
+// any alias tokens unchanged. The base table identifier — which may be
+// schema-qualified ("sg.SalesAgents") — is rendered through chuck.QualifyTable
+// so each part is quoted separately and SQLite drops the schema component.
+// Aliases (with or without the AS keyword) are emitted literally so callers
+// can match them in ON/WHERE clauses without surprise casing.
 //
 // If the target shape is ambiguous (derived tables, more than three tokens,
 // etc.) parseJoinTarget yields an empty base and the full original input is
@@ -229,7 +234,7 @@ func quoteJoinTarget(d chuck.Dialect, target string) string {
 		// Ambiguous shape: fall back to the raw input unchanged.
 		return alias
 	}
-	quoted := d.QuoteIdentifier(d.NormalizeIdentifier(base))
+	quoted := chuck.QualifyTable(d, chuck.ParseObjectName(base))
 	switch {
 	case alias == "":
 		return quoted

--- a/dbrepo/update_builder.go
+++ b/dbrepo/update_builder.go
@@ -51,7 +51,7 @@ func (u *UpdateBuilder) Build() (query string, args []any) {
 	tableName := u.table
 	var setClause string
 	if u.dialect != nil {
-		tableName = u.dialect.QuoteIdentifier(u.dialect.NormalizeIdentifier(u.table))
+		tableName = quoteTable(u.dialect, u.table)
 		setClause = SetClauseQ(u.dialect, u.cols...)
 	} else {
 		setClause = SetClause(u.cols...)

--- a/schema/qualified.go
+++ b/schema/qualified.go
@@ -7,20 +7,10 @@ import (
 )
 
 // qualifyTable returns the dialect-rendered, quoted, fully-qualified table
-// identifier for the given ObjectName. Both the schema and name components are
-// normalized via the dialect before being quoted. SQLite ignores any schema
-// component because SQLite has no first-class schema namespace (see the issue
-// #72 SQLite fallback semantics).
-//
-// This is the single helper that DDL, seed SQL, and snapshot/inspection paths
-// share so qualified-name rendering does not fork across the codebase.
+// identifier for the given ObjectName. Delegates to chuck.QualifyTable so DDL,
+// seed SQL, snapshot/inspection, and dbrepo all share one rendering path.
 func qualifyTable(d chuck.Dialect, o chuck.ObjectName) string {
-	name := d.NormalizeIdentifier(o.Name)
-	if o.Schema == "" || d.Engine() == chuck.SQLite {
-		return d.QuoteIdentifier(name)
-	}
-	schema := d.NormalizeIdentifier(o.Schema)
-	return d.QuoteIdentifier(schema) + "." + d.QuoteIdentifier(name)
+	return chuck.QualifyTable(d, o)
 }
 
 // normalizedObject returns the dialect-normalized schema and name for the


### PR DESCRIPTION
## Summary

- `chuck.QualifyTable` and `chuck.ParseObjectName` shared helpers replace ad hoc dotted-string parsing; the schema package now routes its private `qualifyTable` through `chuck.QualifyTable`.
- `SelectBuilder` `FROM` / `JOIN` / `CountQuery` render `schema.table` part-by-part and support unaliased, space-aliased, and `AS`-aliased forms (`sg.SalesAgents`, `sg.SalesAgents sa`, `sg.SalesAgents AS sa`).
- `quoteDotQualifiedColumns` supports three-part `schema.table.column` references; bare names and expressions (whitespace / parens) still pass through unquoted.
- `UpdateBuilder`, `DeleteBuilder` route through the shared `quoteTable` helper.
- `InsertIntoQ`, `BulkInsertInto`, `UpsertInto`, `UpsertIntoQ` render qualified targets; the upsert paths inline the dialect template only when qualified to avoid double-quoting via `Dialect.Upsert`.
- README documents qualified usage and the SQLite fallback (schema dropped).

Closes #73. Depends on #72 (merged via #74).

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [x] 24 new unit tests covering qualified `FROM`/`JOIN`/CountQuery on MSSQL + Postgres + SQLite, 3-part column refs, qualified `UPDATE`/`DELETE`/`INSERT`/`BULK INSERT`/`UPSERT`, derived-table and raw-join passthrough, and bare-name/expression passthrough