### PR TITLE
fix(dialect): escape embedded double quotes in SQLite/Postgres QuoteIdentifier (#87)

### DIFF
--- a/chuck_test.go
+++ b/chuck_test.go
@@ -261,6 +261,9 @@ func TestSQLiteDialect(t *testing.T) {
 	t.Run("QuoteIdentifier", func(t *testing.T) {
 		assert.Equal(t, `"Users"`, d.QuoteIdentifier("Users"))
 		assert.Equal(t, `"order"`, d.QuoteIdentifier("order"))
+		// Embedded double quote must be doubled so the quoted identifier
+		// parses cleanly under SQL standard rules.
+		assert.Equal(t, `"a""b"`, d.QuoteIdentifier(`a"b`))
 	})
 
 	t.Run("LastInsertID", func(t *testing.T) {
@@ -368,6 +371,9 @@ func TestPostgresDialect(t *testing.T) {
 	t.Run("QuoteIdentifier", func(t *testing.T) {
 		assert.Equal(t, `"Users"`, d.QuoteIdentifier("Users"))
 		assert.Equal(t, `"order"`, d.QuoteIdentifier("order"))
+		// Embedded double quote must be doubled so the quoted identifier
+		// parses cleanly under SQL standard rules.
+		assert.Equal(t, `"a""b"`, d.QuoteIdentifier(`a"b`))
 	})
 
 	t.Run("LastInsertID", func(t *testing.T) {

--- a/postgres.go
+++ b/postgres.go
@@ -48,7 +48,7 @@ func (PostgresDialect) NormalizeIdentifier(name string) string {
 }
 
 func (PostgresDialect) QuoteIdentifier(name string) string {
-	return `"` + name + `"`
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func (PostgresDialect) BigIntType() string  { return "BIGINT" }

--- a/sqlite.go
+++ b/sqlite.go
@@ -49,7 +49,7 @@ func (SQLiteDialect) ReturningClause(columns string) string {
 func (SQLiteDialect) NormalizeIdentifier(name string) string { return name }
 
 func (SQLiteDialect) QuoteIdentifier(name string) string {
-	return `"` + name + `"`
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func (SQLiteDialect) BigIntType() string  { return "INTEGER" }


### PR DESCRIPTION
Closes #87.

## Summary

`SQLiteDialect.QuoteIdentifier` and `PostgresDialect.QuoteIdentifier` previously wrapped the input in double quotes without escaping any embedded `"`. An identifier like `a"b` rendered as `"a"b"` — a quoted empty identifier followed by stray tokens, which the parser rejects.

Both implementations now double any embedded `"` so the rendered identifier conforms to SQL standard quoted-identifier rules. Mirrors the MSSQL bracket-escape policy (`]` → `]]`).

## Details

- `sqlite.go` / `postgres.go`: wrap `strings.ReplaceAll(name, "\"", "\"\"")` inside the existing `"…"` quoting.
- `chuck_test.go`: add `"a""b"` assertion to both SQLite and Postgres `QuoteIdentifier` subtests.
- MSSQL behavior unchanged.

## Test plan

- [x] `go test ./...` — all green
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues