### PR TITLE
refactor(schema): rename canonicalizeViewBody to canonicalizeStatement (#89)

### DIFF
--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -178,8 +178,8 @@ func ValidateProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Diale
 		}}}
 	}
 	liveStripped := stripConfiguredApplyPrefix(live, opts)
-	declaredCanon := canonicalizeViewBody(p.Definition())
-	liveCanon := canonicalizeViewBody(liveStripped)
+	declaredCanon := canonicalizeStatement(p.Definition())
+	liveCanon := canonicalizeStatement(liveStripped)
 	if declaredCanon == liveCanon {
 		return nil
 	}

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -226,11 +226,12 @@ func stripCreateViewPreamble(s string) string {
 	return s[loc[1]:]
 }
 
-// canonicalizeViewBody normalizes a view body for drift comparison. It trims
-// surrounding whitespace, strips trailing semicolons, and collapses runs of
-// internal whitespace (including newlines/tabs) to a single space. The result
-// is the comparable form — not a roundtrippable SQL string.
-func canonicalizeViewBody(s string) string {
+// canonicalizeStatement normalizes a SQL statement body for drift comparison.
+// Used for both view bodies and procedure definitions. It trims surrounding
+// whitespace, strips trailing semicolons, and collapses runs of internal
+// whitespace (including newlines/tabs) to a single space. The result is the
+// comparable form — not a roundtrippable SQL string.
+func canonicalizeStatement(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimRight(s, ";")
 	s = strings.TrimSpace(s)
@@ -311,8 +312,8 @@ func ValidateViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, o
 		}}}
 	}
 	liveStripped := stripConfiguredApplyPrefix(live, opts)
-	declaredCanon := canonicalizeViewBody(v.Body())
-	liveCanon := canonicalizeViewBody(liveStripped)
+	declaredCanon := canonicalizeStatement(v.Body())
+	liveCanon := canonicalizeStatement(liveStripped)
 	if declaredCanon == liveCanon {
 		return nil
 	}

--- a/schema/view_lifecycle_test.go
+++ b/schema/view_lifecycle_test.go
@@ -56,7 +56,7 @@ func TestStripCreateViewPreamble(t *testing.T) {
 	}
 }
 
-func TestCanonicalizeViewBody(t *testing.T) {
+func TestCanonicalizeStatement(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
@@ -70,7 +70,7 @@ func TestCanonicalizeViewBody(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, canonicalizeViewBody(tc.in))
+			assert.Equal(t, tc.want, canonicalizeStatement(tc.in))
 		})
 	}
 }
@@ -125,7 +125,7 @@ func TestValidateView_SQLite_BodyDrift(t *testing.T) {
 }
 
 func TestValidateView_SQLite_WhitespaceTolerant(t *testing.T) {
-	// canonicalizeViewBody collapses whitespace, so a declared body with
+	// canonicalizeStatement collapses whitespace, so a declared body with
 	// different indentation than the live body must still validate as match.
 	ctx, db, d := openSQLiteForViewLifecycle(t)
 	defer db.Close()


### PR DESCRIPTION
Closes #89.

## Summary

Rename `canonicalizeViewBody` -> `canonicalizeStatement` so the helper name matches actual use across both view-body and procedure-definition drift comparison (audit finding F3).

## Details

- `schema/view_lifecycle.go`: rename helper, update godoc to describe statement normalization (used for both views and procedures), update both call sites in `ValidateViewWithOptions`.
- `schema/procedure_lifecycle.go`: update both call sites in `ValidateProcedureWithOptions`.
- `schema/view_lifecycle_test.go`: rename `TestCanonicalizeViewBody` -> `TestCanonicalizeStatement`, update one explanatory comment.

No behavior change: same trim / trailing-semicolon strip / internal-whitespace collapse.

## Test plan

- [x] `go test ./...` — all green
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues