### PR TITLE
feat(schema): opt-in ownership notice for owned views and procedures (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Chuck does not provide a generalized object-graph scheduler that hides this orde
 
 #### Opt-in ownership notice
 
-Owned views and procedures can carry an embedded "owned by chuck" notice so DB-side readers (an operator inspecting `sqlite_master.sql` or `sys.sql_modules.definition`) can tell the object is code-owned. The notice is **opt-in**, set once in a `schema.CodeObjectOptions` struct, and passed to the `*WithOptions` variants of the apply/validate helpers — there is no per-definition boilerplate:
+Owned views and procedures can carry an embedded "owned by https://github.com/catgoose/chuck" notice so DB-side readers (an operator inspecting `sqlite_master.sql` or `sys.sql_modules.definition`) can tell the object is code-owned and find the project directly. The notice is **opt-in**, set once in a `schema.CodeObjectOptions` struct, and passed to the `*WithOptions` variants of the apply/validate helpers — there is no per-definition boilerplate:
 
 ```go
 opts := schema.CodeObjectOptions{

--- a/README.md
+++ b/README.md
@@ -586,6 +586,42 @@ if dialect.Engine() == chuck.MSSQL {
 
 Chuck does not provide a generalized object-graph scheduler that hides this ordering, because the dependency chain on top of an owned table set is almost always short and linear and a scheduler abstraction would obscure more than it would help. Pick the order in code; the helpers preserve it.
 
+#### Opt-in ownership notice
+
+Owned views and procedures can carry an embedded "owned by chuck" notice so DB-side readers (an operator inspecting `sqlite_master.sql` or `sys.sql_modules.definition`) can tell the object is code-owned. The notice is **opt-in**, set once in a `schema.CodeObjectOptions` struct, and passed to the `*WithOptions` variants of the apply/validate helpers — there is no per-definition boilerplate:
+
+```go
+opts := schema.CodeObjectOptions{
+    OwnershipNotice: schema.DefaultOwnershipNotice,
+}
+
+if err := schema.ApplyViewsWithOptions(ctx, db, dialect, opts, views...); err != nil {
+    return err
+}
+if err := schema.ValidateViewsWithOptions(ctx, db, dialect, opts, views...); err != nil {
+    return err
+}
+
+if dialect.Engine() == chuck.MSSQL {
+    if err := schema.ApplyProceduresWithOptions(ctx, db, dialect, opts, procs...); err != nil {
+        return err
+    }
+    if err := schema.ValidateProceduresWithOptions(ctx, db, dialect, opts, procs...); err != nil {
+        return err
+    }
+}
+```
+
+The rendered notice is a SQL block comment (`/* ... */`) prepended to the view body or procedure definition payload. `schema.DefaultOwnershipNotice` is intentionally soft -- it says out-of-band changes "may" fail validation or be overwritten because the `Validate*` and `Apply*` lanes are explicit and Postgres view validation is existence-only. Callers can supply any string they like.
+
+Coherence contract: the same options struct must be used for `Apply*WithOptions` and `Validate*WithOptions`. Mixing the bare helpers with the option-aware ones (e.g. apply with options, validate without) will report drift because the live body now contains the comment the bare declared body does not. The bare `ApplyView` / `ValidateView` / `ApplyProcedure` / `ValidateProcedure` helpers are unchanged: they continue to operate on the raw declared body / definition and emit no comment.
+
+Engine notes:
+
+- **SQLite** stores the view text verbatim in `sqlite_master.sql`, so the comment is fully visible there.
+- **MSSQL** stores both view and procedure text verbatim in `sys.sql_modules.definition`.
+- **Postgres** `pg_get_viewdef` reconstructs the SELECT from the parse tree and discards comments, so the notice will be present in the `CREATE OR REPLACE VIEW` statement chuck issues but will not be visible when an operator reads `pg_get_viewdef` output. This does not produce false drift because Postgres view validation is existence-only (`ErrViewBodyComparisonUnsupported`).
+
 ### Schema Snapshots
 
 Export the declared schema in structured or text format for diffing:

--- a/schema/code_object_options.go
+++ b/schema/code_object_options.go
@@ -1,0 +1,78 @@
+package schema
+
+// CodeObjectOptions controls option-aware rendering and validation for owned
+// code objects (ViewDef, ProcedureDef). The zero value preserves the default
+// no-notice behavior so existing callers see no change unless they explicitly
+// pass a populated CodeObjectOptions to the *WithOptions helpers.
+//
+// The intended usage is one central config built once in bootstrap and passed
+// to ApplyViewsWithOptions / ValidateViewsWithOptions / ApplyProceduresWithOptions
+// / ValidateProceduresWithOptions, rather than repeated per-definition
+// boilerplate:
+//
+//	opts := schema.CodeObjectOptions{
+//	    OwnershipNotice: schema.DefaultOwnershipNotice,
+//	}
+//	if err := schema.ApplyViewsWithOptions(ctx, db, d, opts, views...); err != nil {
+//	    return err
+//	}
+//	if err := schema.ValidateViewsWithOptions(ctx, db, d, opts, views...); err != nil {
+//	    return err
+//	}
+type CodeObjectOptions struct {
+	// OwnershipNotice is an opt-in soft notice the option-aware Apply* /
+	// Validate* helpers prepend to the rendered view body or procedure
+	// definition as a SQL block comment. When empty (the default) nothing is
+	// emitted, matching the existing zero-option Apply* / Validate* behavior.
+	//
+	// Validate-side coherence: the option-aware Validate* helpers prepend the
+	// same notice to the declared body / definition before canonicalization,
+	// so apply followed by validate-with-the-same-options does not report
+	// false drift. Callers must use the same options struct for apply and
+	// validate, or invoke the bare Apply* / Validate* helpers (which compare
+	// against the raw declared body) together.
+	//
+	// Engine notes:
+	//   - SQLite: comment survives in sqlite_master.sql.
+	//   - MSSQL:  comment survives in sys.sql_modules.definition.
+	//   - Postgres: pg_get_viewdef discards comments when it reconstructs the
+	//     SELECT, so the notice will land in the live CREATE statement but
+	//     will not be visible when an operator reads pg_get_viewdef output.
+	//     This does not produce false drift because Postgres view validation
+	//     is existence-only (see ErrViewBodyComparisonUnsupported).
+	OwnershipNotice string
+}
+
+// DefaultOwnershipNotice is the canonical chuck-owned ownership notice text
+// suggested by issue #84. Deliberately soft: it says out-of-band changes
+// "may" fail validation or be overwritten because the explicit Validate* /
+// Apply* lanes leave that choice to the caller, and Postgres view validation
+// is existence-only today (see ErrViewBodyComparisonUnsupported), so a
+// stronger promise would be dishonest.
+const DefaultOwnershipNotice = "Owned by chuck. Do not edit in database.\n" +
+	"Out-of-band changes may fail validation or be overwritten by apply/bootstrap."
+
+// renderOwnershipComment formats a notice as a SQL block comment, or returns
+// "" when no notice is set. Engine-agnostic `/* ... */` syntax is accepted by
+// SQLite, MSSQL, and Postgres at the body / definition payload positions where
+// chuck injects it.
+func renderOwnershipComment(notice string) string {
+	if notice == "" {
+		return ""
+	}
+	return "/* " + notice + " */"
+}
+
+// applyOwnershipNoticePrefix returns the body or definition payload prefixed
+// with a rendered ownership comment when one is set, otherwise the payload
+// unchanged. A single space separates the comment from the payload to keep
+// the resulting statement well-formed regardless of whether the payload
+// starts with a SELECT keyword (views), a parameter declaration (procedures),
+// or an AS keyword (zero-parameter procedures).
+func applyOwnershipNoticePrefix(payload string, opts CodeObjectOptions) string {
+	comment := renderOwnershipComment(opts.OwnershipNotice)
+	if comment == "" {
+		return payload
+	}
+	return comment + " " + payload
+}

--- a/schema/code_object_options.go
+++ b/schema/code_object_options.go
@@ -48,8 +48,10 @@ type CodeObjectOptions struct {
 // "may" fail validation or be overwritten because the explicit Validate* /
 // Apply* lanes leave that choice to the caller, and Postgres view validation
 // is existence-only today (see ErrViewBodyComparisonUnsupported), so a
-// stronger promise would be dishonest.
-const DefaultOwnershipNotice = "Owned by chuck. Do not edit in database.\n" +
+// stronger promise would be dishonest. The notice embeds the chuck GitHub
+// URL rather than the bare project name so DB readers who do not know what
+// "chuck" is can find the project directly.
+const DefaultOwnershipNotice = "Owned by https://github.com/catgoose/chuck. Do not edit in database.\n" +
 	"Out-of-band changes may fail validation or be overwritten by apply/bootstrap."
 
 // renderOwnershipComment formats a notice as a SQL block comment, or returns

--- a/schema/code_object_options_test.go
+++ b/schema/code_object_options_test.go
@@ -30,7 +30,7 @@ func TestRenderOwnershipComment(t *testing.T) {
 		got := renderOwnershipComment(DefaultOwnershipNotice)
 		assert.True(t, strings.HasPrefix(got, "/* "))
 		assert.True(t, strings.HasSuffix(got, " */"))
-		assert.Contains(t, got, "Owned by chuck")
+		assert.Contains(t, got, "Owned by https://github.com/catgoose/chuck")
 		assert.Contains(t, got, "may fail validation")
 	})
 }

--- a/schema/code_object_options_test.go
+++ b/schema/code_object_options_test.go
@@ -1,0 +1,137 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderOwnershipComment(t *testing.T) {
+	t.Run("empty notice returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", renderOwnershipComment(""))
+	})
+
+	t.Run("non-empty notice wraps in block comment", func(t *testing.T) {
+		got := renderOwnershipComment("hello world")
+		assert.Equal(t, "/* hello world */", got)
+	})
+
+	t.Run("multi-line notice survives unchanged", func(t *testing.T) {
+		got := renderOwnershipComment("line1\nline2")
+		assert.Equal(t, "/* line1\nline2 */", got)
+	})
+
+	t.Run("DefaultOwnershipNotice renders into well-formed block comment", func(t *testing.T) {
+		got := renderOwnershipComment(DefaultOwnershipNotice)
+		assert.True(t, strings.HasPrefix(got, "/* "))
+		assert.True(t, strings.HasSuffix(got, " */"))
+		assert.Contains(t, got, "Owned by chuck")
+		assert.Contains(t, got, "may fail validation")
+	})
+}
+
+func TestApplyOwnershipNoticePrefix(t *testing.T) {
+	t.Run("zero options leaves payload untouched", func(t *testing.T) {
+		got := applyOwnershipNoticePrefix("SELECT 1", CodeObjectOptions{})
+		assert.Equal(t, "SELECT 1", got)
+	})
+
+	t.Run("non-empty notice is prepended with single space separator", func(t *testing.T) {
+		got := applyOwnershipNoticePrefix("SELECT 1",
+			CodeObjectOptions{OwnershipNotice: "hello"})
+		assert.Equal(t, "/* hello */ SELECT 1", got)
+	})
+
+	t.Run("proc-style payload (leading param) is preserved verbatim", func(t *testing.T) {
+		// Procedures put parameter declarations first, before AS; the comment
+		// must sit before the parameter list without corrupting it.
+		got := applyOwnershipNoticePrefix("@AgentID INT AS BEGIN SELECT 1 END",
+			CodeObjectOptions{OwnershipNotice: "owned"})
+		assert.Equal(t, "/* owned */ @AgentID INT AS BEGIN SELECT 1 END", got)
+	})
+}
+
+func TestApplyViewWithOptions_DefaultPathUnchanged(t *testing.T) {
+	// Regression guard: the zero CodeObjectOptions must produce the same DDL
+	// that ApplyView issued before this feature existed. We don't have a live
+	// DB here; we compare the rendered statement slice directly.
+	v := NewView("v_x", "SELECT 1")
+	d := chuck.SQLiteDialect{}
+	got := v.createOrReplaceWithBody(d, applyOwnershipNoticePrefix(v.Body(), CodeObjectOptions{}))
+	want := []string{
+		"DROP VIEW IF EXISTS \"v_x\"",
+		"CREATE VIEW \"v_x\" AS SELECT 1",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestApplyViewWithOptions_NoticeRendersIntoBody(t *testing.T) {
+	v := NewView("v_x", "SELECT 1")
+	opts := CodeObjectOptions{OwnershipNotice: "owned"}
+	got := v.createOrReplaceWithBody(chuck.SQLiteDialect{},
+		applyOwnershipNoticePrefix(v.Body(), opts))
+	want := []string{
+		"DROP VIEW IF EXISTS \"v_x\"",
+		"CREATE VIEW \"v_x\" AS /* owned */ SELECT 1",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestApplyViewWithOptions_NoticeRendersForMSSQLAndPostgres(t *testing.T) {
+	v := NewQualifiedView("sg", "v_x", "SELECT 1")
+	opts := CodeObjectOptions{OwnershipNotice: "owned"}
+	body := applyOwnershipNoticePrefix(v.Body(), opts)
+
+	mssql := v.createOrReplaceWithBody(chuck.MSSQLDialect{}, body)
+	assert.Equal(t, []string{"CREATE OR ALTER VIEW [sg].[v_x] AS /* owned */ SELECT 1"}, mssql)
+
+	pg := v.createOrReplaceWithBody(chuck.PostgresDialect{}, body)
+	assert.Equal(t, []string{`CREATE OR REPLACE VIEW "sg"."v_x" AS /* owned */ SELECT 1`}, pg)
+}
+
+func TestApplyProcedureWithOptions_NoticeRendersIntoDefinition(t *testing.T) {
+	p := NewQualifiedProcedure("sg", "usp_X",
+		"@AgentID INT AS BEGIN SET NOCOUNT ON; SELECT 1 END")
+	opts := CodeObjectOptions{OwnershipNotice: "owned"}
+	definition := applyOwnershipNoticePrefix(p.Definition(), opts)
+	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [sg].[usp_X] /* owned */ @AgentID INT AS BEGIN SET NOCOUNT ON; SELECT 1 END",
+		stmt)
+}
+
+func TestApplyProcedureWithOptions_DefaultPathUnchanged(t *testing.T) {
+	// Regression guard: the zero CodeObjectOptions must produce the same DDL
+	// that ApplyProcedure issued before this feature existed.
+	p := NewProcedure("usp_X", "AS BEGIN SELECT 1 END")
+	definition := applyOwnershipNoticePrefix(p.Definition(), CodeObjectOptions{})
+	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [usp_X] AS BEGIN SELECT 1 END",
+		stmt)
+}
+
+func TestApplyProcedureWithOptions_UnsupportedDialectStillErrs(t *testing.T) {
+	// The options-aware path must keep the same engine guard: bootstrap on a
+	// non-MSSQL dialect must fail loud rather than silently emit a SQLite or
+	// Postgres procedure statement.
+	p := NewProcedure("usp_X", "AS BEGIN SELECT 1 END")
+	err := ApplyProcedureWithOptions(context.Background(), nil, chuck.PostgresDialect{},
+		CodeObjectOptions{OwnershipNotice: DefaultOwnershipNotice}, p)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}
+
+func TestValidateProceduresWithOptions_UnsupportedDialect(t *testing.T) {
+	err := ValidateProceduresWithOptions(context.Background(), nil, chuck.SQLiteDialect{},
+		CodeObjectOptions{OwnershipNotice: DefaultOwnershipNotice})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProcedureDialectUnsupported))
+}

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -492,7 +492,7 @@ func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_on_open").
 		Scan(&liveSQL))
-	assert.Contains(t, liveSQL, "Owned by chuck")
+	assert.Contains(t, liveSQL, "Owned by https://github.com/catgoose/chuck")
 	assert.Contains(t, liveSQL, "may fail validation or be overwritten")
 
 	// Bare ValidateView (no opts) must see the live notice as body drift,
@@ -549,7 +549,7 @@ func TestProcedureValidateApplyWithOptions_MSSQL(t *testing.T) {
 	live, exists, err := schema.LiveProcedureDefinition(ctx, db, d, proc)
 	require.NoError(t, err)
 	require.True(t, exists)
-	require.Contains(t, live, "Owned by chuck")
+	require.Contains(t, live, "Owned by https://github.com/catgoose/chuck")
 	require.Contains(t, live, "may fail validation or be overwritten")
 
 	// Bare ValidateProcedure (no opts) must see the live notice as drift.

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -451,3 +451,117 @@ func TestProcedureValidateApply_MSSQL(t *testing.T) {
 	require.NoError(t, schema.ApplyProcedure(ctx, db, d, proc))
 	require.NoError(t, schema.ValidateProcedure(ctx, db, d, proc))
 }
+
+// TestViewValidateApplyWithOptions_SQLite_OwnershipNotice asserts the
+// opt-in ownership-notice path is internally coherent on SQLite, which
+// stores view text verbatim in sqlite_master.sql and therefore lets us
+// observe the comment landed in the live object.
+//
+// Coherence requirements covered:
+//
+//   - apply-with-options + validate-with-same-options is clean
+//   - the rendered comment is visible in sqlite_master.sql
+//   - bare ValidateView (no opts) sees apply-with-options as drift, because
+//     the live body now contains the notice the declared body does not
+//   - bare ApplyView re-renders without the comment and validate-with-opts
+//     then sees that as drift, proving the contract is symmetric
+func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE vva_on_tasks (id INTEGER PRIMARY KEY, done INTEGER)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS vva_on_tasks`) }()
+
+	v := schema.NewView("v_vva_on_open", "SELECT id FROM vva_on_tasks WHERE done = 0")
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	opts := schema.CodeObjectOptions{OwnershipNotice: schema.DefaultOwnershipNotice}
+
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, opts, v))
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, v),
+		"apply-with-options must pair cleanly with validate-with-same-options")
+
+	// Live body in sqlite_master must contain the rendered ownership notice
+	// so DB-side readers can see the chuck-owned marker.
+	var liveSQL string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_on_open").
+		Scan(&liveSQL))
+	assert.Contains(t, liveSQL, "Owned by chuck")
+	assert.Contains(t, liveSQL, "may fail validation or be overwritten")
+
+	// Bare ValidateView (no opts) must see the live notice as body drift,
+	// proving apply and validate must use the same options to stay coherent.
+	err = schema.ValidateView(ctx, db, d, v)
+	require.Error(t, err, "bare ValidateView must report drift when live body carries an apply-only notice")
+	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+
+	// Switching to bare ApplyView strips the comment from the live body,
+	// and validate-with-options now sees drift in the opposite direction.
+	require.NoError(t, schema.ApplyView(ctx, db, d, v))
+	require.NoError(t, schema.ValidateView(ctx, db, d, v),
+		"bare apply + bare validate must still be coherent")
+	err = schema.ValidateViewWithOptions(ctx, db, d, opts, v)
+	require.Error(t, err, "validate-with-options must report drift when live body lost its notice")
+	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+}
+
+// TestProcedureValidateApplyWithOptions_MSSQL gates on a live MSSQL instance
+// because MSSQL is the only engine with first-class procedure ownership in
+// this release. Proves apply-with-options + validate-with-same-options is
+// coherent and that the rendered comment lands in sys.sql_modules.definition.
+func TestProcedureValidateApplyWithOptions_MSSQL(t *testing.T) {
+	dsn := os.Getenv("CHUCK_MSSQL_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_MSSQL_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	proc := schema.NewProcedure("usp_chuck_vva_proc_notice",
+		"@Probe INT = 1 AS BEGIN SET NOCOUNT ON; SELECT @Probe AS Probe; END")
+
+	if stmt, derr := proc.DropSQL(d); derr == nil {
+		_, _ = db.ExecContext(ctx, stmt)
+	}
+	defer func() {
+		if stmt, derr := proc.DropSQL(d); derr == nil {
+			_, _ = db.ExecContext(ctx, stmt)
+		}
+	}()
+
+	opts := schema.CodeObjectOptions{OwnershipNotice: schema.DefaultOwnershipNotice}
+
+	require.NoError(t, schema.ApplyProcedureWithOptions(ctx, db, d, opts, proc))
+	require.NoError(t, schema.ValidateProcedureWithOptions(ctx, db, d, opts, proc),
+		"apply-with-options must pair cleanly with validate-with-same-options")
+
+	// Confirm the live definition carries the comment so operators reading
+	// sys.sql_modules see the chuck-owned marker.
+	live, exists, err := schema.LiveProcedureDefinition(ctx, db, d, proc)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Contains(t, live, "Owned by chuck")
+	require.Contains(t, live, "may fail validation or be overwritten")
+
+	// Bare ValidateProcedure (no opts) must see the live notice as drift.
+	err = schema.ValidateProcedure(ctx, db, d, proc)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schema.ErrProcedureDefinitionDrift)
+
+	// Bare ApplyProcedure strips the notice; validate-with-options then
+	// reports drift in the opposite direction.
+	require.NoError(t, schema.ApplyProcedure(ctx, db, d, proc))
+	require.NoError(t, schema.ValidateProcedure(ctx, db, d, proc))
+	err = schema.ValidateProcedureWithOptions(ctx, db, d, opts, proc)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schema.ErrProcedureDefinitionDrift)
+}

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -114,10 +114,23 @@ func (p *ProcedureDef) QualifiedNameFor(d chuck.Dialect) string {
 //
 // Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
 func (p *ProcedureDef) CreateOrAlterSQL(d chuck.Dialect) (string, error) {
+	return p.createOrAlterWithDefinition(d, p.definition)
+}
+
+// createOrAlterWithDefinition renders the same dialect-idiomatic
+// CREATE OR ALTER PROCEDURE statement as CreateOrAlterSQL, but with a
+// caller-supplied definition override. Used by the option-aware Apply /
+// Validate helpers to inject an ownership notice into the definition payload
+// without mutating the underlying ProcedureDef. The injected notice sits in a
+// grammar-safe position (between the qualified name and the first token of
+// the caller-supplied definition) because T-SQL accepts `/* ... */` block
+// comments wherever whitespace is legal — including before parameter
+// declarations and the AS keyword.
+func (p *ProcedureDef) createOrAlterWithDefinition(d chuck.Dialect, definition string) (string, error) {
 	if d.Engine() != chuck.MSSQL {
 		return "", fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
-	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s %s", p.QualifiedNameFor(d), p.definition), nil
+	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s %s", p.QualifiedNameFor(d), definition), nil
 }
 
 // DropSQL returns a single safe `DROP PROCEDURE` statement that probes

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -146,7 +146,21 @@ func stripCreateProcedurePreamble(s string) string {
 // Returns nil on match. Returns a `*ProcedureDriftError` whose Drifts slice
 // has exactly one entry when the procedure is missing or its definition
 // differs. Returns ErrProcedureDialectUnsupported on non-MSSQL dialects.
+//
+// ValidateProcedure is a thin wrapper around ValidateProcedureWithOptions
+// that passes the zero CodeObjectOptions; callers that opt into an ownership
+// notice during apply must use ValidateProcedureWithOptions with the same
+// options struct to avoid false drift.
 func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *ProcedureDef) error {
+	return ValidateProcedureWithOptions(ctx, db, d, CodeObjectOptions{}, p)
+}
+
+// ValidateProcedureWithOptions is the option-aware counterpart to
+// ValidateProcedure. When opts.OwnershipNotice is set, the declared
+// definition is prefixed with the rendered ownership comment before
+// canonical comparison so apply and validate stay coherent under the same
+// options.
+func ValidateProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
@@ -161,7 +175,8 @@ func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Proc
 			Reason:  "procedure does not exist",
 		}}}
 	}
-	declaredCanon := canonicalizeViewBody(p.Definition())
+	declared := applyOwnershipNoticePrefix(p.Definition(), opts)
+	declaredCanon := canonicalizeViewBody(declared)
 	liveCanon := canonicalizeViewBody(live)
 	if declaredCanon == liveCanon {
 		return nil
@@ -179,12 +194,19 @@ func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Proc
 // any drift into a single `*ProcedureDriftError`. Infrastructure errors and
 // unsupported-dialect errors short-circuit and are returned directly.
 func ValidateProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs ...*ProcedureDef) error {
+	return ValidateProceduresWithOptions(ctx, db, d, CodeObjectOptions{}, procs...)
+}
+
+// ValidateProceduresWithOptions is the option-aware counterpart to
+// ValidateProcedures. See ValidateProcedureWithOptions for the per-procedure
+// semantics; aggregation behavior is identical to ValidateProcedures.
+func ValidateProceduresWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, procs ...*ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
 	var drifts []ProcedureDrift
 	for _, p := range procs {
-		err := ValidateProcedure(ctx, db, d, p)
+		err := ValidateProcedureWithOptions(ctx, db, d, opts, p)
 		if err == nil {
 			continue
 		}
@@ -210,8 +232,24 @@ func ValidateProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs 
 // Returns ErrProcedureDialectUnsupported on non-MSSQL dialects. ApplyProcedure
 // is one-way: declared definition becomes live definition. It does no
 // pre-flight drift check.
+//
+// ApplyProcedure is a thin wrapper around ApplyProcedureWithOptions that
+// passes the zero CodeObjectOptions; use ApplyProcedureWithOptions to opt
+// into an ownership-notice prefix.
 func ApplyProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *ProcedureDef) error {
-	stmt, err := p.CreateOrAlterSQL(d)
+	return ApplyProcedureWithOptions(ctx, db, d, CodeObjectOptions{}, p)
+}
+
+// ApplyProcedureWithOptions is the option-aware counterpart to
+// ApplyProcedure. When opts.OwnershipNotice is set, the definition rendered
+// into the live MSSQL database is prefixed with the corresponding T-SQL
+// block comment, sitting between the qualified procedure name and the first
+// token of the caller's definition payload. Callers that use this path
+// should pair it with ValidateProcedureWithOptions (same opts) to keep apply
+// and validate coherent.
+func ApplyProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef) error {
+	definition := applyOwnershipNoticePrefix(p.Definition(), opts)
+	stmt, err := p.createOrAlterWithDefinition(d, definition)
 	if err != nil {
 		return err
 	}
@@ -224,11 +262,17 @@ func ApplyProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Procedu
 // ApplyProcedures applies each declared procedure in caller-supplied order.
 // Returns the first error encountered.
 func ApplyProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs ...*ProcedureDef) error {
+	return ApplyProceduresWithOptions(ctx, db, d, CodeObjectOptions{}, procs...)
+}
+
+// ApplyProceduresWithOptions is the option-aware counterpart to
+// ApplyProcedures.
+func ApplyProceduresWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, procs ...*ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
 	for _, p := range procs {
-		if err := ApplyProcedure(ctx, db, d, p); err != nil {
+		if err := ApplyProcedureWithOptions(ctx, db, d, opts, p); err != nil {
 			return err
 		}
 	}

--- a/schema/view.go
+++ b/schema/view.go
@@ -93,21 +93,29 @@ func (v *ViewDef) CreateSQL(d chuck.Dialect) string {
 // statement, which matches how the rest of chuck emits MSSQL DDL (one
 // statement per Exec).
 func (v *ViewDef) CreateOrReplaceSQL(d chuck.Dialect) []string {
+	return v.createOrReplaceWithBody(d, v.body)
+}
+
+// createOrReplaceWithBody renders the same dialect-idiomatic create-or-replace
+// statements as CreateOrReplaceSQL, but with a caller-supplied body override.
+// Used by the option-aware Apply / Validate helpers to inject an ownership
+// notice into the body payload without mutating the underlying ViewDef.
+func (v *ViewDef) createOrReplaceWithBody(d chuck.Dialect, body string) []string {
 	qt := v.QualifiedNameFor(d)
 	switch d.Engine() {
 	case chuck.Postgres:
-		return []string{fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", qt, v.body)}
+		return []string{fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", qt, body)}
 	case chuck.MSSQL:
-		return []string{fmt.Sprintf("CREATE OR ALTER VIEW %s AS %s", qt, v.body)}
+		return []string{fmt.Sprintf("CREATE OR ALTER VIEW %s AS %s", qt, body)}
 	case chuck.SQLite:
 		return []string{
 			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
-			fmt.Sprintf("CREATE VIEW %s AS %s", qt, v.body),
+			fmt.Sprintf("CREATE VIEW %s AS %s", qt, body),
 		}
 	default:
 		return []string{
 			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
-			fmt.Sprintf("CREATE VIEW %s AS %s", qt, v.body),
+			fmt.Sprintf("CREATE VIEW %s AS %s", qt, body),
 		}
 	}
 }

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -273,7 +273,21 @@ func canonicalizeViewBody(s string) string {
 // `errors.Is(err, ErrViewBodyComparisonUnsupported)` and treat it as success;
 // callers that need stricter body assertions should fetch `LiveViewBody` and
 // run their own comparison.
+//
+// ValidateView is a thin wrapper around ValidateViewWithOptions that passes
+// the zero CodeObjectOptions, so callers that opt into an ownership notice
+// during apply must use ValidateViewWithOptions with the same options struct
+// to avoid false drift.
 func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) error {
+	return ValidateViewWithOptions(ctx, db, d, CodeObjectOptions{}, v)
+}
+
+// ValidateViewWithOptions is the option-aware counterpart to ValidateView.
+// When opts.OwnershipNotice is set, the declared body is prefixed with the
+// rendered ownership comment before canonical comparison, so apply with the
+// same options followed by validate with the same options does not report
+// false drift.
+func ValidateViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef) error {
 	live, exists, err := LiveViewBody(ctx, db, d, v)
 	if err != nil {
 		return err
@@ -285,16 +299,17 @@ func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) 
 			Reason:  "view does not exist",
 		}}}
 	}
+	declared := applyOwnershipNoticePrefix(v.Body(), opts)
 	if d.Engine() == chuck.Postgres {
 		return &ViewDriftError{Drifts: []ViewDrift{{
 			Object:                v.Object(),
 			BodyComparisonSkipped: true,
-			DeclaredBody:          v.Body(),
+			DeclaredBody:          declared,
 			LiveBody:              live,
 			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
 		}}}
 	}
-	declaredCanon := canonicalizeViewBody(v.Body())
+	declaredCanon := canonicalizeViewBody(declared)
 	liveCanon := canonicalizeViewBody(live)
 	if declaredCanon == liveCanon {
 		return nil
@@ -312,9 +327,16 @@ func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) 
 // into a single `*ViewDriftError`. Infrastructure errors short-circuit and
 // are returned directly. Returns nil if every view matches.
 func ValidateViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*ViewDef) error {
+	return ValidateViewsWithOptions(ctx, db, d, CodeObjectOptions{}, views...)
+}
+
+// ValidateViewsWithOptions is the option-aware counterpart to ValidateViews.
+// See ValidateViewWithOptions for the per-view semantics; aggregation behavior
+// is identical to ValidateViews.
+func ValidateViewsWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, views ...*ViewDef) error {
 	var drifts []ViewDrift
 	for _, v := range views {
-		err := ValidateView(ctx, db, d, v)
+		err := ValidateViewWithOptions(ctx, db, d, opts, v)
 		if err == nil {
 			continue
 		}
@@ -340,8 +362,22 @@ func ValidateViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*V
 // pre-flight drift check; callers that want validate-then-apply semantics
 // should call ValidateView themselves first and only apply when drift is
 // detected.
+//
+// ApplyView is a thin wrapper around ApplyViewWithOptions that passes the
+// zero CodeObjectOptions; use ApplyViewWithOptions to opt into an
+// ownership-notice prefix.
 func ApplyView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) error {
-	for _, stmt := range v.CreateOrReplaceSQL(d) {
+	return ApplyViewWithOptions(ctx, db, d, CodeObjectOptions{}, v)
+}
+
+// ApplyViewWithOptions is the option-aware counterpart to ApplyView. When
+// opts.OwnershipNotice is set, the body rendered into the live database is
+// prefixed with the corresponding SQL block comment so DB-side readers can
+// see the chuck-owned marker. Callers that use this path should pair it with
+// ValidateViewWithOptions (same opts) to keep apply and validate coherent.
+func ApplyViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef) error {
+	body := applyOwnershipNoticePrefix(v.Body(), opts)
+	for _, stmt := range v.createOrReplaceWithBody(d, body) {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("schema: apply view %q: %w", objectKey(v.Object()), err)
 		}
@@ -353,8 +389,13 @@ func ApplyView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) err
 // the first error encountered; partial application up to that point is left
 // in place (matching the rest of chuck's no-implicit-rollback stance).
 func ApplyViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*ViewDef) error {
+	return ApplyViewsWithOptions(ctx, db, d, CodeObjectOptions{}, views...)
+}
+
+// ApplyViewsWithOptions is the option-aware counterpart to ApplyViews.
+func ApplyViewsWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, views ...*ViewDef) error {
 	for _, v := range views {
-		if err := ApplyView(ctx, db, d, v); err != nil {
+		if err := ApplyViewWithOptions(ctx, db, d, opts, v); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #84.

Owned views and procedures can now carry an embedded "owned by chuck" notice so DB-side readers see the chuck-owned marker. The notice is **opt-in**, set once on a `schema.CodeObjectOptions` struct, and consumed by new `*WithOptions` apply/validate helpers — no per-definition boilerplate, no package-global state, no behavior change for existing callers.

## New API

```go
opts := schema.CodeObjectOptions{
    OwnershipNotice: schema.DefaultOwnershipNotice,
}

// Views (all dialects):
schema.ApplyViewsWithOptions(ctx, db, dialect, opts, views...)
schema.ValidateViewsWithOptions(ctx, db, dialect, opts, views...)

// Procedures (MSSQL only):
schema.ApplyProceduresWithOptions(ctx, db, dialect, opts, procs...)
schema.ValidateProceduresWithOptions(ctx, db, dialect, opts, procs...)
```

`schema.DefaultOwnershipNotice` is the canonical soft wording from issue #84:

```
Owned by chuck. Do not edit in database.
Out-of-band changes may fail validation or be overwritten by apply/bootstrap.
```

Callers can substitute any string.

## Coherence contract

- The same `CodeObjectOptions` struct must be used for `Apply*WithOptions` and `Validate*WithOptions` — otherwise the live body will contain a comment the bare declared body does not, and validate will honestly report drift.
- Bare `ApplyView` / `ValidateView` / `ApplyProcedure` / `ValidateProcedure` are unchanged: they delegate to the new helpers with the zero `CodeObjectOptions`, so the default no-notice path stays a single code path.
- Mixing bare and option-aware helpers (apply with options, validate without) is supported and reports drift truthfully — proven by the SQLite e2e test which exercises both directions.

## Injection points (grammar-safe)

- **Views**: `CREATE OR REPLACE VIEW <qn> AS /* notice */ <body>` (Postgres) / `CREATE OR ALTER VIEW <qn> AS /* notice */ <body>` (MSSQL) / `DROP VIEW IF EXISTS <qn>; CREATE VIEW <qn> AS /* notice */ <body>` (SQLite).
- **Procedures (MSSQL)**: `CREATE OR ALTER PROCEDURE <qn> /* notice */ @param INT AS BEGIN ... END`. T-SQL accepts block comments anywhere whitespace is legal, so the comment sits cleanly before the parameter declarations and before AS.

## Engine visibility

| Engine    | Notice visible to operator?                                                                                  |
|-----------|--------------------------------------------------------------------------------------------------------------|
| SQLite    | yes — `sqlite_master.sql` stores verbatim                                                                    |
| MSSQL     | yes — `sys.sql_modules.definition` stores verbatim                                                           |
| Postgres  | **no** — `pg_get_viewdef` reconstructs SELECT and discards comments. Notice lands in CREATE statement but is invisible via pg_get_viewdef. No false drift because Postgres view validation is existence-only (`ErrViewBodyComparisonUnsupported`). |

## Tests

- `schema/code_object_options_test.go` — unit coverage: `renderOwnershipComment`, `applyOwnershipNoticePrefix`, default-path regression (view + procedure renderers), notice-bearing render across SQLite / MSSQL / Postgres dialects, engine-guard preservation on `ApplyProcedureWithOptions` / `ValidateProceduresWithOptions`.
- `schema/integration_test.go`:
  - `TestViewValidateApplyWithOptions_SQLite_OwnershipNotice` — full SQLite cycle: apply-with-opts + validate-with-opts clean; comment present in `sqlite_master.sql`; bare validate sees option-apply as drift; bare re-apply strips comment; validate-with-opts then reports drift the other way.
  - `TestProcedureValidateApplyWithOptions_MSSQL` — same cycle for MSSQL procedures, gated by `CHUCK_MSSQL_URL`.

## Test plan

- [x] `go test ./...` (all green)
- [x] `golangci-lint run --timeout=5m ./...` (0 issues)
- [x] Default no-notice path tests unchanged (regression guards green)
- [ ] MSSQL gated integration test requires reviewer/CI with `CHUCK_MSSQL_URL` to exercise the live procedure path