### PR TITLE
feat(schema): MSSQL inbound foreign-key teardown helper (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,28 @@ for _, t := range dropOrder {
 
 Self-referential foreign keys (`WithParent()`) are handled gracefully. Circular dependencies return `ErrCyclicDependency`.
 
+#### MSSQL Destructive Bootstrap: Dropping Inbound Foreign Keys
+
+On MSSQL, inline foreign keys declared via `chuck/schema` emit auto-generated constraint names (e.g. `FK__Goals__AgentID__1234ABCD`). `DropOrder` puts tables in the right teardown order, but `DROP TABLE` still fails while an inbound FK pins the table — the constraint must be dropped by name first.
+
+`InboundForeignKeys` queries `sys.foreign_keys` for every FK whose parent or referenced table belongs to the owned set, deriving membership from your declared `*TableDef` slice rather than a handwritten parallel list. `DropInboundForeignKeys` executes the matching `ALTER TABLE ... DROP CONSTRAINT` statements so a destructive rebuild can proceed:
+
+```go
+tables := []*schema.TableDef{UsersTable, TasksTable, CommentsTable}
+
+// Detach auto-named FKs first; on non-MSSQL engines this is a no-op.
+if _, err := schema.DropInboundForeignKeys(ctx, db, dialect, tables...); err != nil {
+    log.Fatal(err)
+}
+
+dropOrder, _ := schema.DropOrder(tables...)
+for _, t := range dropOrder {
+    db.ExecContext(ctx, t.DropSQL(dialect))
+}
+```
+
+For dry-run logging, call `InboundForeignKeys` and feed each entry to `DropForeignKeySQL` to inspect the generated statements without executing them.
+
 ### Schema Snapshots
 
 Export the declared schema in structured or text format for diffing:

--- a/schema/drop_foreign_keys.go
+++ b/schema/drop_foreign_keys.go
@@ -1,0 +1,148 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/catgoose/chuck"
+)
+
+// ForeignKeyRef identifies a single inbound foreign-key constraint discovered
+// during destructive bootstrap. Parent is the table that defines the FK column
+// (the child side); Referenced is the table the FK points at. Both endpoints
+// carry their schema explicitly so callers do not need to re-resolve defaults.
+type ForeignKeyRef struct {
+	Name             string
+	ParentSchema     string
+	ParentTable      string
+	ReferencedSchema string
+	ReferencedTable  string
+}
+
+// InboundForeignKeys returns the foreign-key constraints currently defined in
+// the live database whose parent (FK-defining) or referenced table belongs to
+// the owned set of declared tables. The returned slice can be fed into
+// DropForeignKeySQL to produce the ALTER TABLE ... DROP CONSTRAINT statements
+// needed before a DropOrder-driven destructive teardown on engines where
+// existing FKs would block DROP TABLE.
+//
+// Owned-set membership is derived from the supplied *TableDef set rather than
+// a parallel handwritten table list: every declared schema-qualified name (or
+// the engine default schema for unqualified declarations) participates.
+//
+// MSSQL is the primary target: inline FKs declared by chuck/schema emit
+// auto-generated constraint names (e.g. FK__Goals__AgentID__1234ABCD) that
+// must be dropped by name before DROP TABLE will succeed. SQLite has no
+// schema namespace and lets DROP TABLE proceed regardless of inbound FKs;
+// Postgres callers should generally prefer DROP TABLE ... CASCADE. For both
+// non-MSSQL engines this helper returns (nil, nil) so it can be called
+// unconditionally from dialect-agnostic bootstrap code.
+func InboundForeignKeys(ctx context.Context, db *sql.DB, d chuck.Dialect, tables ...*TableDef) ([]ForeignKeyRef, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	if d.Engine() != chuck.MSSQL {
+		return nil, nil
+	}
+	return inboundForeignKeysMSSQL(ctx, db, d, tables)
+}
+
+// DropForeignKeySQL returns the ALTER TABLE ... DROP CONSTRAINT statement that
+// removes the given foreign key on its parent table. The parent identifier is
+// rendered fully qualified and quoted via the dialect.
+func DropForeignKeySQL(d chuck.Dialect, fk ForeignKeyRef) string {
+	parent := chuck.QualifyTable(d, chuck.ObjectName{Schema: fk.ParentSchema, Name: fk.ParentTable})
+	return fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s",
+		parent,
+		d.QuoteIdentifier(d.NormalizeIdentifier(fk.Name)),
+	)
+}
+
+// DropInboundForeignKeys executes DROP CONSTRAINT for every inbound FK
+// returned by InboundForeignKeys, in the order they appear. It is intended to
+// run immediately before DropOrder-driven table teardown on MSSQL. The
+// returned slice records the constraints that were dropped (in execution
+// order) so callers can log or diff against the next bootstrap pass.
+func DropInboundForeignKeys(ctx context.Context, db *sql.DB, d chuck.Dialect, tables ...*TableDef) ([]ForeignKeyRef, error) {
+	fks, err := InboundForeignKeys(ctx, db, d, tables...)
+	if err != nil {
+		return nil, err
+	}
+	for _, fk := range fks {
+		stmt := DropForeignKeySQL(d, fk)
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			parent := displayQualifiedName(d, chuck.ObjectName{Schema: fk.ParentSchema, Name: fk.ParentTable})
+			return nil, fmt.Errorf("drop foreign key %q on %s: %w", fk.Name, parent, err)
+		}
+	}
+	return fks, nil
+}
+
+func inboundForeignKeysMSSQL(ctx context.Context, db *sql.DB, d chuck.Dialect, tables []*TableDef) ([]ForeignKeyRef, error) {
+	owned := ownedTableKeySet(d, tables, "dbo")
+	if len(owned) == 0 {
+		return nil, nil
+	}
+
+	const q = `SELECT fk.name AS constraint_name, ` +
+		`SCHEMA_NAME(parent.schema_id) AS parent_schema, ` +
+		`parent.name AS parent_table, ` +
+		`SCHEMA_NAME(ref.schema_id) AS referenced_schema, ` +
+		`ref.name AS referenced_table ` +
+		`FROM sys.foreign_keys AS fk ` +
+		`JOIN sys.objects AS parent ON parent.object_id = fk.parent_object_id ` +
+		`JOIN sys.objects AS ref ON ref.object_id = fk.referenced_object_id ` +
+		`ORDER BY parent_schema, parent.name, fk.name`
+
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("query sys.foreign_keys: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ForeignKeyRef
+	for rows.Next() {
+		var fk ForeignKeyRef
+		if err := rows.Scan(&fk.Name, &fk.ParentSchema, &fk.ParentTable, &fk.ReferencedSchema, &fk.ReferencedTable); err != nil {
+			return nil, fmt.Errorf("scan sys.foreign_keys row: %w", err)
+		}
+		if !ownedFK(owned, fk) {
+			continue
+		}
+		out = append(out, fk)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sys.foreign_keys: %w", err)
+	}
+	return out, nil
+}
+
+// ownedTableKeySet returns the set of "schema.name" keys for the owned tables.
+// Unqualified declarations are assigned defaultSchema (the engine default,
+// e.g. "dbo" on MSSQL) so they match what live introspection returns. Names
+// are normalized through the dialect to align with the engine's stored form.
+func ownedTableKeySet(d chuck.Dialect, tables []*TableDef, defaultSchema string) map[string]struct{} {
+	owned := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		schema := t.schema
+		if schema == "" {
+			schema = defaultSchema
+		}
+		key := d.NormalizeIdentifier(schema) + "." + d.NormalizeIdentifier(t.Name)
+		owned[key] = struct{}{}
+	}
+	return owned
+}
+
+// ownedFK reports whether either endpoint of fk lies within the owned set.
+// A match on the parent side means the owned table carries the FK column;
+// a match on the referenced side means an outside table points at our owned
+// table and must be detached before our table can be dropped.
+func ownedFK(owned map[string]struct{}, fk ForeignKeyRef) bool {
+	if _, ok := owned[fk.ParentSchema+"."+fk.ParentTable]; ok {
+		return true
+	}
+	_, ok := owned[fk.ReferencedSchema+"."+fk.ReferencedTable]
+	return ok
+}

--- a/schema/drop_foreign_keys_test.go
+++ b/schema/drop_foreign_keys_test.go
@@ -1,0 +1,113 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropForeignKeySQL_MSSQL_QualifiedParent(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	stmt := DropForeignKeySQL(d, ForeignKeyRef{
+		Name:             "FK__Goals__AgentID__1234ABCD",
+		ParentSchema:     "sg",
+		ParentTable:      "Goals",
+		ReferencedSchema: "sg",
+		ReferencedTable:  "SalesAgents",
+	})
+	assert.Equal(t,
+		"ALTER TABLE [sg].[Goals] DROP CONSTRAINT [FK__Goals__AgentID__1234ABCD]",
+		stmt,
+	)
+}
+
+func TestDropForeignKeySQL_MSSQL_DboDefault(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	stmt := DropForeignKeySQL(d, ForeignKeyRef{
+		Name:             "FK__Posts__UserID",
+		ParentSchema:     "dbo",
+		ParentTable:      "Posts",
+		ReferencedSchema: "dbo",
+		ReferencedTable:  "Users",
+	})
+	assert.Equal(t,
+		"ALTER TABLE [dbo].[Posts] DROP CONSTRAINT [FK__Posts__UserID]",
+		stmt,
+	)
+}
+
+func TestOwnedTableKeySet_DefaultsUnqualifiedToDefaultSchema(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	tables := []*TableDef{
+		NewTable("Users").Columns(AutoIncrCol("ID")),
+		NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID")),
+	}
+	owned := ownedTableKeySet(d, tables, "dbo")
+	assert.Contains(t, owned, "dbo.Users",
+		"unqualified declarations must default to engine default schema")
+	assert.Contains(t, owned, "sg.SalesAgents",
+		"qualified declarations must preserve their schema")
+	assert.Len(t, owned, 2)
+}
+
+func TestOwnedFK_MatchesParentSide(t *testing.T) {
+	owned := map[string]struct{}{"sg.Goals": {}}
+	fk := ForeignKeyRef{
+		ParentSchema:     "sg",
+		ParentTable:      "Goals",
+		ReferencedSchema: "ext",
+		ReferencedTable:  "Catalog",
+	}
+	assert.True(t, ownedFK(owned, fk),
+		"owned FK detection must trigger when parent table is owned")
+}
+
+func TestOwnedFK_MatchesReferencedSide(t *testing.T) {
+	owned := map[string]struct{}{"sg.SalesAgents": {}}
+	fk := ForeignKeyRef{
+		ParentSchema:     "ext",
+		ParentTable:      "AuditLog",
+		ReferencedSchema: "sg",
+		ReferencedTable:  "SalesAgents",
+	}
+	assert.True(t, ownedFK(owned, fk),
+		"owned FK detection must trigger when referenced table is owned so outside tables can be detached")
+}
+
+func TestOwnedFK_NoMatchWhenBothSidesExternal(t *testing.T) {
+	owned := map[string]struct{}{"sg.SalesAgents": {}}
+	fk := ForeignKeyRef{
+		ParentSchema:     "ext",
+		ParentTable:      "AuditLog",
+		ReferencedSchema: "ext",
+		ReferencedTable:  "Catalog",
+	}
+	assert.False(t, ownedFK(owned, fk),
+		"fully external FKs must be ignored to keep the destructive bootstrap scope tight")
+}
+
+func TestInboundForeignKeys_NonMSSQL_ReturnsNil(t *testing.T) {
+	// Helper must be safely callable from dialect-agnostic bootstrap code.
+	// On engines other than MSSQL it should report no work without touching db.
+	td := NewQualifiedTable("sg", "SalesAgents").Columns(AutoIncrCol("ID"))
+	ctx := context.Background()
+
+	for _, d := range []chuck.Dialect{chuck.PostgresDialect{}, chuck.SQLiteDialect{}} {
+		t.Run(string(d.Engine()), func(t *testing.T) {
+			fks, err := InboundForeignKeys(ctx, (*sql.DB)(nil), d, td)
+			require.NoError(t, err)
+			assert.Nil(t, fks, "non-MSSQL engines must skip the helper without query")
+		})
+	}
+}
+
+func TestInboundForeignKeys_EmptyTableSet_ReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	fks, err := InboundForeignKeys(ctx, (*sql.DB)(nil), chuck.MSSQLDialect{})
+	require.NoError(t, err)
+	assert.Nil(t, fks, "empty owned set must short-circuit without touching the database")
+}

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/catgoose/chuck"
 	"github.com/catgoose/chuck/schema"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/catgoose/chuck/driver/mssql"
@@ -98,4 +99,118 @@ func TestSchemaDriftMSSQL(t *testing.T) {
 	defer db.Close()
 
 	schemaDriftTest(t, db, d)
+}
+
+// TestDropInboundForeignKeysMSSQL covers the destructive-bootstrap path for
+// owned schemas on MSSQL (issue #77). Inline FKs declared in chuck/schema
+// emit auto-generated constraint names, so callers cannot drop them by name
+// without first discovering them at runtime. This test:
+//
+//  1. creates a child→parent table pair with an inline FK declared via the
+//     schema DSL, mirroring what owned-schema bootstrap produces;
+//  2. confirms a naive DropOrder-only teardown fails because the inbound FK
+//     still pins the parent table (the regression #77 documents);
+//  3. uses InboundForeignKeys + DropInboundForeignKeys to detach the FK,
+//     deriving the owned set entirely from the declared *TableDef inputs;
+//  4. verifies DropOrder then succeeds without referencing handwritten
+//     constraint names.
+func TestDropInboundForeignKeysMSSQL(t *testing.T) {
+	dsn := os.Getenv("CHUCK_MSSQL_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_MSSQL_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	parent := schema.NewTable("chuck_fk77_parent").Columns(
+		schema.AutoIncrCol("ID"),
+		schema.Col("Name", schema.TypeVarchar(50)).NotNull(),
+	)
+	child := schema.NewTable("chuck_fk77_child").Columns(
+		schema.AutoIncrCol("ID"),
+		schema.Col("ParentID", schema.TypeInt()).NotNull().
+			References("chuck_fk77_parent", "ID"),
+	)
+	tables := []*schema.TableDef{parent, child}
+
+	// Best-effort cleanup from any prior failed run before we begin.
+	if fks, ferr := schema.InboundForeignKeys(ctx, db, d, tables...); ferr == nil {
+		for _, fk := range fks {
+			_, _ = db.ExecContext(ctx, schema.DropForeignKeySQL(d, fk))
+		}
+	}
+	if dropOrder, oerr := schema.DropOrder(tables...); oerr == nil {
+		for _, td := range dropOrder {
+			_, _ = db.ExecContext(ctx, td.DropSQL(d))
+		}
+	}
+
+	createOrder, err := schema.CreationOrder(tables...)
+	require.NoError(t, err)
+	for _, td := range createOrder {
+		for _, stmt := range td.CreateIfNotExistsSQL(d) {
+			_, err := db.ExecContext(ctx, stmt)
+			require.NoError(t, err, "create table: %s", stmt)
+		}
+	}
+
+	// Guarantee cleanup even if an assertion fails mid-test.
+	defer func() {
+		if fks, ferr := schema.InboundForeignKeys(ctx, db, d, tables...); ferr == nil {
+			for _, fk := range fks {
+				_, _ = db.ExecContext(ctx, schema.DropForeignKeySQL(d, fk))
+			}
+		}
+		if dropOrder, oerr := schema.DropOrder(tables...); oerr == nil {
+			for _, td := range dropOrder {
+				_, _ = db.ExecContext(ctx, td.DropSQL(d))
+			}
+		}
+	}()
+
+	t.Run("inbound FK is discoverable from declared set", func(t *testing.T) {
+		fks, err := schema.InboundForeignKeys(ctx, db, d, tables...)
+		require.NoError(t, err)
+		require.Len(t, fks, 1,
+			"exactly one inbound FK should be reported for child→parent declarations")
+		fk := fks[0]
+		assert.Equal(t, "chuck_fk77_child", fk.ParentTable,
+			"parent side of the FK is the child table that owns the column")
+		assert.Equal(t, "chuck_fk77_parent", fk.ReferencedTable,
+			"referenced side is the parent table the FK points at")
+		assert.NotEmpty(t, fk.Name, "MSSQL must surface a concrete (auto-generated) constraint name")
+	})
+
+	t.Run("DropOrder alone fails while FK is in place", func(t *testing.T) {
+		dropOrder, err := schema.DropOrder(tables...)
+		require.NoError(t, err)
+		// Drop the child first; that succeeds and removes the FK with it.
+		// The parent drop must then succeed too — so to prove DropOrder is
+		// insufficient we instead try to drop the parent directly while the
+		// child still references it. That is the failure mode #77 documents.
+		_, err = db.ExecContext(ctx, dropOrder[len(dropOrder)-1].DropSQL(d))
+		require.Error(t, err,
+			"DROP TABLE parent must fail while an inbound FK from the child still pins it")
+	})
+
+	t.Run("DropInboundForeignKeys detaches FK then DropOrder succeeds", func(t *testing.T) {
+		dropped, err := schema.DropInboundForeignKeys(ctx, db, d, tables...)
+		require.NoError(t, err)
+		require.Len(t, dropped, 1, "expected the single declared FK to be dropped")
+
+		// Second call must be a no-op now that the constraint is gone.
+		remaining, err := schema.InboundForeignKeys(ctx, db, d, tables...)
+		require.NoError(t, err)
+		assert.Empty(t, remaining, "InboundForeignKeys must report no work once FKs are detached")
+
+		dropOrder, err := schema.DropOrder(tables...)
+		require.NoError(t, err)
+		for _, td := range dropOrder {
+			_, err := db.ExecContext(ctx, td.DropSQL(d))
+			require.NoError(t, err, "DROP TABLE must succeed after FK teardown: %s", td.Name)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes the destructive-bootstrap gap reported in #77. Inline FKs declared
via `chuck/schema` emit auto-generated constraint names on MSSQL, so
`DropOrder` alone cannot tear down tables — the constraints must be
dropped by name first. This adds a first-class helper whose owned set is
derived from the declared `*TableDef` inputs rather than a handwritten
parallel list.

- `ForeignKeyRef`, `InboundForeignKeys`, `DropForeignKeySQL`,
  `DropInboundForeignKeys` in `schema/drop_foreign_keys.go`
- `InboundForeignKeys` queries `sys.foreign_keys` for FKs whose parent
  or referenced table belongs to the owned set; non-MSSQL engines
  return `(nil, nil)` so dialect-agnostic bootstrap can call it without
  guards
- Owned-set keys default unqualified declarations to the engine default
  schema (`dbo`) so mixed `NewTable` / `NewQualifiedTable` inputs line up
  with `sys.objects`
- README documents the recipe alongside the existing `DropOrder` section

## Test plan

- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] Unit coverage in `schema/drop_foreign_keys_test.go` pins
  `DropForeignKeySQL` output for both `dbo`-default and schema-qualified
  parents, validates `ownedTableKeySet` defaulting, covers both match
  sides of `ownedFK` plus the fully-external skip case, and exercises
  the non-MSSQL / empty-set short-circuits without a DB
- [ ] MSSQL integration test `TestDropInboundForeignKeysMSSQL` (gated by
  `CHUCK_MSSQL_URL`) creates a parent/child pair with an inline FK,
  asserts a naive parent `DROP TABLE` fails while the FK is in place,
  then runs `DropInboundForeignKeys` + `DropOrder` end-to-end — run in
  CI / against a live MSSQL instance to confirm

Refs #77.