### PR TITLE
feat(schema): first-class ViewDef for owned-view lifecycle (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [Column Lists](#column-lists)
     - [Seed Data](#seed-data)
     - [Table Dependency Ordering](#table-dependency-ordering)
+    - [Owned Views](#owned-views)
     - [Schema Snapshots](#schema-snapshots)
     - [Live Schema Snapshots](#live-schema-snapshots)
     - [Schema Validation](#schema-validation)
@@ -421,6 +422,34 @@ for _, t := range dropOrder {
 ```
 
 For dry-run logging, call `InboundForeignKeys` and feed each entry to `DropForeignKeySQL` to inspect the generated statements without executing them.
+
+### Owned Views
+
+Views live next to owned tables as first-class `ViewDef` values, so schema ownership stays in one package instead of splitting `TableDef` declarations from handwritten `CREATE VIEW` constants. A view carries an optional schema namespace and a SELECT body; the package emits dialect-aware lifecycle SQL through the same identifier-rendering path as `TableDef`.
+
+```go
+var ActiveTasksView = schema.NewView("v_active_tasks",
+    `SELECT "id", "title" FROM "tasks" WHERE "deleted_at" IS NULL`)
+
+// Or schema-qualified, mirroring NewQualifiedTable.
+var PTOUsageView = schema.NewQualifiedView("sg", "v_pto_usage",
+    `SELECT [AgentID], SUM([Hours]) AS [TotalHours] FROM [sg].[PTOEntries] GROUP BY [AgentID]`)
+
+// Create / replace / drop -- rendered per dialect.
+db.Exec(ActiveTasksView.CreateSQL(dialect))
+for _, stmt := range ActiveTasksView.CreateOrReplaceSQL(dialect) {
+    db.Exec(stmt)
+}
+db.Exec(ActiveTasksView.DropSQL(dialect))
+```
+
+Lifecycle SQL is rendered per dialect:
+
+- **Postgres** uses native `CREATE OR REPLACE VIEW ... AS ...` and `DROP VIEW IF EXISTS ...`.
+- **MSSQL** uses `CREATE OR ALTER VIEW ... AS ...` (MSSQL 2016+) and wraps the drop in a `sys.views` existence probe, matching the table-drop pattern.
+- **SQLite** has no `CREATE OR REPLACE` / `CREATE OR ALTER` for views, so `CreateOrReplaceSQL` returns a `DROP VIEW IF EXISTS` followed by `CREATE VIEW` -- run them in order. The schema component is dropped on SQLite because it has no namespace.
+
+The view body is taken verbatim; callers own its inner quoting and any references to owned tables. Ordering between owned views and the tables they read is caller-owned: create views after their tables, drop them before. This keeps the API thin and avoids forcing a generalized scheduler for what is usually a short linear chain on top of owned tables.
 
 ### Schema Snapshots
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -65,6 +65,52 @@ func schemaDriftTest(t *testing.T, db *sql.DB, d chuck.Dialect) {
 	})
 }
 
+// TestViewLifecycleSQLite exercises the ViewDef create / create-or-replace /
+// drop lifecycle end-to-end against in-memory SQLite. Running this against a
+// real engine catches surface-level breakage (escaping, missing whitespace,
+// dialect-emitted statements that the engine refuses) that pure string tests
+// would miss. SQLite is used because it needs no env-gated DSN.
+func TestViewLifecycleSQLite(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	tbl := schema.NewTable("view_lifecycle_tasks").Columns(
+		schema.AutoIncrCol("ID"),
+		schema.Col("Title", schema.TypeVarchar(255)).NotNull(),
+	)
+	for _, stmt := range tbl.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err, "create base table: %s", stmt)
+	}
+	defer func() {
+		_, _ = db.ExecContext(ctx, d.DropTableIfExists(tbl.TableNameFor(d)))
+	}()
+
+	view := schema.NewView("v_view_lifecycle_active",
+		`SELECT "id", "title" FROM "view_lifecycle_tasks"`)
+
+	// Plain create succeeds against an empty schema.
+	_, err = db.ExecContext(ctx, view.CreateSQL(d))
+	require.NoError(t, err, "create view: %s", view.CreateSQL(d))
+
+	// CreateOrReplaceSQL on SQLite emits DROP-then-CREATE; both must execute
+	// cleanly so a re-bootstrap can refresh the view body.
+	for _, stmt := range view.CreateOrReplaceSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err, "create-or-replace view: %s", stmt)
+	}
+
+	// Drop succeeds once, and runs cleanly a second time thanks to IF EXISTS.
+	for i := range 2 {
+		_, err := db.ExecContext(ctx, view.DropSQL(d))
+		require.NoError(t, err, "drop view iteration %d: %s", i, view.DropSQL(d))
+	}
+}
+
 func TestSchemaDriftSQLite(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)

--- a/schema/view.go
+++ b/schema/view.go
@@ -1,0 +1,136 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/catgoose/chuck"
+)
+
+// ViewDef declares an owned database view as a first-class object alongside
+// TableDef. A view carries an optional schema namespace and a SELECT body; the
+// package emits dialect-aware lifecycle SQL (create / create-or-replace / drop)
+// so callers no longer need raw CREATE VIEW string constants next to their
+// declarative table ownership.
+//
+// View identity follows the same structured ObjectName model as TableDef so
+// schema-qualified views render correctly on MSSQL and Postgres and collapse
+// to bare names on SQLite. The SELECT body is taken verbatim — callers are
+// responsible for any inner identifier quoting, which keeps the API thin and
+// matches the "explicit SQL, composable helpers" stance of the rest of chuck.
+//
+// Dependency ordering between views and the tables they read is intentionally
+// left to the caller. Views typically form a small linear chain on top of
+// owned tables; forcing a generalized scheduler abstraction for that case
+// would add weight without buying clarity. Callers wanting explicit ordering
+// can simply create views after their tables and drop them before.
+type ViewDef struct {
+	Name   string
+	schema string
+	body   string
+}
+
+// NewView creates an unqualified owned view with the given name and SELECT
+// body. The body is the text that follows `CREATE VIEW <name> AS` — typically
+// a SELECT statement — without a trailing semicolon.
+func NewView(name, body string) *ViewDef {
+	return &ViewDef{Name: name, body: body}
+}
+
+// NewQualifiedView creates an owned view with an explicit schema namespace.
+// Equivalent to NewView(name, body).WithSchema(schema).
+func NewQualifiedView(schema, name, body string) *ViewDef {
+	return &ViewDef{Name: name, schema: schema, body: body}
+}
+
+// WithSchema sets the schema namespace for the view. SQLite ignores this
+// because it has no schema namespace; other dialects render qualified
+// identifiers like "schema"."view" or [schema].[view].
+func (v *ViewDef) WithSchema(schema string) *ViewDef {
+	v.schema = schema
+	return v
+}
+
+// Schema returns the declared schema namespace for the view, or "" if none.
+func (v *ViewDef) Schema() string {
+	return v.schema
+}
+
+// Body returns the raw SELECT body declared for the view.
+func (v *ViewDef) Body() string {
+	return v.body
+}
+
+// Object returns the structured ObjectName for the view.
+func (v *ViewDef) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: v.schema, Name: v.Name}
+}
+
+// QualifiedNameFor returns the dialect-rendered, quoted, schema-qualified
+// view identifier (e.g. [sg].[v_PTOUsage] on MSSQL, "sg"."v_pto_usage" on
+// Postgres). On SQLite the schema component is dropped.
+func (v *ViewDef) QualifiedNameFor(d chuck.Dialect) string {
+	return qualifyTable(d, v.Object())
+}
+
+// CreateSQL returns a plain `CREATE VIEW <qualified-name> AS <body>` statement.
+// This is the minimal, non-idempotent lifecycle primitive — use
+// CreateOrReplaceSQL when re-running bootstrap should refresh an existing view.
+func (v *ViewDef) CreateSQL(d chuck.Dialect) string {
+	return fmt.Sprintf("CREATE VIEW %s AS %s", v.QualifiedNameFor(d), v.body)
+}
+
+// CreateOrReplaceSQL returns the dialect-idiomatic statements that create the
+// view, replacing any prior definition with the same identity. The return
+// type is a slice because SQLite has no CREATE OR REPLACE / CREATE OR ALTER
+// equivalent for views and must emit a DROP-then-CREATE pair; callers should
+// execute the slice in order:
+//
+//   - Postgres: `CREATE OR REPLACE VIEW ... AS ...` (single statement)
+//   - MSSQL:    `CREATE OR ALTER VIEW ... AS ...` (single statement; MSSQL 2016+)
+//   - SQLite:   `DROP VIEW IF EXISTS ...` followed by `CREATE VIEW ... AS ...`
+//
+// MSSQL `CREATE OR ALTER VIEW` requires the entire batch to be a standalone
+// statement, which matches how the rest of chuck emits MSSQL DDL (one
+// statement per Exec).
+func (v *ViewDef) CreateOrReplaceSQL(d chuck.Dialect) []string {
+	qt := v.QualifiedNameFor(d)
+	switch d.Engine() {
+	case chuck.Postgres:
+		return []string{fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", qt, v.body)}
+	case chuck.MSSQL:
+		return []string{fmt.Sprintf("CREATE OR ALTER VIEW %s AS %s", qt, v.body)}
+	case chuck.SQLite:
+		return []string{
+			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
+			fmt.Sprintf("CREATE VIEW %s AS %s", qt, v.body),
+		}
+	default:
+		return []string{
+			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
+			fmt.Sprintf("CREATE VIEW %s AS %s", qt, v.body),
+		}
+	}
+}
+
+// DropSQL returns a single `DROP VIEW IF EXISTS` statement rendered for the
+// dialect. MSSQL wraps the drop in a sys.views existence probe (matching the
+// table-drop pattern) so callers can run it unconditionally during teardown.
+func (v *ViewDef) DropSQL(d chuck.Dialect) string {
+	qt := v.QualifiedNameFor(d)
+	switch d.Engine() {
+	case chuck.MSSQL:
+		schema, name := normalizedObject(d, v.Object())
+		var objArg string
+		if schema == "" {
+			objArg = fmt.Sprintf("[%s]", name)
+		} else {
+			objArg = fmt.Sprintf("[%s].[%s]", schema, name)
+		}
+		return fmt.Sprintf(
+			"IF EXISTS (SELECT * FROM sys.views WHERE object_id = OBJECT_ID(N'%s')) BEGIN DROP VIEW %s; END",
+			escapeQuote(objArg), qt,
+		)
+	default:
+		return fmt.Sprintf("DROP VIEW IF EXISTS %s", qt)
+	}
+}

--- a/schema/view_test.go
+++ b/schema/view_test.go
@@ -1,0 +1,141 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+)
+
+const viewBody = "SELECT [ID], [Title] FROM [Tasks] WHERE [DeletedAt] IS NULL"
+
+func TestNewView_UnqualifiedIdentity(t *testing.T) {
+	v := NewView("v_active_tasks", viewBody)
+	assert.Equal(t, "v_active_tasks", v.Name)
+	assert.Equal(t, "", v.Schema())
+	assert.Equal(t, viewBody, v.Body())
+	assert.Equal(t, chuck.ObjectName{Name: "v_active_tasks"}, v.Object())
+}
+
+func TestNewQualifiedView_PreservesSchema(t *testing.T) {
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	assert.Equal(t, "sg", v.Schema())
+	assert.Equal(t, chuck.ObjectName{Schema: "sg", Name: "v_pto_usage"}, v.Object())
+}
+
+func TestNewView_WithSchema_Equivalence(t *testing.T) {
+	// WithSchema must produce the same identity as NewQualifiedView so callers
+	// can mix declaration styles in the same owned-schema bundle.
+	a := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	b := NewView("v_pto_usage", viewBody).WithSchema("sg")
+	assert.Equal(t, a.Object(), b.Object())
+	assert.Equal(t, a.Body(), b.Body())
+}
+
+func TestViewDef_QualifiedNameFor_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	assert.Equal(t, "[sg].[v_pto_usage]", v.QualifiedNameFor(d))
+}
+
+func TestViewDef_QualifiedNameFor_Postgres_NormalizesIdentifiers(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	v := NewQualifiedView("App", "PTOUsageView", viewBody)
+	// Postgres normalizes camelCase to snake_case.
+	assert.Equal(t, `"app"."pto_usage_view"`, v.QualifiedNameFor(d))
+}
+
+func TestViewDef_QualifiedNameFor_SQLite_DropsSchema(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	// SQLite has no schema namespace; the schema component must be dropped.
+	assert.Equal(t, `"v_pto_usage"`, v.QualifiedNameFor(d))
+}
+
+func TestViewDef_CreateSQL_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	got := v.CreateSQL(d)
+	assert.Equal(t, "CREATE VIEW [sg].[v_pto_usage] AS "+viewBody, got)
+}
+
+func TestViewDef_CreateSQL_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	got := v.CreateSQL(d)
+	assert.Equal(t, `CREATE VIEW "sg"."v_pto_usage" AS `+viewBody, got)
+}
+
+func TestViewDef_CreateSQL_SQLite(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	v := NewView("v_active_tasks", viewBody)
+	got := v.CreateSQL(d)
+	assert.Equal(t, `CREATE VIEW "v_active_tasks" AS `+viewBody, got)
+}
+
+func TestViewDef_CreateOrReplaceSQL_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	stmts := v.CreateOrReplaceSQL(d)
+	assert.Equal(t,
+		[]string{`CREATE OR REPLACE VIEW "sg"."v_pto_usage" AS ` + viewBody},
+		stmts,
+		"Postgres has a native CREATE OR REPLACE VIEW; emit a single statement",
+	)
+}
+
+func TestViewDef_CreateOrReplaceSQL_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	stmts := v.CreateOrReplaceSQL(d)
+	assert.Equal(t,
+		[]string{"CREATE OR ALTER VIEW [sg].[v_pto_usage] AS " + viewBody},
+		stmts,
+		"MSSQL 2016+ supports CREATE OR ALTER VIEW as a single batch",
+	)
+}
+
+func TestViewDef_CreateOrReplaceSQL_SQLite_EmitsDropThenCreate(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	v := NewView("v_active_tasks", viewBody)
+	stmts := v.CreateOrReplaceSQL(d)
+	// SQLite has no CREATE OR REPLACE / CREATE OR ALTER for views, so the
+	// helper must emit DROP-then-CREATE in order.
+	assert.Equal(t, []string{
+		`DROP VIEW IF EXISTS "v_active_tasks"`,
+		`CREATE VIEW "v_active_tasks" AS ` + viewBody,
+	}, stmts)
+}
+
+func TestViewDef_DropSQL_Postgres(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	assert.Equal(t, `DROP VIEW IF EXISTS "sg"."v_pto_usage"`, v.DropSQL(d))
+}
+
+func TestViewDef_DropSQL_SQLite(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	v := NewView("v_active_tasks", viewBody)
+	assert.Equal(t, `DROP VIEW IF EXISTS "v_active_tasks"`, v.DropSQL(d))
+}
+
+func TestViewDef_DropSQL_MSSQL_QualifiedExistenceProbe(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	v := NewQualifiedView("sg", "v_pto_usage", viewBody)
+	got := v.DropSQL(d)
+	assert.Contains(t, got, "sys.views",
+		"MSSQL drop must probe sys.views, not sys.objects, so it matches the view-only object class")
+	assert.Contains(t, got, "OBJECT_ID(N'[sg].[v_pto_usage]')",
+		"MSSQL existence probe should use the schema-qualified object literal")
+	assert.Contains(t, got, "DROP VIEW [sg].[v_pto_usage]")
+}
+
+func TestViewDef_DropSQL_MSSQL_UnqualifiedExistenceProbe(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	v := NewView("v_active_tasks", viewBody)
+	got := v.DropSQL(d)
+	// Without a schema namespace, the existence probe must still produce a
+	// valid OBJECT_ID literal — bare name in brackets.
+	assert.Contains(t, got, "OBJECT_ID(N'[v_active_tasks]')")
+	assert.Contains(t, got, "DROP VIEW [v_active_tasks]")
+}


### PR DESCRIPTION
## Summary

Closes the owned-views gap reported in #76. Views previously lived as raw `CREATE VIEW` string constants adjacent to the declarative `TableDef` ownership, splitting the schema across files and silently risking drift when new owned views were added. `ViewDef` makes views first-class objects that share `TableDef`'s structured identity and qualified-rendering path.

- `ViewDef` + `NewView` / `NewQualifiedView` / `WithSchema` / `Object` / `QualifiedNameFor` mirror the `TableDef` ergonomics
- `CreateSQL` — plain `CREATE VIEW`
- `CreateOrReplaceSQL` — dialect-idiomatic idempotent replace: Postgres `CREATE OR REPLACE VIEW`, MSSQL `CREATE OR ALTER VIEW` (MSSQL 2016+), SQLite emits `DROP VIEW IF EXISTS` + `CREATE VIEW` as an ordered slice
- `DropSQL` — `DROP VIEW IF EXISTS`; MSSQL wraps in a `sys.views` existence probe matching the existing table-drop pattern
- View body taken verbatim — callers own inner quoting
- View↔table ordering kept caller-owned per the handoff guidance (short linear chain on top of owned tables; no premature scheduler)

## Test plan

- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] `schema/view_test.go` pins identity, qualified-name rendering, and all three lifecycle SQL forms across MSSQL, Postgres, and SQLite, including MSSQL drops for both qualified and unqualified probes
- [x] `TestViewLifecycleSQLite` in `schema/integration_test.go` executes plain create, create-or-replace (`DROP`+`CREATE` path), and idempotent drop end-to-end against in-memory SQLite

Refs #76. Independent of #78 (issue #77 work).