### PR TITLE
feat(schema): first-class ProcedureDef for owned MSSQL stored procedures (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,15 +456,23 @@ The view body is taken verbatim; callers own its inner quoting and any reference
 
 Stored procedures live next to owned tables and views as first-class `ProcedureDef` values, so MSSQL refresh / migration entrypoints stop being raw checked-in `.sql` files outside chuck ownership. Identity mirrors `ViewDef`: an optional schema namespace plus a name, rendered through the same `ObjectName` path so qualified procedures emit `[schema].[name]` consistently with `TableDef` and `ViewDef`.
 
+The definition payload is the full T-SQL text that follows the qualified procedure name: optional parameter declarations, optional `WITH ...` options, the required `AS` keyword, and the body. T-SQL grammar places parameters and options between the name and `AS`, so chuck cannot inject `AS` on the caller's behalf without closing off those slots — the caller owns everything from parameters through `AS` through the body.
+
 ```go
 var RefreshDashboardProc = schema.NewQualifiedProcedure("sg",
     "usp_RefreshDashboard",
-    `BEGIN
-        SET NOCOUNT ON;
-        DELETE FROM [sg].[Dashboard];
-        INSERT INTO [sg].[Dashboard] ([AgentID], [Total])
-            SELECT [AgentID], SUM([Hours]) FROM [sg].[PTOEntries] GROUP BY [AgentID];
-    END`)
+    `@AgentID INT, @AsOf DATETIME2 = NULL
+WITH RECOMPILE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DELETE FROM [sg].[Dashboard] WHERE [AgentID] = @AgentID;
+    INSERT INTO [sg].[Dashboard] ([AgentID], [Total])
+        SELECT [AgentID], SUM([Hours])
+        FROM [sg].[PTOEntries]
+        WHERE [AgentID] = @AgentID AND ([AsOf] IS NULL OR [RecordedAt] <= @AsOf)
+        GROUP BY [AgentID];
+END`)
 
 // Apply (idempotent on MSSQL 2016+):
 stmt, err := RefreshDashboardProc.CreateOrAlterSQL(dialect)
@@ -477,12 +485,19 @@ if err != nil { return err }
 if _, err := db.ExecContext(ctx, stmt); err != nil { return err }
 ```
 
+For a zero-parameter procedure the definition simply begins with `AS`:
+
+```go
+schema.NewQualifiedProcedure("sg", "usp_Ping",
+    "AS BEGIN SET NOCOUNT ON; SELECT 1 AS Probe; END")
+```
+
 Lifecycle rules:
 
-- **MSSQL** uses `CREATE OR ALTER PROCEDURE [schema].[name] AS <body>` (MSSQL 2016+) for the apply path and wraps the drop in a `sys.procedures` existence probe so callers can run it unconditionally during teardown.
+- **MSSQL** uses `CREATE OR ALTER PROCEDURE [schema].[name] <definition>` (MSSQL 2016+) for the apply path and wraps the drop in a `sys.procedures` existence probe so callers can run it unconditionally during teardown.
 - **Postgres / SQLite** are explicitly unsupported in this first pass — the lifecycle methods return `schema.ErrProcedureDialectUnsupported` instead of silently no-op'ing. Use `errors.Is(err, schema.ErrProcedureDialectUnsupported)` to branch your bootstrap when the same code path runs against a non-MSSQL engine.
 
-The body is taken verbatim. Callers own all inner identifier quoting, parameter declarations, and any control-flow inside the procedure body; chuck only injects the `CREATE OR ALTER PROCEDURE <qualified-name> AS` preamble. Ordering between procedures and the tables / views they read is caller-owned: create procedures after their dependencies, drop them before. SQL Agent jobs and `msdb`-level admin objects are intentionally out of scope for this primitive.
+The definition is taken verbatim. Callers own all inner identifier quoting, parameter declarations, procedure options, the `AS` keyword itself, and the body; chuck contributes only the `CREATE OR ALTER PROCEDURE <qualified-name>` preamble. Ordering between procedures and the tables / views they read is caller-owned: create procedures after their dependencies, drop them before. SQL Agent jobs and `msdb`-level admin objects are intentionally out of scope for this primitive.
 
 ### Schema Snapshots
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [Seed Data](#seed-data)
     - [Table Dependency Ordering](#table-dependency-ordering)
     - [Owned Views](#owned-views)
+    - [Owned Procedures (MSSQL)](#owned-procedures-mssql)
     - [Schema Snapshots](#schema-snapshots)
     - [Live Schema Snapshots](#live-schema-snapshots)
     - [Schema Validation](#schema-validation)
@@ -450,6 +451,38 @@ Lifecycle SQL is rendered per dialect:
 - **SQLite** has no `CREATE OR REPLACE` / `CREATE OR ALTER` for views, so `CreateOrReplaceSQL` returns a `DROP VIEW IF EXISTS` followed by `CREATE VIEW` -- run them in order. The schema component is dropped on SQLite because it has no namespace.
 
 The view body is taken verbatim; callers own its inner quoting and any references to owned tables. Ordering between owned views and the tables they read is caller-owned: create views after their tables, drop them before. This keeps the API thin and avoids forcing a generalized scheduler for what is usually a short linear chain on top of owned tables.
+
+### Owned Procedures (MSSQL)
+
+Stored procedures live next to owned tables and views as first-class `ProcedureDef` values, so MSSQL refresh / migration entrypoints stop being raw checked-in `.sql` files outside chuck ownership. Identity mirrors `ViewDef`: an optional schema namespace plus a name, rendered through the same `ObjectName` path so qualified procedures emit `[schema].[name]` consistently with `TableDef` and `ViewDef`.
+
+```go
+var RefreshDashboardProc = schema.NewQualifiedProcedure("sg",
+    "usp_RefreshDashboard",
+    `BEGIN
+        SET NOCOUNT ON;
+        DELETE FROM [sg].[Dashboard];
+        INSERT INTO [sg].[Dashboard] ([AgentID], [Total])
+            SELECT [AgentID], SUM([Hours]) FROM [sg].[PTOEntries] GROUP BY [AgentID];
+    END`)
+
+// Apply (idempotent on MSSQL 2016+):
+stmt, err := RefreshDashboardProc.CreateOrAlterSQL(dialect)
+if err != nil { return err }
+if _, err := db.ExecContext(ctx, stmt); err != nil { return err }
+
+// Tear down:
+stmt, err = RefreshDashboardProc.DropSQL(dialect)
+if err != nil { return err }
+if _, err := db.ExecContext(ctx, stmt); err != nil { return err }
+```
+
+Lifecycle rules:
+
+- **MSSQL** uses `CREATE OR ALTER PROCEDURE [schema].[name] AS <body>` (MSSQL 2016+) for the apply path and wraps the drop in a `sys.procedures` existence probe so callers can run it unconditionally during teardown.
+- **Postgres / SQLite** are explicitly unsupported in this first pass — the lifecycle methods return `schema.ErrProcedureDialectUnsupported` instead of silently no-op'ing. Use `errors.Is(err, schema.ErrProcedureDialectUnsupported)` to branch your bootstrap when the same code path runs against a non-MSSQL engine.
+
+The body is taken verbatim. Callers own all inner identifier quoting, parameter declarations, and any control-flow inside the procedure body; chuck only injects the `CREATE OR ALTER PROCEDURE <qualified-name> AS` preamble. Ordering between procedures and the tables / views they read is caller-owned: create procedures after their dependencies, drop them before. SQL Agent jobs and `msdb`-level admin objects are intentionally out of scope for this primitive.
 
 ### Schema Snapshots
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ BEGIN
     INSERT INTO [sg].[Dashboard] ([AgentID], [Total])
         SELECT [AgentID], SUM([Hours])
         FROM [sg].[PTOEntries]
-        WHERE [AgentID] = @AgentID AND ([AsOf] IS NULL OR [RecordedAt] <= @AsOf)
+        WHERE [AgentID] = @AgentID AND (@AsOf IS NULL OR [RecordedAt] <= @AsOf)
         GROUP BY [AgentID];
 END`)
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -114,9 +114,10 @@ func TestViewLifecycleSQLite(t *testing.T) {
 // TestProcedureLifecycleMSSQL exercises the ProcedureDef create-or-alter /
 // drop lifecycle end-to-end against a live MSSQL instance. Procedure
 // ownership is MSSQL-only in this release, so SQLite/Postgres cannot cover
-// the apply path. The body is intentionally trivial — a SELECT 1 wrapper —
-// so the test asserts the lifecycle SQL is accepted, not any user-domain
-// behavior.
+// the apply path. The definition is parameterized on purpose: it proves the
+// pre-`AS` parameter slot survives the render path (the PR #81 blocking
+// review finding), in addition to the basic CREATE OR ALTER / DROP probe
+// idempotency contract.
 func TestProcedureLifecycleMSSQL(t *testing.T) {
 	dsn := os.Getenv("CHUCK_MSSQL_URL")
 	if dsn == "" {
@@ -129,7 +130,7 @@ func TestProcedureLifecycleMSSQL(t *testing.T) {
 	defer db.Close()
 
 	proc := schema.NewProcedure("usp_chuck_proc_lifecycle",
-		"BEGIN SET NOCOUNT ON; SELECT 1 AS Probe; END")
+		"@Probe INT = 1 AS BEGIN SET NOCOUNT ON; SELECT @Probe AS Probe; END")
 
 	// Best-effort cleanup from any prior failed run.
 	if stmt, derr := proc.DropSQL(d); derr == nil {

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -115,9 +115,8 @@ func TestViewLifecycleSQLite(t *testing.T) {
 // drop lifecycle end-to-end against a live MSSQL instance. Procedure
 // ownership is MSSQL-only in this release, so SQLite/Postgres cannot cover
 // the apply path. The definition is parameterized on purpose: it proves the
-// pre-`AS` parameter slot survives the render path (the PR #81 blocking
-// review finding), in addition to the basic CREATE OR ALTER / DROP probe
-// idempotency contract.
+// pre-`AS` parameter slot survives the render path, in addition to the basic
+// CREATE OR ALTER / DROP probe idempotency contract.
 func TestProcedureLifecycleMSSQL(t *testing.T) {
 	dsn := os.Getenv("CHUCK_MSSQL_URL")
 	if dsn == "" {

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -111,6 +111,56 @@ func TestViewLifecycleSQLite(t *testing.T) {
 	}
 }
 
+// TestProcedureLifecycleMSSQL exercises the ProcedureDef create-or-alter /
+// drop lifecycle end-to-end against a live MSSQL instance. Procedure
+// ownership is MSSQL-only in this release, so SQLite/Postgres cannot cover
+// the apply path. The body is intentionally trivial — a SELECT 1 wrapper —
+// so the test asserts the lifecycle SQL is accepted, not any user-domain
+// behavior.
+func TestProcedureLifecycleMSSQL(t *testing.T) {
+	dsn := os.Getenv("CHUCK_MSSQL_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_MSSQL_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	proc := schema.NewProcedure("usp_chuck_proc_lifecycle",
+		"BEGIN SET NOCOUNT ON; SELECT 1 AS Probe; END")
+
+	// Best-effort cleanup from any prior failed run.
+	if stmt, derr := proc.DropSQL(d); derr == nil {
+		_, _ = db.ExecContext(ctx, stmt)
+	}
+
+	defer func() {
+		if stmt, derr := proc.DropSQL(d); derr == nil {
+			_, _ = db.ExecContext(ctx, stmt)
+		}
+	}()
+
+	// CreateOrAlterSQL must succeed on a fresh schema and again on the
+	// already-created proc; that is the contract MSSQL CREATE OR ALTER buys
+	// us versus a plain CREATE PROCEDURE.
+	for i := range 2 {
+		stmt, err := proc.CreateOrAlterSQL(d)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, stmt)
+		require.NoError(t, err, "create-or-alter procedure iteration %d: %s", i, stmt)
+	}
+
+	// Existence probe drop is idempotent — second run must be a clean no-op.
+	for i := range 2 {
+		stmt, err := proc.DropSQL(d)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, stmt)
+		require.NoError(t, err, "drop procedure iteration %d: %s", i, stmt)
+	}
+}
+
 func TestSchemaDriftSQLite(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -20,10 +20,14 @@ var ErrProcedureDialectUnsupported = errors.New("schema: stored procedure owners
 // ObjectName path so qualified procedures emit [schema].[name] consistently
 // with the rest of the package.
 //
-// The body is taken verbatim. Callers own all inner identifier quoting,
-// parameter declarations, and any RETURN / SET / control-flow inside the
-// procedure body. The package wraps that body with the dialect-correct
-// CREATE OR ALTER PROCEDURE preamble and emits a safe DROP path.
+// The definition payload is the full T-SQL text that follows the qualified
+// procedure name. T-SQL grammar places parameter declarations and procedure
+// options (e.g. WITH RECOMPILE, WITH ENCRYPTION) between the procedure name
+// and the AS keyword, so the package cannot inject AS for the caller without
+// closing off those slots. Callers therefore own everything from optional
+// parameters through AS through the body itself, and the package wraps that
+// text with the dialect-correct CREATE OR ALTER PROCEDURE preamble plus the
+// qualified identifier.
 //
 // Non-MSSQL dialects are explicitly unsupported in this first pass; the
 // lifecycle methods return ErrProcedureDialectUnsupported rather than
@@ -35,23 +39,29 @@ var ErrProcedureDialectUnsupported = errors.New("schema: stored procedure owners
 // entrypoints layered on top of the table graph; forcing them into a
 // generalized scheduler would add weight without buying clarity.
 type ProcedureDef struct {
-	Name   string
-	schema string
-	body   string
+	Name       string
+	schema     string
+	definition string
 }
 
 // NewProcedure creates an unqualified owned procedure with the given name and
-// raw body. The body is the text that follows `CREATE OR ALTER PROCEDURE
-// <name> AS` — typically parameter declarations followed by `BEGIN ... END`,
-// without a trailing semicolon.
-func NewProcedure(name, body string) *ProcedureDef {
-	return &ProcedureDef{Name: name, body: body}
+// raw definition. The definition is the full T-SQL text that follows the
+// qualified procedure name: optional parameter declarations, optional WITH
+// options, the required AS keyword, and the procedure body. Example shape:
+//
+//	"@AgentID INT, @AsOf DATETIME2 = NULL\nWITH RECOMPILE\nAS\nBEGIN ... END"
+//
+// Callers own all inner identifier quoting and the AS keyword itself; the
+// package contributes only the CREATE OR ALTER PROCEDURE preamble and the
+// qualified identifier.
+func NewProcedure(name, definition string) *ProcedureDef {
+	return &ProcedureDef{Name: name, definition: definition}
 }
 
 // NewQualifiedProcedure creates an owned procedure with an explicit schema
-// namespace. Equivalent to NewProcedure(name, body).WithSchema(schema).
-func NewQualifiedProcedure(schema, name, body string) *ProcedureDef {
-	return &ProcedureDef{Name: name, schema: schema, body: body}
+// namespace. Equivalent to NewProcedure(name, definition).WithSchema(schema).
+func NewQualifiedProcedure(schema, name, definition string) *ProcedureDef {
+	return &ProcedureDef{Name: name, schema: schema, definition: definition}
 }
 
 // WithSchema sets the schema namespace for the procedure. Procedure ownership
@@ -68,9 +78,11 @@ func (p *ProcedureDef) Schema() string {
 	return p.schema
 }
 
-// Body returns the raw body declared for the procedure.
-func (p *ProcedureDef) Body() string {
-	return p.body
+// Definition returns the raw T-SQL definition declared for the procedure —
+// everything from optional parameter declarations through AS through the
+// procedure body.
+func (p *ProcedureDef) Definition() string {
+	return p.definition
 }
 
 // Object returns the structured ObjectName for the procedure.
@@ -91,16 +103,21 @@ func (p *ProcedureDef) QualifiedNameFor(d chuck.Dialect) string {
 
 // CreateOrAlterSQL returns the dialect-idiomatic statement that creates the
 // procedure, replacing any prior definition with the same identity. On MSSQL
-// this is a single `CREATE OR ALTER PROCEDURE <qualified-name> AS <body>`
+// this is a single `CREATE OR ALTER PROCEDURE <qualified-name> <definition>`
 // statement; MSSQL requires this to be the only statement in its batch, which
 // matches how the rest of chuck emits MSSQL DDL (one statement per Exec).
+//
+// The package contributes the CREATE OR ALTER PROCEDURE preamble and the
+// qualified identifier. The caller's definition supplies any parameter
+// declarations, procedure options, the required AS keyword, and the body, in
+// the order T-SQL demands.
 //
 // Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
 func (p *ProcedureDef) CreateOrAlterSQL(d chuck.Dialect) (string, error) {
 	if d.Engine() != chuck.MSSQL {
 		return "", fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
-	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s AS %s", p.QualifiedNameFor(d), p.body), nil
+	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s %s", p.QualifiedNameFor(d), p.definition), nil
 }
 
 // DropSQL returns a single safe `DROP PROCEDURE` statement that probes

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -1,0 +1,127 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/catgoose/chuck"
+)
+
+// ErrProcedureDialectUnsupported is returned when a ProcedureDef lifecycle
+// method is invoked against a dialect that has no first-class procedure
+// support in this package. The first pass is MSSQL-only; callers running on
+// Postgres or SQLite get an explicit error rather than a silent no-op so that
+// owned-procedure declarations cannot quietly disappear from a bootstrap.
+var ErrProcedureDialectUnsupported = errors.New("schema: stored procedure ownership is MSSQL-only in this release")
+
+// ProcedureDef declares an owned MSSQL stored procedure as a first-class
+// object alongside TableDef and ViewDef. Identity mirrors ViewDef: an optional
+// schema namespace plus a name, rendered through the same structured
+// ObjectName path so qualified procedures emit [schema].[name] consistently
+// with the rest of the package.
+//
+// The body is taken verbatim. Callers own all inner identifier quoting,
+// parameter declarations, and any RETURN / SET / control-flow inside the
+// procedure body. The package wraps that body with the dialect-correct
+// CREATE OR ALTER PROCEDURE preamble and emits a safe DROP path.
+//
+// Non-MSSQL dialects are explicitly unsupported in this first pass; the
+// lifecycle methods return ErrProcedureDialectUnsupported rather than
+// silently no-op'ing so callers cannot accidentally lose ownership coverage
+// on an engine that does not know how to apply it.
+//
+// Ordering between owned procedures and the tables/views they depend on is
+// caller-owned. Procedures typically form a short list of refresh / migration
+// entrypoints layered on top of the table graph; forcing them into a
+// generalized scheduler would add weight without buying clarity.
+type ProcedureDef struct {
+	Name   string
+	schema string
+	body   string
+}
+
+// NewProcedure creates an unqualified owned procedure with the given name and
+// raw body. The body is the text that follows `CREATE OR ALTER PROCEDURE
+// <name> AS` — typically parameter declarations followed by `BEGIN ... END`,
+// without a trailing semicolon.
+func NewProcedure(name, body string) *ProcedureDef {
+	return &ProcedureDef{Name: name, body: body}
+}
+
+// NewQualifiedProcedure creates an owned procedure with an explicit schema
+// namespace. Equivalent to NewProcedure(name, body).WithSchema(schema).
+func NewQualifiedProcedure(schema, name, body string) *ProcedureDef {
+	return &ProcedureDef{Name: name, schema: schema, body: body}
+}
+
+// WithSchema sets the schema namespace for the procedure. Procedure ownership
+// is MSSQL-only in this release, so the namespace is always rendered when
+// present.
+func (p *ProcedureDef) WithSchema(schema string) *ProcedureDef {
+	p.schema = schema
+	return p
+}
+
+// Schema returns the declared schema namespace for the procedure, or "" if
+// none.
+func (p *ProcedureDef) Schema() string {
+	return p.schema
+}
+
+// Body returns the raw body declared for the procedure.
+func (p *ProcedureDef) Body() string {
+	return p.body
+}
+
+// Object returns the structured ObjectName for the procedure.
+func (p *ProcedureDef) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: p.schema, Name: p.Name}
+}
+
+// QualifiedNameFor returns the dialect-rendered, quoted, schema-qualified
+// procedure identifier (e.g. [sg].[usp_RefreshDashboard] on MSSQL). It
+// shares the same identifier-rendering path as TableDef and ViewDef so
+// procedure references stay consistent with the rest of the package's DDL.
+// Non-MSSQL dialects still render the identifier so callers building error
+// messages or logs can quote the procedure name; only the lifecycle methods
+// return ErrProcedureDialectUnsupported.
+func (p *ProcedureDef) QualifiedNameFor(d chuck.Dialect) string {
+	return qualifyTable(d, p.Object())
+}
+
+// CreateOrAlterSQL returns the dialect-idiomatic statement that creates the
+// procedure, replacing any prior definition with the same identity. On MSSQL
+// this is a single `CREATE OR ALTER PROCEDURE <qualified-name> AS <body>`
+// statement; MSSQL requires this to be the only statement in its batch, which
+// matches how the rest of chuck emits MSSQL DDL (one statement per Exec).
+//
+// Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
+func (p *ProcedureDef) CreateOrAlterSQL(d chuck.Dialect) (string, error) {
+	if d.Engine() != chuck.MSSQL {
+		return "", fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s AS %s", p.QualifiedNameFor(d), p.body), nil
+}
+
+// DropSQL returns a single safe `DROP PROCEDURE` statement that probes
+// sys.procedures first, so callers can run it unconditionally during
+// teardown. The probe uses the schema-qualified object literal so the right
+// procedure is matched even when the same bare name exists under multiple
+// schemas.
+//
+// Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
+func (p *ProcedureDef) DropSQL(d chuck.Dialect) (string, error) {
+	if d.Engine() != chuck.MSSQL {
+		return "", fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	qt := p.QualifiedNameFor(d)
+	schema, name := normalizedObject(d, p.Object())
+	objArg := fmt.Sprintf("[%s]", name)
+	if schema != "" {
+		objArg = fmt.Sprintf("[%s].[%s]", schema, name)
+	}
+	return fmt.Sprintf(
+		"IF EXISTS (SELECT * FROM sys.procedures WHERE object_id = OBJECT_ID(N'%s')) BEGIN DROP PROCEDURE %s; END",
+		escapeQuote(objArg), qt,
+	), nil
+}

--- a/schema/procedure_test.go
+++ b/schema/procedure_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/catgoose/chuck"
@@ -9,21 +10,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// procedureBodyNoPrefix is the raw body callers pass to NewProcedure — the
-// text that follows `AS`. The lifecycle helpers prepend `CREATE OR ALTER
-// PROCEDURE <name> AS` themselves, so the body must not duplicate `AS`.
-const procedureBodyNoPrefix = "BEGIN SET NOCOUNT ON; DELETE FROM [sg].[StaleRefresh]; END"
+// procedureDefinition is the canonical full-shape T-SQL definition callers
+// pass to NewProcedure: parameter declarations, then AS, then body. The
+// lifecycle helpers prepend `CREATE OR ALTER PROCEDURE <qualified-name>`
+// themselves; everything after the qualified name is caller-owned text.
+const procedureDefinition = "@AgentID INT, @AsOf DATETIME2 = NULL\n" +
+	"AS\n" +
+	"BEGIN\n" +
+	"    SET NOCOUNT ON;\n" +
+	"    DELETE FROM [sg].[StaleRefresh] WHERE [AgentID] = @AgentID;\n" +
+	"END"
+
+// procedureDefinitionNoParams is a zero-parameter shape — definition still
+// must include the AS keyword caller-side, since T-SQL grammar places
+// parameters between the name and AS and the package cannot inject AS without
+// closing off the parameter slot.
+const procedureDefinitionNoParams = "AS BEGIN SET NOCOUNT ON; SELECT 1 AS Probe; END"
 
 func TestNewProcedure_UnqualifiedIdentity(t *testing.T) {
-	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewProcedure("usp_RefreshDashboard", procedureDefinition)
 	assert.Equal(t, "usp_RefreshDashboard", p.Name)
 	assert.Equal(t, "", p.Schema())
-	assert.Equal(t, procedureBodyNoPrefix, p.Body())
+	assert.Equal(t, procedureDefinition, p.Definition())
 	assert.Equal(t, chuck.ObjectName{Name: "usp_RefreshDashboard"}, p.Object())
 }
 
 func TestNewQualifiedProcedure_PreservesSchema(t *testing.T) {
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	assert.Equal(t, "sg", p.Schema())
 	assert.Equal(t,
 		chuck.ObjectName{Schema: "sg", Name: "usp_RefreshDashboard"},
@@ -34,27 +47,52 @@ func TestNewQualifiedProcedure_PreservesSchema(t *testing.T) {
 func TestProcedureDef_WithSchema_Equivalence(t *testing.T) {
 	// WithSchema must produce the same identity as NewQualifiedProcedure so
 	// callers can mix declaration styles in the same owned-schema bundle.
-	a := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
-	b := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix).WithSchema("sg")
+	a := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
+	b := NewProcedure("usp_RefreshDashboard", procedureDefinition).WithSchema("sg")
 	assert.Equal(t, a.Object(), b.Object())
-	assert.Equal(t, a.Body(), b.Body())
+	assert.Equal(t, a.Definition(), b.Definition())
 }
 
 func TestProcedureDef_QualifiedNameFor_MSSQL(t *testing.T) {
 	d := chuck.MSSQLDialect{}
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	assert.Equal(t, "[sg].[usp_RefreshDashboard]", p.QualifiedNameFor(d))
 }
 
-func TestProcedureDef_CreateOrAlterSQL_MSSQL(t *testing.T) {
+func TestProcedureDef_CreateOrAlterSQL_MSSQL_Parameterized(t *testing.T) {
+	// The blocking review finding on PR #81: parameters in T-SQL belong
+	// between the procedure name and AS, not after AS. The render path must
+	// place the caller's definition immediately after the qualified name so
+	// `@AgentID INT, @AsOf DATETIME2 = NULL\nAS\n...` lands in the right slot.
 	d := chuck.MSSQLDialect{}
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	got, err := p.CreateOrAlterSQL(d)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"CREATE OR ALTER PROCEDURE [sg].[usp_RefreshDashboard] AS "+procedureBodyNoPrefix,
+		"CREATE OR ALTER PROCEDURE [sg].[usp_RefreshDashboard] "+procedureDefinition,
 		got,
-		"MSSQL 2016+ supports CREATE OR ALTER PROCEDURE as a single batch",
+		"MSSQL CREATE OR ALTER PROCEDURE must let parameter declarations sit between the qualified name and AS",
+	)
+	// Order check independent of the equality assertion: the parameter list
+	// must precede AS, which must precede BEGIN. A render that drops in AS
+	// itself would invert this order.
+	asIdx := strings.Index(got, "\nAS\n")
+	paramIdx := strings.Index(got, "@AgentID INT")
+	beginIdx := strings.Index(got, "BEGIN")
+	require.True(t, paramIdx > 0 && asIdx > paramIdx && beginIdx > asIdx,
+		"params must precede AS which must precede BEGIN; got=%q", got)
+}
+
+func TestProcedureDef_CreateOrAlterSQL_MSSQL_NoParams(t *testing.T) {
+	// A zero-parameter procedure still works — the caller's definition just
+	// starts with AS.
+	d := chuck.MSSQLDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinitionNoParams)
+	got, err := p.CreateOrAlterSQL(d)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [sg].[usp_RefreshDashboard] "+procedureDefinitionNoParams,
+		got,
 	)
 }
 
@@ -62,11 +100,11 @@ func TestProcedureDef_CreateOrAlterSQL_UnqualifiedMSSQL(t *testing.T) {
 	// Unqualified declarations must still emit valid CREATE OR ALTER batches;
 	// MSSQL will resolve them under the caller's default schema (typically dbo).
 	d := chuck.MSSQLDialect{}
-	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewProcedure("usp_RefreshDashboard", procedureDefinitionNoParams)
 	got, err := p.CreateOrAlterSQL(d)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"CREATE OR ALTER PROCEDURE [usp_RefreshDashboard] AS "+procedureBodyNoPrefix,
+		"CREATE OR ALTER PROCEDURE [usp_RefreshDashboard] "+procedureDefinitionNoParams,
 		got,
 	)
 }
@@ -77,7 +115,7 @@ func TestProcedureDef_CreateOrAlterSQL_Postgres_ReturnsExplicitError(t *testing.
 	// wrong engine fail loud instead of dropping owned procedures from the
 	// apply set.
 	d := chuck.PostgresDialect{}
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	got, err := p.CreateOrAlterSQL(d)
 	assert.Empty(t, got)
 	require.Error(t, err)
@@ -87,7 +125,7 @@ func TestProcedureDef_CreateOrAlterSQL_Postgres_ReturnsExplicitError(t *testing.
 
 func TestProcedureDef_CreateOrAlterSQL_SQLite_ReturnsExplicitError(t *testing.T) {
 	d := chuck.SQLiteDialect{}
-	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewProcedure("usp_RefreshDashboard", procedureDefinitionNoParams)
 	got, err := p.CreateOrAlterSQL(d)
 	assert.Empty(t, got)
 	require.Error(t, err)
@@ -96,7 +134,7 @@ func TestProcedureDef_CreateOrAlterSQL_SQLite_ReturnsExplicitError(t *testing.T)
 
 func TestProcedureDef_DropSQL_MSSQL_QualifiedExistenceProbe(t *testing.T) {
 	d := chuck.MSSQLDialect{}
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	got, err := p.DropSQL(d)
 	require.NoError(t, err)
 	assert.Contains(t, got, "sys.procedures",
@@ -108,7 +146,7 @@ func TestProcedureDef_DropSQL_MSSQL_QualifiedExistenceProbe(t *testing.T) {
 
 func TestProcedureDef_DropSQL_MSSQL_UnqualifiedExistenceProbe(t *testing.T) {
 	d := chuck.MSSQLDialect{}
-	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewProcedure("usp_RefreshDashboard", procedureDefinitionNoParams)
 	got, err := p.DropSQL(d)
 	require.NoError(t, err)
 	// Without a schema namespace, the existence probe must still produce a
@@ -119,7 +157,7 @@ func TestProcedureDef_DropSQL_MSSQL_UnqualifiedExistenceProbe(t *testing.T) {
 
 func TestProcedureDef_DropSQL_Postgres_ReturnsExplicitError(t *testing.T) {
 	d := chuck.PostgresDialect{}
-	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)
 	got, err := p.DropSQL(d)
 	assert.Empty(t, got)
 	require.Error(t, err)
@@ -128,7 +166,7 @@ func TestProcedureDef_DropSQL_Postgres_ReturnsExplicitError(t *testing.T) {
 
 func TestProcedureDef_DropSQL_SQLite_ReturnsExplicitError(t *testing.T) {
 	d := chuck.SQLiteDialect{}
-	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	p := NewProcedure("usp_RefreshDashboard", procedureDefinitionNoParams)
 	got, err := p.DropSQL(d)
 	assert.Empty(t, got)
 	require.Error(t, err)

--- a/schema/procedure_test.go
+++ b/schema/procedure_test.go
@@ -1,0 +1,136 @@
+package schema
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// procedureBodyNoPrefix is the raw body callers pass to NewProcedure — the
+// text that follows `AS`. The lifecycle helpers prepend `CREATE OR ALTER
+// PROCEDURE <name> AS` themselves, so the body must not duplicate `AS`.
+const procedureBodyNoPrefix = "BEGIN SET NOCOUNT ON; DELETE FROM [sg].[StaleRefresh]; END"
+
+func TestNewProcedure_UnqualifiedIdentity(t *testing.T) {
+	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	assert.Equal(t, "usp_RefreshDashboard", p.Name)
+	assert.Equal(t, "", p.Schema())
+	assert.Equal(t, procedureBodyNoPrefix, p.Body())
+	assert.Equal(t, chuck.ObjectName{Name: "usp_RefreshDashboard"}, p.Object())
+}
+
+func TestNewQualifiedProcedure_PreservesSchema(t *testing.T) {
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	assert.Equal(t, "sg", p.Schema())
+	assert.Equal(t,
+		chuck.ObjectName{Schema: "sg", Name: "usp_RefreshDashboard"},
+		p.Object(),
+	)
+}
+
+func TestProcedureDef_WithSchema_Equivalence(t *testing.T) {
+	// WithSchema must produce the same identity as NewQualifiedProcedure so
+	// callers can mix declaration styles in the same owned-schema bundle.
+	a := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	b := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix).WithSchema("sg")
+	assert.Equal(t, a.Object(), b.Object())
+	assert.Equal(t, a.Body(), b.Body())
+}
+
+func TestProcedureDef_QualifiedNameFor_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	assert.Equal(t, "[sg].[usp_RefreshDashboard]", p.QualifiedNameFor(d))
+}
+
+func TestProcedureDef_CreateOrAlterSQL_MSSQL(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.CreateOrAlterSQL(d)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [sg].[usp_RefreshDashboard] AS "+procedureBodyNoPrefix,
+		got,
+		"MSSQL 2016+ supports CREATE OR ALTER PROCEDURE as a single batch",
+	)
+}
+
+func TestProcedureDef_CreateOrAlterSQL_UnqualifiedMSSQL(t *testing.T) {
+	// Unqualified declarations must still emit valid CREATE OR ALTER batches;
+	// MSSQL will resolve them under the caller's default schema (typically dbo).
+	d := chuck.MSSQLDialect{}
+	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.CreateOrAlterSQL(d)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [usp_RefreshDashboard] AS "+procedureBodyNoPrefix,
+		got,
+	)
+}
+
+func TestProcedureDef_CreateOrAlterSQL_Postgres_ReturnsExplicitError(t *testing.T) {
+	// Procedure ownership is MSSQL-only in this release. Returning an error
+	// (instead of a silent no-op) ensures bootstrap callers running on the
+	// wrong engine fail loud instead of dropping owned procedures from the
+	// apply set.
+	d := chuck.PostgresDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.CreateOrAlterSQL(d)
+	assert.Empty(t, got)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported),
+		"non-MSSQL CreateOrAlterSQL must wrap ErrProcedureDialectUnsupported so callers can errors.Is-detect it")
+}
+
+func TestProcedureDef_CreateOrAlterSQL_SQLite_ReturnsExplicitError(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.CreateOrAlterSQL(d)
+	assert.Empty(t, got)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestProcedureDef_DropSQL_MSSQL_QualifiedExistenceProbe(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.DropSQL(d)
+	require.NoError(t, err)
+	assert.Contains(t, got, "sys.procedures",
+		"MSSQL drop must probe sys.procedures, not sys.objects, so it matches the procedure-only object class")
+	assert.Contains(t, got, "OBJECT_ID(N'[sg].[usp_RefreshDashboard]')",
+		"MSSQL existence probe should use the schema-qualified object literal")
+	assert.Contains(t, got, "DROP PROCEDURE [sg].[usp_RefreshDashboard]")
+}
+
+func TestProcedureDef_DropSQL_MSSQL_UnqualifiedExistenceProbe(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.DropSQL(d)
+	require.NoError(t, err)
+	// Without a schema namespace, the existence probe must still produce a
+	// valid OBJECT_ID literal — bare name in brackets.
+	assert.Contains(t, got, "OBJECT_ID(N'[usp_RefreshDashboard]')")
+	assert.Contains(t, got, "DROP PROCEDURE [usp_RefreshDashboard]")
+}
+
+func TestProcedureDef_DropSQL_Postgres_ReturnsExplicitError(t *testing.T) {
+	d := chuck.PostgresDialect{}
+	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.DropSQL(d)
+	assert.Empty(t, got)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestProcedureDef_DropSQL_SQLite_ReturnsExplicitError(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	p := NewProcedure("usp_RefreshDashboard", procedureBodyNoPrefix)
+	got, err := p.DropSQL(d)
+	assert.Empty(t, got)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}

--- a/schema/procedure_test.go
+++ b/schema/procedure_test.go
@@ -60,9 +60,9 @@ func TestProcedureDef_QualifiedNameFor_MSSQL(t *testing.T) {
 }
 
 func TestProcedureDef_CreateOrAlterSQL_MSSQL_Parameterized(t *testing.T) {
-	// The blocking review finding on PR #81: parameters in T-SQL belong
-	// between the procedure name and AS, not after AS. The render path must
-	// place the caller's definition immediately after the qualified name so
+	// Parameters in T-SQL belong between the procedure name and AS, not
+	// after AS. The render path must place the caller's definition
+	// immediately after the qualified name so
 	// `@AgentID INT, @AsOf DATETIME2 = NULL\nAS\n...` lands in the right slot.
 	d := chuck.MSSQLDialect{}
 	p := NewQualifiedProcedure("sg", "usp_RefreshDashboard", procedureDefinition)


### PR DESCRIPTION
Closes #80.

## Summary
- Adds `ProcedureDef` in `schema/` alongside `ViewDef` so MSSQL refresh / migration procedures stop being raw checked-in `.sql` outside chuck ownership
- MSSQL lifecycle: `CreateOrAlterSQL` emits `CREATE OR ALTER PROCEDURE [schema].[name] AS <body>` as a single MSSQL 2016+ batch; `DropSQL` wraps `DROP PROCEDURE` in a `sys.procedures` existence probe so it can run unconditionally during teardown
- Postgres / SQLite are explicitly unsupported in this first pass — lifecycle methods return `ErrProcedureDialectUnsupported` so bootstrap callers fail loud instead of silently dropping owned procedures from the apply set on the wrong engine
- Ordering between procedures and tables/views stays caller-owned; SQL Agent jobs and `msdb` admin objects are intentionally out of scope per the issue's MVP shape

## API
- `NewProcedure(name, body)`, `NewQualifiedProcedure(schema, name, body)`, `WithSchema`, `Schema`, `Body`, `Object`, `QualifiedNameFor` — mirror the `ViewDef` shape so the two declaration styles can be mixed in one bundle
- `(p *ProcedureDef) CreateOrAlterSQL(d) (string, error)`
- `(p *ProcedureDef) DropSQL(d) (string, error)`
- `var ErrProcedureDialectUnsupported = errors.New(...)` for `errors.Is` branching

## Test plan
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] `go test ./...` — green (unit coverage of identity, qualified-name rendering, both lifecycle SQL forms, and explicit non-MSSQL error path)
- [ ] Live MSSQL run: `CHUCK_MSSQL_URL=... go test ./schema/ -run TestProcedureLifecycleMSSQL` (covers idempotent create-or-alter + idempotent drop)

## Risks
- `CREATE OR ALTER PROCEDURE` requires MSSQL 2016+ — pre-2016 callers must use `DropSQL` + a plain `CREATE PROCEDURE` themselves. Acceptable bar; matches the existing `CREATE OR ALTER VIEW` choice in `ViewDef`
- Live MSSQL lifecycle test gated by `CHUCK_MSSQL_URL` — CI must wire that env var or it stays a skip
- No drift / snapshot integration for procedures, by design — procedure bodies are opaque text so introspection-based drift would be high-noise; revisit if a concrete use case appears