### PR TITLE
feat(schema): explicit validate/apply for owned views and procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,11 +526,23 @@ schema.ValidateProcedures(ctx, db, dialect, p1, p2)
 | ---------- | -------- | --------- | --------------------------------------------------------------------------------------------------- |
 | View       | SQLite   | yes       | yes (`sqlite_master.sql` stored verbatim)                                                           |
 | View       | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                  |
-| View       | Postgres | yes       | **skipped** — `pg_get_viewdef` canonicalizes too aggressively to support honest text comparison     |
+| View       | Postgres | yes       | **fails loud** — returns `ErrViewBodyComparisonUnsupported`; `pg_get_viewdef` canonicalizes too aggressively to support honest text comparison |
 | Procedure  | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                  |
 | Procedure  | other    | n/a       | returns `schema.ErrProcedureDialectUnsupported`                                                     |
 
-Postgres view-body comparison is intentionally not attempted: `pg_get_viewdef` expands `SELECT *` into explicit column lists, fully qualifies references, and inserts casts, so a textual compare against the declared body produces false drift on legitimate-looking declarations. `ValidateView` on Postgres confirms existence only. Callers that need a stricter assertion can fetch the live body via `schema.LiveViewBody(ctx, db, dialect, viewDef)` and run their own comparison against a canonicalized form they trust.
+Postgres view-body comparison is intentionally not attempted: `pg_get_viewdef` expands `SELECT *` into explicit column lists, fully qualifies references, and inserts casts, so a textual compare against the declared body produces false drift on legitimate-looking declarations. Rather than silently returning success on existence, `ValidateView` on Postgres fails loud with a `*schema.ViewDriftError` whose single entry has `BodyComparisonSkipped=true` and unwraps to `schema.ErrViewBodyComparisonUnsupported`. Callers that want existence-only semantics on Postgres can opt in explicitly:
+
+```go
+if err := schema.ValidateView(ctx, db, dialect, viewDef); err != nil {
+    if errors.Is(err, schema.ErrViewBodyComparisonUnsupported) {
+        // Postgres: view exists, body compare unavailable — treat as success.
+    } else {
+        return err // ErrViewMissing or infra failure: still hard fail.
+    }
+}
+```
+
+Callers that need a stricter body assertion can fetch the live body via `schema.LiveViewBody(ctx, db, dialect, viewDef)` and run their own comparison against a canonicalized form they trust.
 
 Drift surfaces as a structured error:
 
@@ -547,6 +559,11 @@ if err != nil {
     // For single-cause results, the error also unwraps to a sentinel:
     if errors.Is(err, schema.ErrViewMissing)  { /* none of the views exist */ }
     if errors.Is(err, schema.ErrViewBodyDrift) { /* every drifted view is a body mismatch */ }
+    if errors.Is(err, schema.ErrViewBodyComparisonUnsupported) {
+        // Every drift was a body-compare-skip (Postgres). Existence confirmed
+        // for all — callers that want existence-only semantics treat this as
+        // success.
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [Table Dependency Ordering](#table-dependency-ordering)
     - [Owned Views](#owned-views)
     - [Owned Procedures (MSSQL)](#owned-procedures-mssql)
+    - [Code-Object Validate and Apply](#code-object-validate-and-apply)
     - [Schema Snapshots](#schema-snapshots)
     - [Live Schema Snapshots](#live-schema-snapshots)
     - [Schema Validation](#schema-validation)
@@ -498,6 +499,75 @@ Lifecycle rules:
 - **Postgres / SQLite** are explicitly unsupported in this first pass — the lifecycle methods return `schema.ErrProcedureDialectUnsupported` instead of silently no-op'ing. Use `errors.Is(err, schema.ErrProcedureDialectUnsupported)` to branch your bootstrap when the same code path runs against a non-MSSQL engine.
 
 The definition is taken verbatim. Callers own all inner identifier quoting, parameter declarations, procedure options, the `AS` keyword itself, and the body; chuck contributes only the `CREATE OR ALTER PROCEDURE <qualified-name>` preamble. Ordering between procedures and the tables / views they read is caller-owned: create procedures after their dependencies, drop them before. SQL Agent jobs and `msdb`-level admin objects are intentionally out of scope for this primitive.
+
+### Code-Object Validate and Apply
+
+Tables stay on the strict `Ensure(...)` / `DiffSchema(...)` / `ValidateSchema(...)` covenant — relational data must never be auto-migrated, and drift in a table is always an error to escalate. Views and procedures are different: their bodies are code, callers usually want them to track the declaration the same way application code tracks `main.go`, and the safe answer is an idempotent re-apply. Chuck exposes explicit verb helpers so bootstrap code can pick the behavior intentionally rather than receiving it as a side effect of `Ensure`:
+
+```go
+// Views (all dialects):
+schema.ApplyView(ctx, db, dialect, RefreshDashboardView)
+schema.ApplyViews(ctx, db, dialect, v1, v2, v3) // caller-ordered, dependency-aware
+schema.ValidateView(ctx, db, dialect, RefreshDashboardView)
+schema.ValidateViews(ctx, db, dialect, v1, v2, v3)
+
+// Procedures (MSSQL only):
+schema.ApplyProcedure(ctx, db, dialect, RefreshDashboardProc)
+schema.ApplyProcedures(ctx, db, dialect, p1, p2)
+schema.ValidateProcedure(ctx, db, dialect, RefreshDashboardProc)
+schema.ValidateProcedures(ctx, db, dialect, p1, p2)
+```
+
+`Apply*` is one-way: declared definition overwrites the live object. It is idempotent on Postgres / MSSQL (`CREATE OR REPLACE` / `CREATE OR ALTER`) and effectively idempotent on SQLite (`DROP IF EXISTS` + `CREATE`). `Apply*` does no pre-flight drift check — callers that want validate-then-apply semantics call `Validate*` first and apply only when drift is reported.
+
+`Validate*` confirms the object exists and, where the engine stores definitions verbatim, also confirms the body / definition text matches the declaration after canonical normalization (whitespace collapse, trailing-semicolon strip, CREATE-preamble strip):
+
+| Object     | Engine   | Existence | Body / definition comparison                                                                        |
+| ---------- | -------- | --------- | --------------------------------------------------------------------------------------------------- |
+| View       | SQLite   | yes       | yes (`sqlite_master.sql` stored verbatim)                                                           |
+| View       | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                  |
+| View       | Postgres | yes       | **skipped** — `pg_get_viewdef` canonicalizes too aggressively to support honest text comparison     |
+| Procedure  | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                  |
+| Procedure  | other    | n/a       | returns `schema.ErrProcedureDialectUnsupported`                                                     |
+
+Postgres view-body comparison is intentionally not attempted: `pg_get_viewdef` expands `SELECT *` into explicit column lists, fully qualifies references, and inserts casts, so a textual compare against the declared body produces false drift on legitimate-looking declarations. `ValidateView` on Postgres confirms existence only. Callers that need a stricter assertion can fetch the live body via `schema.LiveViewBody(ctx, db, dialect, viewDef)` and run their own comparison against a canonicalized form they trust.
+
+Drift surfaces as a structured error:
+
+```go
+err := schema.ValidateViews(ctx, db, dialect, v1, v2, v3)
+if err != nil {
+    var drift *schema.ViewDriftError
+    if errors.As(err, &drift) {
+        for _, d := range drift.Drifts {
+            // d.Object, d.Missing, d.BodyMismatch, d.BodyComparisonSkipped,
+            // d.DeclaredBody, d.LiveBody, d.Reason
+        }
+    }
+    // For single-cause results, the error also unwraps to a sentinel:
+    if errors.Is(err, schema.ErrViewMissing)  { /* none of the views exist */ }
+    if errors.Is(err, schema.ErrViewBodyDrift) { /* every drifted view is a body mismatch */ }
+}
+```
+
+`schema.ProcedureDriftError` has the same shape with sentinels `schema.ErrProcedureMissing` and `schema.ErrProcedureDefinitionDrift`. Mixed-cause aggregate results (some missing + some drifted) intentionally do not unwrap to either sentinel, so callers can't branch on a single cause when the real failure mode is heterogeneous.
+
+The intended ordering in bootstrap code stays caller-owned:
+
+```go
+// Tables strict — drift always fails, never auto-applies.
+if _, err := schema.Ensure(ctx, db, dialect, tables); err != nil { return err }
+
+// Views second — apply unconditionally, or validate-then-apply.
+if err := schema.ApplyViews(ctx, db, dialect, views...); err != nil { return err }
+
+// Procedures last — MSSQL only; non-MSSQL deployments skip this branch.
+if dialect.Engine() == chuck.MSSQL {
+    if err := schema.ApplyProcedures(ctx, db, dialect, procs...); err != nil { return err }
+}
+```
+
+Chuck does not provide a generalized object-graph scheduler that hides this ordering, because the dependency chain on top of an owned table set is almost always short and linear and a scheduler abstraction would obscure more than it would help. Pick the order in code; the helpers preserve it.
 
 ### Schema Snapshots
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -351,6 +351,53 @@ func TestViewValidateApply_SQLite(t *testing.T) {
 		"validate must pass again after re-apply")
 }
 
+// TestValidateView_Postgres_FailsLoud asserts the Postgres ValidateView
+// contract: existence is confirmed, but body comparison is NOT silently
+// green-lit. After apply, validate must return a *ViewDriftError whose entry
+// has BodyComparisonSkipped=true and unwraps to
+// ErrViewBodyComparisonUnsupported. Gated by CHUCK_POSTGRES_URL.
+func TestValidateView_Postgres_FailsLoud(t *testing.T) {
+	dsn := os.Getenv("CHUCK_POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_POSTGRES_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS vva_pg_tasks (id SERIAL PRIMARY KEY, done BOOLEAN)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS vva_pg_tasks`) }()
+
+	v := schema.NewView("v_vva_pg_open", "SELECT id FROM vva_pg_tasks WHERE done = FALSE")
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	// Missing → ValidateView reports drift wrapping ErrViewMissing.
+	err = schema.ValidateView(ctx, db, d, v)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schema.ErrViewMissing,
+		"missing view on Postgres must still fail loud with ErrViewMissing")
+
+	require.NoError(t, schema.ApplyView(ctx, db, d, v))
+
+	// Exists but body comparison is unavailable on Postgres → must fail loud
+	// with ErrViewBodyComparisonUnsupported instead of returning nil.
+	err = schema.ValidateView(ctx, db, d, v)
+	require.Error(t, err, "Postgres ValidateView must NOT silently green-light when body compare is unavailable")
+	assert.ErrorIs(t, err, schema.ErrViewBodyComparisonUnsupported)
+
+	var drift *schema.ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	require.Len(t, drift.Drifts, 1)
+	assert.True(t, drift.Drifts[0].BodyComparisonSkipped,
+		"Postgres drift entry must set BodyComparisonSkipped so callers can see why compare was skipped")
+	assert.False(t, drift.Drifts[0].Missing)
+	assert.False(t, drift.Drifts[0].BodyMismatch)
+	assert.NotEmpty(t, drift.Drifts[0].Reason)
+}
+
 // TestProcedureValidateApply_MSSQL exercises the validate/apply lane against
 // a live MSSQL instance. Procedure ownership is MSSQL-only, so SQLite /
 // Postgres cannot stand in for this test. Gated by CHUCK_MSSQL_URL.

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -310,3 +310,97 @@ func TestDropInboundForeignKeysMSSQL(t *testing.T) {
 		}
 	})
 }
+
+// TestViewValidateApply_SQLite exercises the validate/apply lane against
+// in-memory SQLite end-to-end: apply a declared view, validate it matches,
+// drift the live body out-of-band, validate the drift is detected, then
+// re-apply and validate it is gone. Uses SQLite because the lane works on
+// all dialects but SQLite needs no env DSN.
+func TestViewValidateApply_SQLite(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE vva_tasks (id INTEGER PRIMARY KEY, done INTEGER)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS vva_tasks`) }()
+
+	v := schema.NewView("v_vva_open", "SELECT id FROM vva_tasks WHERE done = 0")
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	require.NoError(t, schema.ApplyView(ctx, db, d, v))
+	require.NoError(t, schema.ValidateView(ctx, db, d, v),
+		"ValidateView must report a clean match immediately after ApplyView")
+
+	// Drift the live view out-of-band.
+	_, err = db.ExecContext(ctx, `DROP VIEW v_vva_open`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `CREATE VIEW v_vva_open AS SELECT id FROM vva_tasks WHERE done = 1`)
+	require.NoError(t, err)
+
+	err = schema.ValidateView(ctx, db, d, v)
+	require.Error(t, err, "out-of-band body change must be detected")
+	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+
+	// ApplyView should restore the declared body.
+	require.NoError(t, schema.ApplyView(ctx, db, d, v))
+	require.NoError(t, schema.ValidateView(ctx, db, d, v),
+		"validate must pass again after re-apply")
+}
+
+// TestProcedureValidateApply_MSSQL exercises the validate/apply lane against
+// a live MSSQL instance. Procedure ownership is MSSQL-only, so SQLite /
+// Postgres cannot stand in for this test. Gated by CHUCK_MSSQL_URL.
+func TestProcedureValidateApply_MSSQL(t *testing.T) {
+	dsn := os.Getenv("CHUCK_MSSQL_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_MSSQL_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	proc := schema.NewProcedure("usp_chuck_vva_proc",
+		"@Probe INT = 1 AS BEGIN SET NOCOUNT ON; SELECT @Probe AS Probe; END")
+
+	// Best-effort cleanup from any prior failed run.
+	if stmt, derr := proc.DropSQL(d); derr == nil {
+		_, _ = db.ExecContext(ctx, stmt)
+	}
+	defer func() {
+		if stmt, derr := proc.DropSQL(d); derr == nil {
+			_, _ = db.ExecContext(ctx, stmt)
+		}
+	}()
+
+	// Missing → ValidateProcedure reports drift wrapping ErrProcedureMissing.
+	err = schema.ValidateProcedure(ctx, db, d, proc)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schema.ErrProcedureMissing)
+
+	// Apply then validate matches.
+	require.NoError(t, schema.ApplyProcedure(ctx, db, d, proc))
+	require.NoError(t, schema.ValidateProcedure(ctx, db, d, proc),
+		"validate must pass immediately after apply")
+
+	// Drift definition out-of-band via a different definition body.
+	drifted := schema.NewProcedure("usp_chuck_vva_proc",
+		"@Probe INT = 2 AS BEGIN SET NOCOUNT ON; SELECT @Probe + 100 AS Probe; END")
+	stmt, err := drifted.CreateOrAlterSQL(d)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, stmt)
+	require.NoError(t, err)
+
+	err = schema.ValidateProcedure(ctx, db, d, proc)
+	require.Error(t, err, "out-of-band definition change must be detected")
+	assert.ErrorIs(t, err, schema.ErrProcedureDefinitionDrift)
+
+	// Re-apply the original and validate clean.
+	require.NoError(t, schema.ApplyProcedure(ctx, db, d, proc))
+	require.NoError(t, schema.ValidateProcedure(ctx, db, d, proc))
+}

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -1,0 +1,236 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/catgoose/chuck"
+)
+
+// ErrProcedureMissing is returned by ValidateProcedure / ValidateProcedures
+// when a declared procedure does not exist in the live database.
+var ErrProcedureMissing = errors.New("schema: declared procedure does not exist in live database")
+
+// ErrProcedureDefinitionDrift is returned by ValidateProcedure /
+// ValidateProcedures when a declared procedure exists but its normalized
+// definition differs from the declaration.
+var ErrProcedureDefinitionDrift = errors.New("schema: declared procedure definition differs from live database definition")
+
+// ProcedureDrift describes one declared procedure whose state in the live
+// database does not match the declared definition. Either Missing is true,
+// or DefinitionMismatch is true with DeclaredDefinition / LiveDefinition
+// populated for diagnosis.
+type ProcedureDrift struct {
+	Object             chuck.ObjectName
+	Missing            bool
+	DefinitionMismatch bool
+	DeclaredDefinition string
+	LiveDefinition     string
+	Reason             string
+}
+
+// ProcedureDriftError is returned by ValidateProcedure / ValidateProcedures
+// when one or more declared procedures are missing or drifted. Drifts holds
+// one entry per offending procedure. The error wraps ErrProcedureMissing
+// when every drift is a missing object and ErrProcedureDefinitionDrift when
+// every drift is a definition mismatch.
+type ProcedureDriftError struct {
+	Drifts []ProcedureDrift
+}
+
+func (e *ProcedureDriftError) Error() string {
+	parts := make([]string, 0, len(e.Drifts))
+	for _, d := range e.Drifts {
+		obj := objectKey(d.Object)
+		switch {
+		case d.Missing:
+			parts = append(parts, fmt.Sprintf("procedure %q: missing", obj))
+		case d.DefinitionMismatch:
+			parts = append(parts, fmt.Sprintf("procedure %q: definition drift", obj))
+		default:
+			parts = append(parts, fmt.Sprintf("procedure %q: %s", obj, d.Reason))
+		}
+	}
+	return "schema: procedure drift detected: " + strings.Join(parts, ", ")
+}
+
+func (e *ProcedureDriftError) Unwrap() error {
+	if len(e.Drifts) == 0 {
+		return nil
+	}
+	onlyMissing := true
+	onlyDefn := true
+	for _, d := range e.Drifts {
+		if !d.Missing {
+			onlyMissing = false
+		}
+		if !d.DefinitionMismatch {
+			onlyDefn = false
+		}
+	}
+	switch {
+	case onlyMissing:
+		return ErrProcedureMissing
+	case onlyDefn:
+		return ErrProcedureDefinitionDrift
+	default:
+		return nil
+	}
+}
+
+// LiveProcedureDefinition queries the live MSSQL database for the declared
+// definition of an owned procedure, returning the text that follows
+// `CREATE OR ALTER PROCEDURE <qualified-name>` — i.e. the same shape the
+// caller passes to NewProcedure / NewQualifiedProcedure as the definition
+// payload. Returns ("", false, nil) when the procedure does not exist and a
+// non-nil error only on infrastructure failure or unsupported dialect.
+//
+// Returns ErrProcedureDialectUnsupported on non-MSSQL dialects so callers
+// running validate/apply against the wrong engine fail loud instead of
+// silently no-op'ing.
+func LiveProcedureDefinition(ctx context.Context, db *sql.DB, d chuck.Dialect, p *ProcedureDef) (definition string, exists bool, err error) {
+	if d.Engine() != chuck.MSSQL {
+		return "", false, fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	schema, name := normalizedObject(d, p.Object())
+	objArg := name
+	if schema != "" {
+		objArg = schema + "." + name
+	}
+	const q = `SELECT sm.definition
+FROM sys.sql_modules sm
+JOIN sys.procedures pr ON pr.object_id = sm.object_id
+WHERE sm.object_id = OBJECT_ID(@p1)`
+	var raw sql.NullString
+	switch err := db.QueryRowContext(ctx, q, objArg).Scan(&raw); err {
+	case nil:
+		if !raw.Valid {
+			return "", true, nil
+		}
+		return stripCreateProcedurePreamble(raw.String), true, nil
+	case sql.ErrNoRows:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("schema: query sys.sql_modules for procedure %q: %w", objArg, err)
+	}
+}
+
+// procedurePreambleRe matches a leading `CREATE [OR ALTER] PROCEDURE <name>`
+// prefix on a stored procedure definition. The identifier subpattern accepts
+// bracketed, double-quoted, or bare names with an optional `schema.` prefix
+// so MSSQL `[dbo].[name]` and bare-name definitions both strip cleanly.
+var procedurePreambleRe = regexp.MustCompile(`(?is)^\s*CREATE\s+(?:OR\s+ALTER\s+)?PROCEDURE\s+(?:\[[^\]]+\]|"[^"]+"|[A-Za-z_][\w$]*)(?:\.(?:\[[^\]]+\]|"[^"]+"|[A-Za-z_][\w$]*))?\s*`)
+
+// stripCreateProcedurePreamble removes the leading
+// `CREATE [OR ALTER] PROCEDURE <name>` preamble from a stored procedure
+// definition, returning just the definition payload. If the preamble is not
+// found the input is returned unchanged.
+func stripCreateProcedurePreamble(s string) string {
+	loc := procedurePreambleRe.FindStringIndex(s)
+	if loc == nil {
+		return s
+	}
+	return s[loc[1]:]
+}
+
+// ValidateProcedure checks that a declared MSSQL procedure exists in the
+// live database and that its definition matches the declaration after
+// canonical normalization (whitespace collapse, trailing-semicolon strip,
+// CREATE-preamble strip). MSSQL stores `sys.sql_modules.definition`
+// verbatim, so body comparison is honest on this engine.
+//
+// Returns nil on match. Returns a `*ProcedureDriftError` whose Drifts slice
+// has exactly one entry when the procedure is missing or its definition
+// differs. Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
+func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *ProcedureDef) error {
+	if d.Engine() != chuck.MSSQL {
+		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	live, exists, err := LiveProcedureDefinition(ctx, db, d, p)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return &ProcedureDriftError{Drifts: []ProcedureDrift{{
+			Object:  p.Object(),
+			Missing: true,
+			Reason:  "procedure does not exist",
+		}}}
+	}
+	declaredCanon := canonicalizeViewBody(p.Definition())
+	liveCanon := canonicalizeViewBody(live)
+	if declaredCanon == liveCanon {
+		return nil
+	}
+	return &ProcedureDriftError{Drifts: []ProcedureDrift{{
+		Object:             p.Object(),
+		DefinitionMismatch: true,
+		DeclaredDefinition: declaredCanon,
+		LiveDefinition:     liveCanon,
+		Reason:             "procedure definition differs after canonical normalization",
+	}}}
+}
+
+// ValidateProcedures validates each declared procedure in order, aggregating
+// any drift into a single `*ProcedureDriftError`. Infrastructure errors and
+// unsupported-dialect errors short-circuit and are returned directly.
+func ValidateProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs ...*ProcedureDef) error {
+	if d.Engine() != chuck.MSSQL {
+		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	var drifts []ProcedureDrift
+	for _, p := range procs {
+		err := ValidateProcedure(ctx, db, d, p)
+		if err == nil {
+			continue
+		}
+		var drift *ProcedureDriftError
+		if errors.As(err, &drift) {
+			drifts = append(drifts, drift.Drifts...)
+			continue
+		}
+		return err
+	}
+	if len(drifts) == 0 {
+		return nil
+	}
+	return &ProcedureDriftError{Drifts: drifts}
+}
+
+// ApplyProcedure writes the declared procedure to the live MSSQL database
+// via its CreateOrAlterSQL statement, executing it as a single batch
+// (matching chuck's one-statement-per-Exec MSSQL model). Idempotent: the
+// MSSQL CREATE OR ALTER PROCEDURE batch replaces any prior definition with
+// the same identity.
+//
+// Returns ErrProcedureDialectUnsupported on non-MSSQL dialects. ApplyProcedure
+// is one-way: declared definition becomes live definition. It does no
+// pre-flight drift check.
+func ApplyProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *ProcedureDef) error {
+	stmt, err := p.CreateOrAlterSQL(d)
+	if err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("schema: apply procedure %q: %w", objectKey(p.Object()), err)
+	}
+	return nil
+}
+
+// ApplyProcedures applies each declared procedure in caller-supplied order.
+// Returns the first error encountered.
+func ApplyProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs ...*ProcedureDef) error {
+	if d.Engine() != chuck.MSSQL {
+		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	for _, p := range procs {
+		if err := ApplyProcedure(ctx, db, d, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/schema/procedure_lifecycle_test.go
+++ b/schema/procedure_lifecycle_test.go
@@ -1,0 +1,130 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripCreateProcedurePreamble(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "mssql CREATE OR ALTER with bracketed schema",
+			in:   `CREATE OR ALTER PROCEDURE [sg].[usp_Refresh] @AgentID INT AS BEGIN SELECT 1 END`,
+			want: `@AgentID INT AS BEGIN SELECT 1 END`,
+		},
+		{
+			name: "mssql CREATE bare-name no schema",
+			in:   `CREATE PROCEDURE usp_Refresh AS BEGIN SET NOCOUNT ON; SELECT 1 END`,
+			want: `AS BEGIN SET NOCOUNT ON; SELECT 1 END`,
+		},
+		{
+			name: "mssql leading whitespace and newlines",
+			in:   "\n   CREATE OR ALTER PROCEDURE [dbo].[usp_X]\n@Probe INT = 1\nAS\nBEGIN SELECT @Probe END",
+			want: "@Probe INT = 1\nAS\nBEGIN SELECT @Probe END",
+		},
+		{
+			name: "no preamble returned unchanged",
+			in:   `AS BEGIN SELECT 1 END`,
+			want: `AS BEGIN SELECT 1 END`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripCreateProcedurePreamble(tc.in))
+		})
+	}
+}
+
+func TestValidateProcedure_UnsupportedDialect_Postgres(t *testing.T) {
+	// Procedure validation is MSSQL-only; non-MSSQL calls must fail loud
+	// rather than silently no-op, so bootstrap callers running on the wrong
+	// engine cannot accidentally drop ownership coverage from the apply set.
+	err := ValidateProcedure(context.Background(), nil, chuck.PostgresDialect{},
+		NewQualifiedProcedure("sg", "usp_X", "AS BEGIN SELECT 1 END"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestValidateProcedure_UnsupportedDialect_SQLite(t *testing.T) {
+	err := ValidateProcedure(context.Background(), nil, chuck.SQLiteDialect{},
+		NewProcedure("usp_X", "AS BEGIN SELECT 1 END"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestValidateProcedures_UnsupportedDialect_FailsBeforeQuery(t *testing.T) {
+	// Even when the caller passes zero procedures, the dialect guard must
+	// fire so misconfigured deployments fail loud rather than silently
+	// reporting success.
+	err := ValidateProcedures(context.Background(), nil, chuck.PostgresDialect{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestApplyProcedure_UnsupportedDialect_Postgres(t *testing.T) {
+	err := ApplyProcedure(context.Background(), nil, chuck.PostgresDialect{},
+		NewQualifiedProcedure("sg", "usp_X", "AS BEGIN SELECT 1 END"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestApplyProcedures_UnsupportedDialect_FailsBeforeExec(t *testing.T) {
+	err := ApplyProcedures(context.Background(), nil, chuck.SQLiteDialect{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestProcedureDriftError_Unwrap_AllMissing(t *testing.T) {
+	e := &ProcedureDriftError{Drifts: []ProcedureDrift{
+		{Object: chuck.ObjectName{Schema: "sg", Name: "usp_A"}, Missing: true},
+		{Object: chuck.ObjectName{Schema: "sg", Name: "usp_B"}, Missing: true},
+	}}
+	assert.True(t, errors.Is(e, ErrProcedureMissing))
+	assert.False(t, errors.Is(e, ErrProcedureDefinitionDrift))
+}
+
+func TestProcedureDriftError_Unwrap_AllDefinition(t *testing.T) {
+	e := &ProcedureDriftError{Drifts: []ProcedureDrift{
+		{Object: chuck.ObjectName{Name: "usp_A"}, DefinitionMismatch: true},
+	}}
+	assert.True(t, errors.Is(e, ErrProcedureDefinitionDrift))
+	assert.False(t, errors.Is(e, ErrProcedureMissing))
+}
+
+func TestProcedureDriftError_Unwrap_MixedCauses_NoWrap(t *testing.T) {
+	// Mixed missing + definition-drift cases intentionally do not wrap
+	// either sentinel so callers can't branch on a single cause when the
+	// real failure mode is heterogeneous.
+	e := &ProcedureDriftError{Drifts: []ProcedureDrift{
+		{Object: chuck.ObjectName{Name: "usp_A"}, Missing: true},
+		{Object: chuck.ObjectName{Name: "usp_B"}, DefinitionMismatch: true},
+	}}
+	assert.False(t, errors.Is(e, ErrProcedureMissing))
+	assert.False(t, errors.Is(e, ErrProcedureDefinitionDrift))
+}
+
+func TestViewDriftError_Unwrap_AllMissing(t *testing.T) {
+	e := &ViewDriftError{Drifts: []ViewDrift{
+		{Object: chuck.ObjectName{Name: "v_a"}, Missing: true},
+		{Object: chuck.ObjectName{Name: "v_b"}, Missing: true},
+	}}
+	assert.True(t, errors.Is(e, ErrViewMissing))
+	assert.False(t, errors.Is(e, ErrViewBodyDrift))
+}
+
+func TestViewDriftError_Unwrap_AllBody(t *testing.T) {
+	e := &ViewDriftError{Drifts: []ViewDrift{
+		{Object: chuck.ObjectName{Name: "v_a"}, BodyMismatch: true},
+	}}
+	assert.True(t, errors.Is(e, ErrViewBodyDrift))
+	assert.False(t, errors.Is(e, ErrViewMissing))
+}

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -1,0 +1,329 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/catgoose/chuck"
+)
+
+// ErrViewMissing is returned by ValidateView / ValidateViews when a declared
+// view does not exist in the live database. Callers can errors.Is-detect this
+// to distinguish "not bootstrapped yet" from "definition drift."
+var ErrViewMissing = errors.New("schema: declared view does not exist in live database")
+
+// ErrViewBodyDrift is returned by ValidateView / ValidateViews when a declared
+// view exists in the live database but its normalized body does not match the
+// declared body. Callers can errors.Is-detect this to distinguish drift from
+// missing-object and from infrastructure errors.
+var ErrViewBodyDrift = errors.New("schema: declared view body differs from live database body")
+
+// ViewDrift describes one declared view whose state in the live database does
+// not match the declared definition. Either Missing is true, or BodyMismatch
+// is true (with DeclaredBody / LiveBody populated for diagnosis).
+//
+// BodyComparisonSkipped is true when the live engine canonicalizes view
+// definitions enough that body-text drift cannot be honestly reported (today:
+// Postgres pg_get_viewdef rewrites identifiers, expands stars, fully-qualifies
+// references). In that case Validate only confirms existence and Reason
+// explains why body comparison was skipped.
+type ViewDrift struct {
+	Object                chuck.ObjectName
+	Missing               bool
+	BodyMismatch          bool
+	BodyComparisonSkipped bool
+	DeclaredBody          string
+	LiveBody              string
+	Reason                string
+}
+
+// ViewDriftError is returned by ValidateView / ValidateViews when one or more
+// declared views are missing or drifted. Drifts holds one entry per offending
+// view, in caller-supplied order. The error wraps ErrViewMissing when every
+// drift is a missing object and ErrViewBodyDrift when every drift is a body
+// mismatch, so the most common single-cause cases can be branched cleanly via
+// errors.Is. Mixed-cause errors do not wrap either sentinel.
+type ViewDriftError struct {
+	Drifts []ViewDrift
+}
+
+func (e *ViewDriftError) Error() string {
+	parts := make([]string, 0, len(e.Drifts))
+	for _, d := range e.Drifts {
+		obj := objectKey(d.Object)
+		switch {
+		case d.Missing:
+			parts = append(parts, fmt.Sprintf("view %q: missing", obj))
+		case d.BodyComparisonSkipped:
+			parts = append(parts, fmt.Sprintf("view %q: %s", obj, d.Reason))
+		case d.BodyMismatch:
+			parts = append(parts, fmt.Sprintf("view %q: body drift", obj))
+		default:
+			parts = append(parts, fmt.Sprintf("view %q: %s", obj, d.Reason))
+		}
+	}
+	return "schema: view drift detected: " + strings.Join(parts, ", ")
+}
+
+func (e *ViewDriftError) Unwrap() error {
+	if len(e.Drifts) == 0 {
+		return nil
+	}
+	onlyMissing := true
+	onlyBody := true
+	for _, d := range e.Drifts {
+		if !d.Missing {
+			onlyMissing = false
+		}
+		if !d.BodyMismatch {
+			onlyBody = false
+		}
+	}
+	switch {
+	case onlyMissing:
+		return ErrViewMissing
+	case onlyBody:
+		return ErrViewBodyDrift
+	default:
+		return nil
+	}
+}
+
+// LiveViewBody queries the live database for the declared body of an owned
+// view, returning the body text (the portion that follows `AS` for engines
+// that store the full CREATE statement). Returns (body, true, nil) on
+// success, ("", false, nil) when the view does not exist, and a non-nil
+// error only on infrastructure failure.
+//
+// On Postgres the returned body is whatever pg_get_viewdef(..., true) emits:
+// a heavily canonicalized SELECT with expanded stars, fully-qualified
+// references, and inserted casts. That text is exposed verbatim for callers
+// that want to do their own comparison; the package's own ValidateView
+// chooses not to compare it against a declared body because the rewrites
+// produce too much false drift to be honest about.
+func LiveViewBody(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) (body string, exists bool, err error) {
+	switch d.Engine() {
+	case chuck.SQLite:
+		return liveViewBodySQLite(ctx, db, v)
+	case chuck.MSSQL:
+		return liveViewBodyMSSQL(ctx, db, d, v)
+	case chuck.Postgres:
+		return liveViewBodyPostgres(ctx, db, d, v)
+	default:
+		return "", false, fmt.Errorf("schema: unsupported engine for view introspection: %s", d.Engine())
+	}
+}
+
+func liveViewBodySQLite(ctx context.Context, db *sql.DB, v *ViewDef) (body string, exists bool, err error) {
+	const q = `SELECT sql FROM sqlite_master WHERE type='view' AND name=?`
+	var raw sql.NullString
+	switch err := db.QueryRowContext(ctx, q, v.Name).Scan(&raw); err {
+	case nil:
+		if !raw.Valid {
+			return "", true, nil
+		}
+		return stripCreateViewPreamble(raw.String), true, nil
+	case sql.ErrNoRows:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("schema: query sqlite_master for view %q: %w", v.Name, err)
+	}
+}
+
+func liveViewBodyMSSQL(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) (body string, exists bool, err error) {
+	schema, name := normalizedObject(d, v.Object())
+	objArg := name
+	if schema != "" {
+		objArg = schema + "." + name
+	}
+	const q = `SELECT sm.definition
+FROM sys.sql_modules sm
+JOIN sys.views vw ON vw.object_id = sm.object_id
+WHERE sm.object_id = OBJECT_ID(@p1)`
+	var raw sql.NullString
+	switch err := db.QueryRowContext(ctx, q, objArg).Scan(&raw); err {
+	case nil:
+		if !raw.Valid {
+			return "", true, nil
+		}
+		return stripCreateViewPreamble(raw.String), true, nil
+	case sql.ErrNoRows:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("schema: query sys.sql_modules for view %q: %w", objArg, err)
+	}
+}
+
+func liveViewBodyPostgres(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) (body string, exists bool, err error) {
+	schema := resolveSchemaForInspection(d, v.Object())
+	_, name := normalizedObject(d, v.Object())
+	const q = `SELECT pg_get_viewdef(c.oid, true)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'v' AND n.nspname = $1 AND c.relname = $2`
+	var raw sql.NullString
+	switch err := db.QueryRowContext(ctx, q, schema, name).Scan(&raw); err {
+	case nil:
+		if !raw.Valid {
+			return "", true, nil
+		}
+		return raw.String, true, nil
+	case sql.ErrNoRows:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("schema: query pg_get_viewdef for view %q.%q: %w", schema, name, err)
+	}
+}
+
+// viewBodyPreambleRe matches a leading `CREATE [OR REPLACE | OR ALTER] VIEW
+// <identifier>(.<identifier>)? AS` prefix on a stored view definition. It is
+// anchored to the start of the string and runs case-insensitively, so the
+// matching tail is everything after the AS keyword and any trailing
+// whitespace. The identifier subpattern accepts bracket-quoted, double-quoted,
+// or bare names with an optional `schema.` prefix so SQLite (bare) and MSSQL
+// (bracketed, optionally schema-qualified) live definitions both collapse to
+// just the body.
+var viewBodyPreambleRe = regexp.MustCompile(`(?is)^\s*CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?VIEW\s+(?:\[[^\]]+\]|"[^"]+"|[A-Za-z_][\w$]*)(?:\.(?:\[[^\]]+\]|"[^"]+"|[A-Za-z_][\w$]*))?\s+AS\s+`)
+
+// stripCreateViewPreamble removes the leading `CREATE [OR ...] VIEW <name> AS`
+// preamble from a stored view definition, returning just the body text. If
+// the preamble is not found the input is returned unchanged so callers
+// comparing already-bare bodies (e.g. Postgres pg_get_viewdef output) still
+// get a usable string.
+func stripCreateViewPreamble(s string) string {
+	loc := viewBodyPreambleRe.FindStringIndex(s)
+	if loc == nil {
+		return s
+	}
+	return s[loc[1]:]
+}
+
+// canonicalizeViewBody normalizes a view body for drift comparison. It trims
+// surrounding whitespace, strips trailing semicolons, and collapses runs of
+// internal whitespace (including newlines/tabs) to a single space. The result
+// is the comparable form — not a roundtrippable SQL string.
+func canonicalizeViewBody(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimRight(s, ";")
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	inWS := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			if !inWS {
+				b.WriteByte(' ')
+				inWS = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		inWS = false
+	}
+	return b.String()
+}
+
+// ValidateView checks that a declared view exists in the live database and
+// that its body matches the declaration after canonical normalization
+// (whitespace collapse, trailing-semicolon strip, CREATE-preamble strip on
+// engines that store the full statement).
+//
+// Returns nil on match. Returns a `*ViewDriftError` whose Drifts slice has
+// exactly one entry when the view is missing or its body differs.
+// Infrastructure failures (query errors, unsupported engine) are returned
+// directly.
+//
+// On Postgres the live body is whatever pg_get_viewdef emits — a
+// canonicalized SELECT with expanded stars, fully-qualified references, and
+// inserted casts. That canonicalization is too aggressive to support
+// faithful body-drift detection against a hand-written declared body, so on
+// Postgres ValidateView only confirms existence and records
+// BodyComparisonSkipped=true with an explanatory Reason. Callers that need
+// stricter Postgres view-body assertions should fetch LiveViewBody and run
+// their own comparison.
+func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) error {
+	live, exists, err := LiveViewBody(ctx, db, d, v)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return &ViewDriftError{Drifts: []ViewDrift{{
+			Object:  v.Object(),
+			Missing: true,
+			Reason:  "view does not exist",
+		}}}
+	}
+	if d.Engine() == chuck.Postgres {
+		return nil
+	}
+	declaredCanon := canonicalizeViewBody(v.Body())
+	liveCanon := canonicalizeViewBody(live)
+	if declaredCanon == liveCanon {
+		return nil
+	}
+	return &ViewDriftError{Drifts: []ViewDrift{{
+		Object:       v.Object(),
+		BodyMismatch: true,
+		DeclaredBody: declaredCanon,
+		LiveBody:     liveCanon,
+		Reason:       "view body differs after canonical normalization",
+	}}}
+}
+
+// ValidateViews validates each given view in order, aggregating any drift
+// into a single `*ViewDriftError`. Infrastructure errors short-circuit and
+// are returned directly. Returns nil if every view matches.
+func ValidateViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*ViewDef) error {
+	var drifts []ViewDrift
+	for _, v := range views {
+		err := ValidateView(ctx, db, d, v)
+		if err == nil {
+			continue
+		}
+		var drift *ViewDriftError
+		if errors.As(err, &drift) {
+			drifts = append(drifts, drift.Drifts...)
+			continue
+		}
+		return err
+	}
+	if len(drifts) == 0 {
+		return nil
+	}
+	return &ViewDriftError{Drifts: drifts}
+}
+
+// ApplyView writes the declared view to the live database via its
+// CreateOrReplaceSQL statement chain, executing each statement in order.
+// This is idempotent on Postgres/MSSQL (CREATE OR REPLACE / CREATE OR ALTER)
+// and effectively idempotent on SQLite (DROP IF EXISTS + CREATE).
+//
+// ApplyView is one-way: declared body becomes live body. It does no
+// pre-flight drift check; callers that want validate-then-apply semantics
+// should call ValidateView themselves first and only apply when drift is
+// detected.
+func ApplyView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) error {
+	for _, stmt := range v.CreateOrReplaceSQL(d) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("schema: apply view %q: %w", objectKey(v.Object()), err)
+		}
+	}
+	return nil
+}
+
+// ApplyViews applies each declared view in caller-supplied order. Returns
+// the first error encountered; partial application up to that point is left
+// in place (matching the rest of chuck's no-implicit-rollback stance).
+func ApplyViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*ViewDef) error {
+	for _, v := range views {
+		if err := ApplyView(ctx, db, d, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -23,6 +23,18 @@ var ErrViewMissing = errors.New("schema: declared view does not exist in live da
 // missing-object and from infrastructure errors.
 var ErrViewBodyDrift = errors.New("schema: declared view body differs from live database body")
 
+// ErrViewBodyComparisonUnsupported is returned by ValidateView / ValidateViews
+// when the live engine canonicalizes view definitions enough that body-text
+// drift cannot be honestly compared (today: Postgres `pg_get_viewdef` expands
+// `SELECT *`, fully qualifies references, and inserts casts). Validate fails
+// loud with this sentinel rather than silently returning success so callers
+// asking for "validate" cannot mistake existence-only confirmation for a clean
+// body match. Callers that want to opt into existence-only semantics on these
+// engines can detect the sentinel via `errors.Is` and treat it as success;
+// callers that need stricter assertions can fetch `LiveViewBody` and run their
+// own comparison.
+var ErrViewBodyComparisonUnsupported = errors.New("schema: view body comparison unsupported on this engine; existence confirmed")
+
 // ViewDrift describes one declared view whose state in the live database does
 // not match the declared definition. Either Missing is true, or BodyMismatch
 // is true (with DeclaredBody / LiveBody populated for diagnosis).
@@ -43,11 +55,14 @@ type ViewDrift struct {
 }
 
 // ViewDriftError is returned by ValidateView / ValidateViews when one or more
-// declared views are missing or drifted. Drifts holds one entry per offending
-// view, in caller-supplied order. The error wraps ErrViewMissing when every
-// drift is a missing object and ErrViewBodyDrift when every drift is a body
-// mismatch, so the most common single-cause cases can be branched cleanly via
-// errors.Is. Mixed-cause errors do not wrap either sentinel.
+// declared views are missing, drifted, or could not be honestly compared on
+// the live engine. Drifts holds one entry per offending view, in
+// caller-supplied order. The error wraps ErrViewMissing when every drift is a
+// missing object, ErrViewBodyDrift when every drift is a body mismatch, and
+// ErrViewBodyComparisonUnsupported when every drift is a body-comparison-skip
+// (engine canonicalization made textual compare unreliable). Single-cause
+// results can be branched cleanly via errors.Is. Mixed-cause errors do not
+// wrap any sentinel.
 type ViewDriftError struct {
 	Drifts []ViewDrift
 }
@@ -76,6 +91,7 @@ func (e *ViewDriftError) Unwrap() error {
 	}
 	onlyMissing := true
 	onlyBody := true
+	onlySkipped := true
 	for _, d := range e.Drifts {
 		if !d.Missing {
 			onlyMissing = false
@@ -83,12 +99,17 @@ func (e *ViewDriftError) Unwrap() error {
 		if !d.BodyMismatch {
 			onlyBody = false
 		}
+		if !d.BodyComparisonSkipped {
+			onlySkipped = false
+		}
 	}
 	switch {
 	case onlyMissing:
 		return ErrViewMissing
 	case onlyBody:
 		return ErrViewBodyDrift
+	case onlySkipped:
+		return ErrViewBodyComparisonUnsupported
 	default:
 		return nil
 	}
@@ -103,9 +124,11 @@ func (e *ViewDriftError) Unwrap() error {
 // On Postgres the returned body is whatever pg_get_viewdef(..., true) emits:
 // a heavily canonicalized SELECT with expanded stars, fully-qualified
 // references, and inserted casts. That text is exposed verbatim for callers
-// that want to do their own comparison; the package's own ValidateView
-// chooses not to compare it against a declared body because the rewrites
-// produce too much false drift to be honest about.
+// that want to do their own comparison; the package's own ValidateView refuses
+// to compare it against a declared body because the rewrites produce too much
+// false drift to be honest about, and instead returns
+// ErrViewBodyComparisonUnsupported so callers cannot mistake silent success
+// for a clean body match.
 func LiveViewBody(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) (body string, exists bool, err error) {
 	switch d.Engine() {
 	case chuck.SQLite:
@@ -242,10 +265,14 @@ func canonicalizeViewBody(s string) string {
 // canonicalized SELECT with expanded stars, fully-qualified references, and
 // inserted casts. That canonicalization is too aggressive to support
 // faithful body-drift detection against a hand-written declared body, so on
-// Postgres ValidateView only confirms existence and records
-// BodyComparisonSkipped=true with an explanatory Reason. Callers that need
-// stricter Postgres view-body assertions should fetch LiveViewBody and run
-// their own comparison.
+// Postgres ValidateView fails loud by returning a `*ViewDriftError` whose
+// single entry has `BodyComparisonSkipped=true` and unwraps to
+// `ErrViewBodyComparisonUnsupported`. Existence is still confirmed: if the
+// view is missing the error unwraps to `ErrViewMissing` instead. Callers that
+// want existence-only semantics on Postgres can branch on
+// `errors.Is(err, ErrViewBodyComparisonUnsupported)` and treat it as success;
+// callers that need stricter body assertions should fetch `LiveViewBody` and
+// run their own comparison.
 func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) error {
 	live, exists, err := LiveViewBody(ctx, db, d, v)
 	if err != nil {
@@ -259,7 +286,13 @@ func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) 
 		}}}
 	}
 	if d.Engine() == chuck.Postgres {
-		return nil
+		return &ViewDriftError{Drifts: []ViewDrift{{
+			Object:                v.Object(),
+			BodyComparisonSkipped: true,
+			DeclaredBody:          v.Body(),
+			LiveBody:              live,
+			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
+		}}}
 	}
 	declaredCanon := canonicalizeViewBody(v.Body())
 	liveCanon := canonicalizeViewBody(live)

--- a/schema/view_lifecycle_test.go
+++ b/schema/view_lifecycle_test.go
@@ -1,0 +1,209 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripCreateViewPreamble(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "sqlite bare CREATE VIEW",
+			in:   `CREATE VIEW v_active AS SELECT id FROM users WHERE active = 1`,
+			want: `SELECT id FROM users WHERE active = 1`,
+		},
+		{
+			name: "mssql bracketed schema-qualified",
+			in:   `CREATE VIEW [sg].[v_active] AS SELECT [id] FROM [sg].[Users]`,
+			want: `SELECT [id] FROM [sg].[Users]`,
+		},
+		{
+			name: "mssql CREATE OR ALTER",
+			in:   `CREATE OR ALTER VIEW [sg].[v_active] AS SELECT 1 AS Probe`,
+			want: `SELECT 1 AS Probe`,
+		},
+		{
+			name: "postgres CREATE OR REPLACE",
+			in:   `CREATE OR REPLACE VIEW "sg"."v_active" AS SELECT id FROM users`,
+			want: `SELECT id FROM users`,
+		},
+		{
+			name: "no preamble returned as-is (postgres pg_get_viewdef style)",
+			in:   ` SELECT users.id FROM users WHERE users.active = true;`,
+			want: ` SELECT users.id FROM users WHERE users.active = true;`,
+		},
+		{
+			name: "multiline preamble strip",
+			in:   "CREATE VIEW v\n  AS\n  SELECT 1",
+			want: "SELECT 1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripCreateViewPreamble(tc.in))
+		})
+	}
+}
+
+func TestCanonicalizeViewBody(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trailing semicolon", "SELECT 1;", "SELECT 1"},
+		{"whitespace runs collapse", "SELECT\n\t1   FROM   t", "SELECT 1 FROM t"},
+		{"leading and trailing trim", "   SELECT 1   ", "SELECT 1"},
+		{"multiple trailing semicolons stripped", "SELECT 1;;;  ", "SELECT 1"},
+		{"empty input", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, canonicalizeViewBody(tc.in))
+		})
+	}
+}
+
+func TestValidateView_SQLite_Match(t *testing.T) {
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY, active INTEGER)`)
+	v := NewView("v_active_users", "SELECT id FROM users WHERE active = 1")
+	require.NoError(t, ApplyView(ctx, db, d, v))
+
+	require.NoError(t, ValidateView(ctx, db, d, v))
+}
+
+func TestValidateView_SQLite_Missing(t *testing.T) {
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	v := NewView("v_missing", "SELECT 1")
+	err := ValidateView(ctx, db, d, v)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrViewMissing),
+		"missing-only ViewDriftError must unwrap to ErrViewMissing for errors.Is branching")
+	var drift *ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	require.Len(t, drift.Drifts, 1)
+	assert.True(t, drift.Drifts[0].Missing)
+	assert.Equal(t, "v_missing", drift.Drifts[0].Object.Name)
+}
+
+func TestValidateView_SQLite_BodyDrift(t *testing.T) {
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY, active INTEGER)`)
+	declared := NewView("v_users", "SELECT id FROM users WHERE active = 1")
+	require.NoError(t, ApplyView(ctx, db, d, declared))
+
+	// Stomp the live view with a different body to simulate drift.
+	mustExec(t, db, `DROP VIEW v_users`)
+	mustExec(t, db, `CREATE VIEW v_users AS SELECT id FROM users WHERE active = 0`)
+
+	err := ValidateView(ctx, db, d, declared)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrViewBodyDrift))
+	var drift *ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	require.Len(t, drift.Drifts, 1)
+	assert.True(t, drift.Drifts[0].BodyMismatch)
+	assert.NotEqual(t, drift.Drifts[0].DeclaredBody, drift.Drifts[0].LiveBody)
+}
+
+func TestValidateView_SQLite_WhitespaceTolerant(t *testing.T) {
+	// canonicalizeViewBody collapses whitespace, so a declared body with
+	// different indentation than the live body must still validate as match.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	mustExec(t, db, `CREATE VIEW v_users AS SELECT    id
+	FROM users`)
+
+	declared := NewView("v_users", "SELECT id FROM users")
+	require.NoError(t, ValidateView(ctx, db, d, declared))
+}
+
+func TestValidateViews_SQLite_AggregatesDrift(t *testing.T) {
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	good := NewView("v_good", "SELECT id FROM t")
+	require.NoError(t, ApplyView(ctx, db, d, good))
+
+	missing := NewView("v_missing", "SELECT 1")
+
+	err := ValidateViews(ctx, db, d, good, missing)
+	require.Error(t, err)
+	var drift *ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	// Only the missing view should land in Drifts; good shouldn't.
+	require.Len(t, drift.Drifts, 1)
+	assert.Equal(t, "v_missing", drift.Drifts[0].Object.Name)
+	assert.True(t, drift.Drifts[0].Missing)
+}
+
+func TestApplyView_SQLite_IdempotentReplaceBody(t *testing.T) {
+	// ApplyView on SQLite issues DROP IF EXISTS + CREATE — running it twice
+	// against the same declared body must succeed, and running it after the
+	// body changes must update the live view to match.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, active INTEGER)`)
+	v1 := NewView("v_t", "SELECT id FROM t WHERE active = 1")
+	require.NoError(t, ApplyView(ctx, db, d, v1))
+	require.NoError(t, ApplyView(ctx, db, d, v1))
+
+	v2 := NewView("v_t", "SELECT id FROM t WHERE active = 0")
+	require.NoError(t, ApplyView(ctx, db, d, v2))
+	require.NoError(t, ValidateView(ctx, db, d, v2))
+
+	// Validating against the original declaration now reports drift.
+	err := ValidateView(ctx, db, d, v1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrViewBodyDrift))
+}
+
+func TestApplyViews_SQLite_OrderRespected(t *testing.T) {
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	// v_outer reads v_inner, so v_inner must be created first; the helper
+	// must preserve caller-supplied order rather than re-sorting.
+	vInner := NewView("v_inner", "SELECT id FROM t")
+	vOuter := NewView("v_outer", "SELECT id FROM v_inner")
+
+	require.NoError(t, ApplyViews(ctx, db, d, vInner, vOuter))
+	require.NoError(t, ValidateView(ctx, db, d, vInner))
+	require.NoError(t, ValidateView(ctx, db, d, vOuter))
+}
+
+func openSQLiteForViewLifecycle(t *testing.T) (context.Context, *sql.DB, chuck.Dialect) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	return context.Background(), db, chuck.SQLiteDialect{}
+}
+
+func mustExec(t *testing.T, db *sql.DB, stmt string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), stmt)
+	require.NoError(t, err, stmt)
+}

--- a/schema/view_lifecycle_test.go
+++ b/schema/view_lifecycle_test.go
@@ -180,6 +180,33 @@ func TestApplyView_SQLite_IdempotentReplaceBody(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrViewBodyDrift))
 }
 
+func TestViewDriftError_Unwrap_AllBodyComparisonSkipped(t *testing.T) {
+	// When every drift is a Postgres-style body-comparison-skip, the aggregate
+	// error must unwrap to ErrViewBodyComparisonUnsupported so callers that
+	// want existence-only semantics on those engines can branch on the
+	// sentinel and treat it as success.
+	e := &ViewDriftError{Drifts: []ViewDrift{
+		{Object: chuck.ObjectName{Name: "v_a"}, BodyComparisonSkipped: true, Reason: "pg_get_viewdef canonicalization"},
+		{Object: chuck.ObjectName{Name: "v_b"}, BodyComparisonSkipped: true, Reason: "pg_get_viewdef canonicalization"},
+	}}
+	assert.True(t, errors.Is(e, ErrViewBodyComparisonUnsupported))
+	assert.False(t, errors.Is(e, ErrViewMissing))
+	assert.False(t, errors.Is(e, ErrViewBodyDrift))
+}
+
+func TestViewDriftError_Unwrap_Mixed_SkippedAndMissing_NoWrap(t *testing.T) {
+	// Mixed missing + body-comparison-skipped must not wrap either sentinel:
+	// the existence failure is a hard error and must not be hidden behind the
+	// existence-only escape hatch.
+	e := &ViewDriftError{Drifts: []ViewDrift{
+		{Object: chuck.ObjectName{Name: "v_a"}, Missing: true},
+		{Object: chuck.ObjectName{Name: "v_b"}, BodyComparisonSkipped: true},
+	}}
+	assert.False(t, errors.Is(e, ErrViewMissing))
+	assert.False(t, errors.Is(e, ErrViewBodyDrift))
+	assert.False(t, errors.Is(e, ErrViewBodyComparisonUnsupported))
+}
+
 func TestApplyViews_SQLite_OrderRespected(t *testing.T) {
 	ctx, db, d := openSQLiteForViewLifecycle(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary

Adds dedicated `Apply*` and `Validate*` helpers for owned views and owned procedures, kept deliberately separate from the table `Ensure()` / `DiffSchema()` covenant.

- **Tables stay strict** — drift is always an error, nothing is auto-migrated. No change to `Ensure`, `DiffSchema`, `ValidateSchema`.
- **Views and procedures are code-objects** — callers usually want them to track the declaration the same way application code tracks source, so the package exposes explicit verb helpers that callers invoke intentionally in bootstrap code.

## New API

View lane (all dialects):
- `ApplyView` / `ApplyViews`
- `ValidateView` / `ValidateViews`
- `LiveViewBody` (introspection escape hatch)
- `ViewDrift`, `ViewDriftError`, `ErrViewMissing`, `ErrViewBodyDrift`

Procedure lane (MSSQL only):
- `ApplyProcedure` / `ApplyProcedures`
- `ValidateProcedure` / `ValidateProcedures`
- `LiveProcedureDefinition`
- `ProcedureDrift`, `ProcedureDriftError`, `ErrProcedureMissing`, `ErrProcedureDefinitionDrift`

## Behavior

`Apply*` is one-way (declared overwrites live), idempotent on Postgres/MSSQL via CREATE OR REPLACE/ALTER and effectively idempotent on SQLite via DROP IF EXISTS + CREATE. No pre-flight drift check — callers wanting validate-then-apply call `Validate*` first.

`Validate*` confirms existence and, where the engine stores definitions verbatim, also confirms body/definition text matches after canonical normalization (whitespace collapse, trailing-semicolon strip, CREATE-preamble strip):

| Object    | Engine   | Existence | Body / definition comparison                                                                       |
| --------- | -------- | --------- | -------------------------------------------------------------------------------------------------- |
| View      | SQLite   | yes       | yes (`sqlite_master.sql` stored verbatim)                                                          |
| View      | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                 |
| View      | Postgres | yes       | **skipped** — `pg_get_viewdef` canonicalizes too aggressively for honest textual comparison        |
| Procedure | MSSQL    | yes       | yes (`sys.sql_modules.definition` stored verbatim)                                                 |
| Procedure | other    | n/a       | returns `ErrProcedureDialectUnsupported`                                                           |

Drift errors aggregate one entry per offending object and unwrap to a single sentinel when every drift in the batch shares the same cause (missing-only or body-only). Mixed-cause aggregates intentionally do not unwrap to either sentinel — callers can't be misled when the real failure mode is heterogeneous.

## Tests

- Unit coverage for `stripCreateViewPreamble`, `stripCreateProcedurePreamble`, `canonicalizeViewBody`, drift-error sentinel unwrapping (missing-only, body-only, mixed).
- SQLite end-to-end validate/apply for views: apply → validate clean → out-of-band drift stomp → validate detects → re-apply → validate clean.
- Procedure unsupported-dialect guard tests for Postgres + SQLite (single and batch paths).
- MSSQL integration test gated by `CHUCK_MSSQL_URL` covering missing → apply → validate clean → out-of-band drift → re-apply → clean.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [ ] Live MSSQL integration via `CHUCK_MSSQL_URL` (skipped by default; runs in environments where the env var is set)
- [ ] Postgres existence-only validate path exercised against a live database (manual verification by reviewer if desired)