### PR TITLE
feat(dbrepo): UpdateBuilder.SetValues positional-bind opt-out (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ Before chuck: hand-roll WHERE clauses, duplicate column lists, maintain separate
 
 After chuck: `dbrepo.NewWhere().NotDeleted().HasStatus("active")`.
 
-The `dbrepo` package provides composable helpers that keep SQL visible. Functions use `@Name` placeholders with `sql.Named()` for dialect-agnostic parameter binding.
+The `dbrepo` package provides composable helpers that keep SQL visible. By default, the named fragment helpers (`SetClause`, `Placeholders`, `InsertInto`, `UpsertInto`, etc.) and `UpdateBuilder` emit `@Name` placeholders paired with `sql.Named()`. This works directly against `database/sql` drivers that translate `sql.NamedArg` into native parameter syntax (e.g. `mattn/go-sqlite3`, `microsoft/go-mssqldb`, `jackc/pgx`), but it is **not** universally driver-agnostic: `lib/pq` and `sqlx.Rebind` do not understand `@Name` tokens, so callers on that stack must use the positional-bind escape hatches (`BulkInsertInto`, `UpdateBuilder.SetValues` -- see [UpdateBuilder](#updatebuilder)).
 
 ### Building Queries
 
@@ -1166,6 +1166,30 @@ query, args := ub.Build()
 Chain `.Returning("id")` for Postgres/SQLite RETURNING clause support (no-op on MSSQL).
 
 WhereBuilder's semantic filters are most valuable here -- accidentally updating soft-deleted rows is a real bug that `.NotDeleted()` prevents.
+
+#### Positional bind opt-out (`SetValues`)
+
+The default `@Name` SET clause is opaque to `lib/pq` and to `sqlx.Rebind` (issue [#71](https://github.com/catgoose/chuck/issues/71)). Call `.SetValues(...)` to opt the SET clause out of `@Name` placeholders and into positional `?` placeholders that survive `sqlx.Rebind`:
+
+```go
+query, args := dbrepo.NewUpdate("accounts", "last_digest_sent_at").
+    WithDialect(pgDialect).
+    SetValues(time.Now()).
+    Where(dbrepo.NewWhere().And("id = ?", accountID)).
+    Build()
+// query: UPDATE "accounts" SET "last_digest_sent_at" = ? WHERE id = ?
+// args:  [time.Now(), accountID]
+
+// Feed it through sqlx.Rebind for lib/pq:
+result, err := db.ExecContext(ctx, sqlx.Rebind(sqlx.DOLLAR, query), args...)
+```
+
+Contract:
+
+- SET values are supplied in column-declaration order (the order passed to `NewUpdate`); `Build` panics if the count does not match the column count.
+- Returned args slice is `<SET values...> <WHERE args...>`. WHERE conditions are caller-supplied -- use `?` placeholders inside `NewWhere().And(...)` fragments so `sqlx.Rebind` rewrites SET and WHERE together.
+- Dialect identifier quoting (`WithDialect`) still applies to column identifiers; only the placeholder shape changes.
+- The default named-placeholder path is unchanged when `SetValues` is not called.
 
 ### DeleteBuilder
 

--- a/dbrepo/example_test.go
+++ b/dbrepo/example_test.go
@@ -248,6 +248,25 @@ func ExampleUpsertIntoQ() {
 	// INSERT INTO "users" ("email", "name", "age") VALUES (@Email, @Name, @Age) ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name", "age" = EXCLUDED."age"
 }
 
+func ExampleUpdateBuilder_SetValues() {
+	// SetValues opts out of the default @Name placeholders and into
+	// positional `?` placeholders, prepending the supplied SET values to
+	// the args slice. This is the path for callers that route their query
+	// through sqlx.Rebind / lib/pq, which do not understand @Name tokens.
+	d, _ := chuck.New(chuck.Postgres)
+	query, args := dbrepo.NewUpdate("accounts", "last_digest_sent_at").
+		WithDialect(d).
+		SetValues("2026-05-18T00:00:00Z").
+		Where(dbrepo.NewWhere().And("id = ?", 42)).
+		Build()
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// UPDATE "accounts" SET "last_digest_sent_at" = ? WHERE id = ?
+	// [2026-05-18T00:00:00Z 42]
+}
+
 func ExampleBuildOrderByClause() {
 	columnMap := map[string]string{
 		"name":       "Name",

--- a/dbrepo/fragments.go
+++ b/dbrepo/fragments.go
@@ -1,17 +1,24 @@
 // Package dbrepo provides composable SQL fragment helpers for building queries.
 //
-// Functions in this package use @Name placeholders (e.g., @ID, @Name) which rely on
-// database/sql's sql.Named() for driver-level parameter translation. This is distinct
-// from the chuck.Dialect.Placeholder() method which returns engine-specific positional
-// syntax ($1, ?, @p1) for raw SQL composition.
+// Most helpers in this package use @Name placeholders (e.g., @ID, @Name) which
+// rely on database/sql's sql.Named() for driver-level parameter translation.
+// This is distinct from the chuck.Dialect.Placeholder() method which returns
+// engine-specific positional syntax ($1, ?, @p1) for raw SQL composition.
 //
-// The @Name convention works because database/sql drivers translate sql.NamedArg values
-// into their native parameter syntax at execution time. This means dbrepo output is
-// dialect-agnostic — the same query string works across all engines when paired with
-// sql.Named() arguments.
+// The @Name convention works on database/sql drivers that translate
+// sql.NamedArg into native parameter syntax — mattn/go-sqlite3,
+// microsoft/go-mssqldb, and jackc/pgx all do this. It does NOT work on
+// lib/pq, which leaves @Name tokens verbatim, and it does not survive
+// sqlx.Rebind, which only recognizes ? and :name. Callers on those stacks
+// should use the positional-bind escape hatches:
 //
-// For identifier quoting, use the Q-suffixed variants (ColumnsQ, SetClauseQ, InsertIntoQ)
-// which accept a chuck.Dialect and quote table/column names via QuoteIdentifier.
+//   - BulkInsertInto: dialect-positional placeholders for INSERT batches.
+//   - UpdateBuilder.SetValues: opt-out from @Name on UPDATE statements,
+//     emitting ? placeholders that survive sqlx.Rebind.
+//
+// For identifier quoting, use the Q-suffixed variants (ColumnsQ, SetClauseQ,
+// InsertIntoQ) which accept a chuck.Dialect and quote table/column names via
+// QuoteIdentifier.
 package dbrepo
 
 import (

--- a/dbrepo/update_builder.go
+++ b/dbrepo/update_builder.go
@@ -9,11 +9,13 @@ import (
 
 // UpdateBuilder constructs composable UPDATE queries with SET, WHERE, and RETURNING clauses.
 type UpdateBuilder struct {
-	table     string
-	cols      []string
-	where     *WhereBuilder
-	returning []string
-	dialect   chuck.Dialect
+	table      string
+	cols       []string
+	setValues  []any
+	positional bool
+	where      *WhereBuilder
+	returning  []string
+	dialect    chuck.Dialect
 }
 
 // NewUpdate creates a new UpdateBuilder for the given table and columns.
@@ -44,16 +46,52 @@ func (u *UpdateBuilder) Returning(cols ...string) *UpdateBuilder {
 	return u
 }
 
+// SetValues opts UpdateBuilder out of the default `SET col = @col` named
+// placeholders and into positional `?` placeholders. values must be supplied
+// in the same order as the columns passed to NewUpdate; Build will panic if
+// len(values) != len(columns). The returned args slice from Build then begins
+// with these SET values followed by the WHERE-clause args.
+//
+// This is the escape hatch for callers that route their query through
+// sqlx.Rebind / lib/pq, where the default `@Name` token does not survive the
+// driver layer. WHERE conditions are caller-supplied: use `?` placeholders
+// inside WhereBuilder.And / Or fragments so they pass through Rebind cleanly
+// alongside the SET clause. Dialect identifier quoting (WithDialect) still
+// applies to the column identifiers; only the placeholder shape changes.
+func (u *UpdateBuilder) SetValues(values ...any) *UpdateBuilder {
+	u.setValues = values
+	u.positional = true
+	return u
+}
+
 // Build returns the complete SQL query string and the collected arguments.
+//
+// Default (named) mode: SET clause uses `@Name` placeholders and the returned
+// args slice contains only the WHERE-clause args; callers supply SET values
+// separately via sql.Named / NamedArgs.
+//
+// Positional mode (after SetValues): SET clause uses `?` placeholders and the
+// returned args slice begins with the supplied SET values in column order,
+// followed by the WHERE-clause args. Panics if the number of SetValues does
+// not match the number of columns supplied to NewUpdate.
 func (u *UpdateBuilder) Build() (query string, args []any) {
 	var parts []string
 
 	tableName := u.table
 	var setClause string
-	if u.dialect != nil {
+	switch {
+	case u.positional:
+		if len(u.setValues) != len(u.cols) {
+			panic(fmt.Sprintf("dbrepo: UpdateBuilder.SetValues count (%d) does not match column count (%d)", len(u.setValues), len(u.cols)))
+		}
+		if u.dialect != nil {
+			tableName = quoteTable(u.dialect, u.table)
+		}
+		setClause = positionalSetClause(u.dialect, u.cols)
+	case u.dialect != nil:
 		tableName = quoteTable(u.dialect, u.table)
 		setClause = SetClauseQ(u.dialect, u.cols...)
-	} else {
+	default:
 		setClause = SetClause(u.cols...)
 	}
 
@@ -63,7 +101,10 @@ func (u *UpdateBuilder) Build() (query string, args []any) {
 		parts = append(parts, u.where.String())
 	}
 
-	args = u.where.Args()
+	if u.positional {
+		args = append(args, u.setValues...)
+	}
+	args = append(args, u.where.Args()...)
 
 	if len(u.returning) > 0 && u.dialect != nil {
 		rc := u.dialect.ReturningClause(Columns(u.returning...))
@@ -73,4 +114,21 @@ func (u *UpdateBuilder) Build() (query string, args []any) {
 	}
 
 	return strings.Join(parts, " "), args
+}
+
+// positionalSetClause builds a SET fragment using `?` placeholders. Column
+// identifiers are dialect-quoted when d is non-nil so callers retain quoting
+// across the positional path; the placeholder is always `?` because the path
+// targets sqlx.Rebind-style rewriting (which converts `?` to the engine's
+// native positional syntax at execution time).
+func positionalSetClause(d chuck.Dialect, cols []string) string {
+	parts := make([]string, len(cols))
+	for i, c := range cols {
+		if d != nil {
+			parts[i] = fmt.Sprintf("%s = ?", d.QuoteIdentifier(d.NormalizeIdentifier(c)))
+		} else {
+			parts[i] = c + " = ?"
+		}
+	}
+	return strings.Join(parts, ", ")
 }

--- a/dbrepo/update_builder_test.go
+++ b/dbrepo/update_builder_test.go
@@ -101,3 +101,104 @@ func TestUpdateBuilder(t *testing.T) {
 		assert.Len(t, args, 1)
 	})
 }
+
+func TestUpdateBuilder_SetValues_Positional(t *testing.T) {
+	t.Run("no_dialect_emits_question_placeholders", func(t *testing.T) {
+		q, args := NewUpdate("Users", "Name", "Email").
+			SetValues("Alice", "alice@chuck.rock").
+			Build()
+		assert.Equal(t, "UPDATE Users SET Name = ?, Email = ?", q)
+		assert.Equal(t, []any{"Alice", "alice@chuck.rock"}, args)
+	})
+
+	t.Run("with_where_set_args_before_where_args", func(t *testing.T) {
+		// Issue #71 scenario: opt-out lets callers feed UpdateBuilder output
+		// through sqlx.Rebind. SET values must precede WHERE args in args
+		// slice so positional rewriting binds correctly.
+		w := NewWhere().And("id = ?", 42)
+		q, args := NewUpdate("accounts", "last_digest_sent_at").
+			SetValues("2026-05-18T00:00:00Z").
+			Where(w).
+			Build()
+		assert.Equal(t, "UPDATE accounts SET last_digest_sent_at = ? WHERE id = ?", q)
+		assert.Equal(t, []any{"2026-05-18T00:00:00Z", 42}, args)
+	})
+
+	t.Run("postgres_dialect_preserves_quoting", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, args := NewUpdate("Users", "Name", "Email").
+			WithDialect(d).
+			SetValues("Alice", "alice@chuck.rock").
+			Build()
+		assert.Equal(t, `UPDATE "users" SET "name" = ?, "email" = ?`, q)
+		assert.Equal(t, []any{"Alice", "alice@chuck.rock"}, args)
+	})
+
+	t.Run("mssql_dialect_preserves_quoting", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, _ := NewUpdate("Users", "Name").
+			WithDialect(d).
+			SetValues("Alice").
+			Build()
+		assert.Equal(t, "UPDATE [Users] SET [Name] = ?", q)
+	})
+
+	t.Run("sqlite_dialect_preserves_quoting", func(t *testing.T) {
+		d := chuck.SQLiteDialect{}
+		q, _ := NewUpdate("Users", "Name").
+			WithDialect(d).
+			SetValues("Alice").
+			Build()
+		assert.Equal(t, `UPDATE "Users" SET "Name" = ?`, q)
+	})
+
+	t.Run("returning_still_appended_in_positional_mode", func(t *testing.T) {
+		d := chuck.PostgresDialect{}
+		q, args := NewUpdate("Users", "Name").
+			WithDialect(d).
+			SetValues("Alice").
+			Where(NewWhere().And("id = ?", 7)).
+			Returning("ID", "Name").
+			Build()
+		assert.Equal(t, `UPDATE "users" SET "name" = ? WHERE id = ? RETURNING ID, Name`, q)
+		assert.Equal(t, []any{"Alice", 7}, args)
+	})
+
+	t.Run("schema_qualified_table_still_quoted", func(t *testing.T) {
+		d := chuck.MSSQLDialect{}
+		q, args := NewUpdate("sg.SalesAgents", "Name").
+			WithDialect(d).
+			SetValues("Gobo").
+			Where(NewWhere().And("ID = ?", 1)).
+			Build()
+		assert.Equal(t, "UPDATE [sg].[SalesAgents] SET [Name] = ? WHERE ID = ?", q)
+		assert.Equal(t, []any{"Gobo", 1}, args)
+	})
+
+	t.Run("zero_set_values_with_zero_cols_is_legal", func(t *testing.T) {
+		// Degenerate edge case: caller wires SetValues path with empty column
+		// list. Should not panic and should emit an empty SET clause; this
+		// proves the length check is symmetric, not min-arity-1.
+		q, args := NewUpdate("Users").SetValues().Build()
+		assert.Equal(t, "UPDATE Users SET ", q)
+		assert.Empty(t, args)
+	})
+
+	t.Run("mismatched_set_values_panics", func(t *testing.T) {
+		assert.PanicsWithValue(t,
+			"dbrepo: UpdateBuilder.SetValues count (1) does not match column count (2)",
+			func() {
+				_, _ = NewUpdate("Users", "Name", "Email").
+					SetValues("Alice").
+					Build()
+			})
+	})
+
+	t.Run("default_named_path_unchanged", func(t *testing.T) {
+		// Regression guard: confirm that not calling SetValues leaves the
+		// existing @Name contract intact.
+		q, args := NewUpdate("Users", "Name", "Email").Build()
+		assert.Equal(t, "UPDATE Users SET Name = @Name, Email = @Email", q)
+		assert.Empty(t, args)
+	})
+}


### PR DESCRIPTION
## Summary

Closes #71.

`dbrepo.UpdateBuilder` unconditionally emitted `SET col = @col` placeholders. The `@Name` token survives `database/sql` drivers that translate `sql.NamedArg` natively (`mattn/go-sqlite3`, `microsoft/go-mssqldb`, `jackc/pgx`) but does not survive `lib/pq` or `sqlx.Rebind` — leaving the `@col` token verbatim, which Postgres then rejects on parse. Callers on the `lib/pq + sqlx` stack had no escape hatch for the UPDATE path (issue #71 ShopMaint repro).

## New API

Additive method on `UpdateBuilder`:

```go
query, args := dbrepo.NewUpdate("accounts", "last_digest_sent_at").
    WithDialect(pgDialect).
    SetValues(time.Now()).
    Where(dbrepo.NewWhere().And("id = ?", accountID)).
    Build()
// query: UPDATE "accounts" SET "last_digest_sent_at" = ? WHERE id = ?
// args:  [time.Now(), accountID]

result, err := db.ExecContext(ctx, sqlx.Rebind(sqlx.DOLLAR, query), args...)
```

## Contract

- `len(values)` must match `len(columns)` from `NewUpdate`; `Build` panics on mismatch rather than silently emitting a malformed statement.
- Returned args slice is `<SET values...> <WHERE args...>` — SET first so `sqlx.Rebind` rewrites left-to-right against deterministic input.
- Dialect identifier quoting (`WithDialect`) still applies to column identifiers; only the placeholder shape changes.
- Placeholder is always `?` independent of dialect; the path targets `sqlx.Rebind`-style rewriting.
- Default `@Name` behavior is untouched. Existing callers see no behavior change unless they explicitly call `SetValues`.

## Behavior matrix

| Caller did                          | SET clause                | args returned                |
|------------------------------------|---------------------------|------------------------------|
| (nothing — default)                | `col = @col`              | `<WHERE args>`               |
| `.WithDialect(d)`                  | `"col" = @col`            | `<WHERE args>`               |
| `.SetValues(v1, v2)`               | `col = ?, col = ?`        | `<v1, v2, WHERE args>`       |
| `.WithDialect(d).SetValues(v1)`    | `"col" = ?`               | `<v1, WHERE args>`           |

## Tests

`TestUpdateBuilder_SetValues_Positional` covers nine subtests: `?` emission, SET-before-WHERE arg ordering, per-dialect quoting (Postgres / MSSQL / SQLite), `RETURNING` composition, schema-qualified table quoting, the zero-cols/zero-values edge, the count-mismatch panic, and a regression guard that the default `@Name` path is unchanged. `ExampleUpdateBuilder_SetValues` added for godoc.

## Docs

- `dbrepo/fragments.go` package doc: previous claim that "dbrepo output is dialect-agnostic — the same query string works across all engines" was overstated. Replaced with the truth (works on go-sqlite3/go-mssqldb/pgx; does NOT work on lib/pq or sqlx.Rebind) and a pointer to the positional escape hatches.
- `README.md`: matching correction at the top of the `dbrepo` section; new "Positional bind opt-out (`SetValues`)" subsection under UpdateBuilder.

## Test plan

- [x] `go test ./...` (all green)
- [x] `golangci-lint run --timeout=5m ./...` (0 issues)
- [x] New positional unit tests pass; default named tests untouched