### PR TITLE
feat(schema): declaration-owned per-object doc annotations (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,17 @@ if dialect.Engine() == chuck.MSSQL {
 - **`OwnershipNotice`** — apply-owned marker. `schema.DefaultOwnershipNotice` is intentionally soft (it says out-of-band changes "may" fail validation or be overwritten) because the `Validate*` / `Apply*` lanes are explicit and Postgres view validation is existence-only. Callers can supply any string.
 - **`DocPreamble`** — optional caller-controlled doc comment. Intended for purpose / contact / runbook links. **Not** treated as proof of ownership; it is metadata only.
 
-When both are set the rendered order is **`DocPreamble` first, then `OwnershipNotice`**, then the payload. Each non-empty field becomes a `/* ... */` SQL block comment followed by a single space. `Validate*WithOptions` strips this exact ordered prefix only; live text that begins with a different leading comment still reports drift.
+A third lane is **declaration-owned** and lives on the object itself:
+
+- **`ViewDef.WithDocAnnotation(text)` / `ProcedureDef.WithDocAnnotation(text)`** — per-object doc comment carried by the declaration. Unlike `DocPreamble` (which is shared across many objects and apply-owned), the annotation is part of the object's own declared identity: it renders into the live SQL **and** participates in body-drift comparison, so changing the text in code produces validation drift against a live object rendered from the prior annotation.
+
+```go
+v := schema.NewView("v_open_tasks",
+    "SELECT id FROM tasks WHERE done = 0").
+    WithDocAnnotation("v_open_tasks v1: returns currently-open task ids")
+```
+
+When all three are set the rendered order is **`DocPreamble`, then declaration-owned annotation, then `OwnershipNotice`**, then the payload. Each non-empty segment becomes a `/* ... */` SQL block comment followed by a single space. `Validate*WithOptions` strips the apply-owned segments (`DocPreamble` + `OwnershipNotice`) in their declared slots, retains the declaration-owned annotation in canonical comparison, and reports drift when the annotation in live SQL differs from the annotation in code. Live text that begins with a different leading comment still reports drift.
 
 Apply-owned tolerance, summarized:
 
@@ -628,6 +638,15 @@ Apply-owned tolerance, summarized:
 | Raw declared body + configured prefix (preamble + notice) | drift | pass |
 | Raw declared body + a different leading comment | drift | drift |
 | Raw declared body + stale configured prefix that no longer matches `opts` | drift | drift |
+
+Declaration-owned drift (per-object `WithDocAnnotation`):
+
+| Declared annotation vs. live annotation | `ValidateViewWithOptions(opts)` |
+| --- | --- |
+| Same text in code and live SQL | pass |
+| Annotation changed in code (live still has prior text) | drift |
+| Annotation added in code (live has no annotation) | drift |
+| Annotation removed in code (live still carries old annotation) | drift |
 
 Bare `ApplyView` / `ValidateView` / `ApplyProcedure` / `ValidateProcedure` are unchanged: they neither inject nor tolerate markers.
 

--- a/schema/code_object_options.go
+++ b/schema/code_object_options.go
@@ -13,6 +13,12 @@ import "strings"
 // Validate*WithOptions. Validate-only callers may pass options without
 // forcing the markers to exist in the live database.
 //
+// For per-object documentation that should be declaration-owned — part of
+// the object's own SQL identity and a drift signal when changed — use
+// ViewDef.WithDocAnnotation / ProcedureDef.WithDocAnnotation instead. The
+// declaration-owned annotation renders between DocPreamble and
+// OwnershipNotice in the live SQL and is included in body-drift comparison.
+//
 // Intended usage is one central config built once in bootstrap and passed
 // to ApplyViewsWithOptions / ValidateViewsWithOptions /
 // ApplyProceduresWithOptions / ValidateProceduresWithOptions rather than
@@ -29,12 +35,13 @@ import "strings"
 //	    return err
 //	}
 //
-// Render order when both fields are set: DocPreamble first, then
-// OwnershipNotice, then payload. Each non-empty field is rendered as a
-// `/* ... */` SQL block comment followed by a single space. Validate*WithOptions
-// strips this exact ordered prefix from the live text before canonical
-// comparison; live text that begins with a different leading comment will
-// still report drift.
+// Render order when fields are set: DocPreamble first, then any per-object
+// declaration-owned doc annotation, then OwnershipNotice, then payload. Each
+// non-empty segment is rendered as a `/* ... */` SQL block comment followed
+// by a single space. Validate*WithOptions strips this exact ordered prefix
+// from the live text before canonical comparison (keeping the
+// declaration-owned annotation, which participates in comparison); live text
+// that begins with a different leading comment will still report drift.
 type CodeObjectOptions struct {
 	// OwnershipNotice is an opt-in apply-owned marker the option-aware Apply*
 	// helpers prepend to the rendered view body or procedure definition as a
@@ -93,12 +100,17 @@ func renderOwnershipComment(notice string) string {
 
 // renderApplyPrefix returns the full configured comment prefix that
 // Apply*WithOptions prepends to the rendered body / definition payload.
-// DocPreamble is rendered first, then OwnershipNotice; each non-empty field
-// contributes a `/* ... */ ` segment (block comment plus single trailing
-// space). When both fields are empty, returns "".
-func renderApplyPrefix(opts CodeObjectOptions) string {
+// Render order: DocPreamble (apply-owned), declared per-object annotation
+// (declaration-owned), OwnershipNotice (apply-owned). Each non-empty
+// segment contributes a `/* ... */ ` chunk (block comment plus single
+// trailing space). When all three are empty, returns "".
+func renderApplyPrefix(opts CodeObjectOptions, declaredAnnotation string) string {
 	var b strings.Builder
 	if c := renderOwnershipComment(opts.DocPreamble); c != "" {
+		b.WriteString(c)
+		b.WriteByte(' ')
+	}
+	if c := renderOwnershipComment(declaredAnnotation); c != "" {
 		b.WriteString(c)
 		b.WriteByte(' ')
 	}
@@ -115,8 +127,14 @@ func renderApplyPrefix(opts CodeObjectOptions) string {
 // segment to keep the resulting statement well-formed regardless of whether
 // the payload starts with a SELECT keyword (views), a parameter declaration
 // (procedures), or an AS keyword (zero-parameter procedures).
-func applyOwnershipNoticePrefix(payload string, opts CodeObjectOptions) string {
-	prefix := renderApplyPrefix(opts)
+//
+// declaredAnnotation is the per-object declaration-owned doc annotation
+// (ViewDef.DocAnnotation / ProcedureDef.DocAnnotation); pass "" when not
+// declared. When non-empty it is rendered between the caller-level
+// DocPreamble and the caller-level OwnershipNotice so callers reading the
+// live SQL see preamble → per-object annotation → ownership.
+func applyOwnershipNoticePrefix(payload string, opts CodeObjectOptions, declaredAnnotation string) string {
+	prefix := renderApplyPrefix(opts, declaredAnnotation)
 	if prefix == "" {
 		return payload
 	}
@@ -124,24 +142,33 @@ func applyOwnershipNoticePrefix(payload string, opts CodeObjectOptions) string {
 }
 
 // stripConfiguredApplyPrefix strips the exact configured DocPreamble and
-// OwnershipNotice comment prefixes (in that order) from the front of live
-// text, plus any leading whitespace, returning the remainder. When a
-// configured prefix is not present the function leaves the text unchanged
-// for that segment — a configured-but-absent marker is tolerated so
-// validate-only callers can pass options without forcing markers into the
-// live object. When no fields are configured, the function returns live
-// unchanged.
-func stripConfiguredApplyPrefix(live string, opts CodeObjectOptions) string {
+// OwnershipNotice comment prefixes from the front of live text in their
+// declared render order, plus any leading whitespace. When a per-object
+// declaration-owned doc annotation is declared, it is recognized in its
+// natural slot (between DocPreamble and OwnershipNotice) and retained in
+// the returned string so it can participate in canonical drift comparison.
+// Configured-but-absent apply-owned markers are tolerated; an absent or
+// mismatched declaration-owned annotation reports as body drift because
+// declared identity has changed.
+func stripConfiguredApplyPrefix(live string, opts CodeObjectOptions, declaredAnnotation string) string {
+	docComment := renderOwnershipComment(opts.DocPreamble)
+	annComment := renderOwnershipComment(declaredAnnotation)
+	ownComment := renderOwnershipComment(opts.OwnershipNotice)
+
 	out := strings.TrimLeft(live, " \t\r\n")
-	if c := renderOwnershipComment(opts.DocPreamble); c != "" {
-		if strings.HasPrefix(out, c) {
-			out = strings.TrimLeft(out[len(c):], " \t\r\n")
-		}
+	if docComment != "" && strings.HasPrefix(out, docComment) {
+		out = strings.TrimLeft(out[len(docComment):], " \t\r\n")
 	}
-	if c := renderOwnershipComment(opts.OwnershipNotice); c != "" {
-		if strings.HasPrefix(out, c) {
-			out = strings.TrimLeft(out[len(c):], " \t\r\n")
-		}
+	kept := ""
+	if annComment != "" && strings.HasPrefix(out, annComment) {
+		kept = annComment
+		out = strings.TrimLeft(out[len(annComment):], " \t\r\n")
+	}
+	if ownComment != "" && strings.HasPrefix(out, ownComment) {
+		out = strings.TrimLeft(out[len(ownComment):], " \t\r\n")
+	}
+	if kept != "" {
+		return kept + " " + out
 	}
 	return out
 }

--- a/schema/code_object_options_test.go
+++ b/schema/code_object_options_test.go
@@ -37,56 +37,73 @@ func TestRenderOwnershipComment(t *testing.T) {
 
 func TestApplyOwnershipNoticePrefix(t *testing.T) {
 	t.Run("zero options leaves payload untouched", func(t *testing.T) {
-		got := applyOwnershipNoticePrefix("SELECT 1", CodeObjectOptions{})
+		got := applyOwnershipNoticePrefix("SELECT 1", CodeObjectOptions{}, "")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
 	t.Run("notice-only is prepended with single space separator", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned"})
+			CodeObjectOptions{OwnershipNotice: "owned"}, "")
 		assert.Equal(t, "/* owned */ SELECT 1", got)
 	})
 
 	t.Run("doc-preamble-only is prepended with single space separator", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
-			CodeObjectOptions{DocPreamble: "doc"})
+			CodeObjectOptions{DocPreamble: "doc"}, "")
 		assert.Equal(t, "/* doc */ SELECT 1", got)
 	})
 
 	t.Run("both fields render in preamble-then-notice order", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"})
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "")
 		assert.Equal(t, "/* doc */ /* owned */ SELECT 1", got)
 	})
 
 	t.Run("proc-style payload (leading param) is preserved verbatim", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("@AgentID INT AS BEGIN SELECT 1 END",
-			CodeObjectOptions{OwnershipNotice: "owned"})
+			CodeObjectOptions{OwnershipNotice: "owned"}, "")
 		assert.Equal(t, "/* owned */ @AgentID INT AS BEGIN SELECT 1 END", got)
+	})
+
+	t.Run("declared annotation alone is prepended", func(t *testing.T) {
+		got := applyOwnershipNoticePrefix("SELECT 1", CodeObjectOptions{}, "ann")
+		assert.Equal(t, "/* ann */ SELECT 1", got)
+	})
+
+	t.Run("annotation renders between DocPreamble and OwnershipNotice", func(t *testing.T) {
+		got := applyOwnershipNoticePrefix("SELECT 1",
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "ann")
+		assert.Equal(t, "/* doc */ /* ann */ /* owned */ SELECT 1", got)
+	})
+
+	t.Run("annotation + notice (no preamble)", func(t *testing.T) {
+		got := applyOwnershipNoticePrefix("SELECT 1",
+			CodeObjectOptions{OwnershipNotice: "owned"}, "ann")
+		assert.Equal(t, "/* ann */ /* owned */ SELECT 1", got)
 	})
 }
 
 func TestStripConfiguredApplyPrefix(t *testing.T) {
 	t.Run("zero options leaves live unchanged", func(t *testing.T) {
 		assert.Equal(t, "SELECT 1",
-			stripConfiguredApplyPrefix("SELECT 1", CodeObjectOptions{}))
+			stripConfiguredApplyPrefix("SELECT 1", CodeObjectOptions{}, ""))
 	})
 
 	t.Run("exact configured notice is stripped", func(t *testing.T) {
 		got := stripConfiguredApplyPrefix("/* owned */ SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned"})
+			CodeObjectOptions{OwnershipNotice: "owned"}, "")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
 	t.Run("exact configured preamble is stripped", func(t *testing.T) {
 		got := stripConfiguredApplyPrefix("/* doc */ SELECT 1",
-			CodeObjectOptions{DocPreamble: "doc"})
+			CodeObjectOptions{DocPreamble: "doc"}, "")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
 	t.Run("both prefixes strip in preamble-then-notice order", func(t *testing.T) {
 		got := stripConfiguredApplyPrefix("/* doc */ /* owned */ SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"})
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
@@ -94,7 +111,7 @@ func TestStripConfiguredApplyPrefix(t *testing.T) {
 		// Live has an unconfigured leading comment. Strip must leave it
 		// in place so canonical compare reports drift.
 		got := stripConfiguredApplyPrefix("/* something else */ SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned"})
+			CodeObjectOptions{OwnershipNotice: "owned"}, "")
 		assert.Equal(t, "/* something else */ SELECT 1", got)
 	})
 
@@ -102,7 +119,7 @@ func TestStripConfiguredApplyPrefix(t *testing.T) {
 		// Live has no comment, options has notice. Strip is a no-op so
 		// canonical compare passes against raw declared body.
 		got := stripConfiguredApplyPrefix("SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned"})
+			CodeObjectOptions{OwnershipNotice: "owned"}, "")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
@@ -110,15 +127,47 @@ func TestStripConfiguredApplyPrefix(t *testing.T) {
 		// Live has notice before preamble (wrong order). Preamble strip
 		// fails, notice strip succeeds, leaving preamble in place.
 		got := stripConfiguredApplyPrefix("/* owned */ /* doc */ SELECT 1",
-			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"})
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "")
 		assert.Equal(t, "/* doc */ SELECT 1", got)
+	})
+
+	t.Run("declared annotation kept while apply-owned prefixes stripped", func(t *testing.T) {
+		got := stripConfiguredApplyPrefix(
+			"/* doc */ /* ann */ /* owned */ SELECT 1",
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "ann")
+		assert.Equal(t, "/* ann */ SELECT 1", got)
+	})
+
+	t.Run("annotation alone is kept", func(t *testing.T) {
+		got := stripConfiguredApplyPrefix("/* ann */ SELECT 1",
+			CodeObjectOptions{}, "ann")
+		assert.Equal(t, "/* ann */ SELECT 1", got)
+	})
+
+	t.Run("declared annotation missing in live yields drift signal", func(t *testing.T) {
+		// Live lacks the declared annotation entirely. Strip leaves the
+		// payload alone so canonical compare against
+		// `annotation + body` reports drift.
+		got := stripConfiguredApplyPrefix("SELECT 1",
+			CodeObjectOptions{}, "ann")
+		assert.Equal(t, "SELECT 1", got)
+	})
+
+	t.Run("declared annotation mismatched in live yields drift signal", func(t *testing.T) {
+		// Live carries a different annotation comment in the annotation
+		// slot; strip leaves it in place (not matching the declared
+		// annotation) and OwnershipNotice strip cannot proceed past it.
+		got := stripConfiguredApplyPrefix(
+			"/* doc */ /* not the ann */ /* owned */ SELECT 1",
+			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "ann")
+		assert.Equal(t, "/* not the ann */ /* owned */ SELECT 1", got)
 	})
 }
 
 func TestApplyViewWithOptions_DefaultPathUnchanged(t *testing.T) {
 	v := NewView("v_x", "SELECT 1")
 	d := chuck.SQLiteDialect{}
-	got := v.createOrReplaceWithBody(d, applyOwnershipNoticePrefix(v.Body(), CodeObjectOptions{}))
+	got := v.createOrReplaceWithBody(d, applyOwnershipNoticePrefix(v.Body(), CodeObjectOptions{}, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
 		"CREATE VIEW \"v_x\" AS SELECT 1",
@@ -130,7 +179,7 @@ func TestApplyViewWithOptions_NoticeRendersIntoBody(t *testing.T) {
 	v := NewView("v_x", "SELECT 1")
 	opts := CodeObjectOptions{OwnershipNotice: "owned"}
 	got := v.createOrReplaceWithBody(chuck.SQLiteDialect{},
-		applyOwnershipNoticePrefix(v.Body(), opts))
+		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
 		"CREATE VIEW \"v_x\" AS /* owned */ SELECT 1",
@@ -142,7 +191,7 @@ func TestApplyViewWithOptions_DocPreambleAndNoticeRender(t *testing.T) {
 	v := NewView("v_x", "SELECT 1")
 	opts := CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}
 	got := v.createOrReplaceWithBody(chuck.SQLiteDialect{},
-		applyOwnershipNoticePrefix(v.Body(), opts))
+		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
 		"CREATE VIEW \"v_x\" AS /* doc */ /* owned */ SELECT 1",
@@ -153,7 +202,7 @@ func TestApplyViewWithOptions_DocPreambleAndNoticeRender(t *testing.T) {
 func TestApplyViewWithOptions_NoticeRendersForMSSQLAndPostgres(t *testing.T) {
 	v := NewQualifiedView("sg", "v_x", "SELECT 1")
 	opts := CodeObjectOptions{OwnershipNotice: "owned"}
-	body := applyOwnershipNoticePrefix(v.Body(), opts)
+	body := applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation())
 
 	mssql := v.createOrReplaceWithBody(chuck.MSSQLDialect{}, body)
 	assert.Equal(t, []string{"CREATE OR ALTER VIEW [sg].[v_x] AS /* owned */ SELECT 1"}, mssql)
@@ -162,11 +211,34 @@ func TestApplyViewWithOptions_NoticeRendersForMSSQLAndPostgres(t *testing.T) {
 	assert.Equal(t, []string{`CREATE OR REPLACE VIEW "sg"."v_x" AS /* owned */ SELECT 1`}, pg)
 }
 
+func TestApplyViewWithOptions_DocAnnotationRendersBetweenPreambleAndNotice(t *testing.T) {
+	v := NewView("v_x", "SELECT 1").WithDocAnnotation("ann")
+	opts := CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}
+	got := v.createOrReplaceWithBody(chuck.SQLiteDialect{},
+		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
+	want := []string{
+		"DROP VIEW IF EXISTS \"v_x\"",
+		"CREATE VIEW \"v_x\" AS /* doc */ /* ann */ /* owned */ SELECT 1",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestApplyViewWithOptions_DocAnnotationAlone(t *testing.T) {
+	v := NewView("v_x", "SELECT 1").WithDocAnnotation("ann")
+	got := v.createOrReplaceWithBody(chuck.SQLiteDialect{},
+		applyOwnershipNoticePrefix(v.Body(), CodeObjectOptions{}, v.DocAnnotation()))
+	want := []string{
+		"DROP VIEW IF EXISTS \"v_x\"",
+		"CREATE VIEW \"v_x\" AS /* ann */ SELECT 1",
+	}
+	assert.Equal(t, want, got)
+}
+
 func TestApplyProcedureWithOptions_NoticeRendersIntoDefinition(t *testing.T) {
 	p := NewQualifiedProcedure("sg", "usp_X",
 		"@AgentID INT AS BEGIN SET NOCOUNT ON; SELECT 1 END")
 	opts := CodeObjectOptions{OwnershipNotice: "owned"}
-	definition := applyOwnershipNoticePrefix(p.Definition(), opts)
+	definition := applyOwnershipNoticePrefix(p.Definition(), opts, p.DocAnnotation())
 	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
 	require.NoError(t, err)
 	assert.Equal(t,
@@ -176,11 +248,23 @@ func TestApplyProcedureWithOptions_NoticeRendersIntoDefinition(t *testing.T) {
 
 func TestApplyProcedureWithOptions_DefaultPathUnchanged(t *testing.T) {
 	p := NewProcedure("usp_X", "AS BEGIN SELECT 1 END")
-	definition := applyOwnershipNoticePrefix(p.Definition(), CodeObjectOptions{})
+	definition := applyOwnershipNoticePrefix(p.Definition(), CodeObjectOptions{}, p.DocAnnotation())
 	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"CREATE OR ALTER PROCEDURE [usp_X] AS BEGIN SELECT 1 END",
+		stmt)
+}
+
+func TestApplyProcedureWithOptions_DocAnnotationRendersBetweenPreambleAndNotice(t *testing.T) {
+	p := NewQualifiedProcedure("sg", "usp_X",
+		"@AgentID INT AS BEGIN SELECT 1 END").WithDocAnnotation("ann")
+	opts := CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}
+	definition := applyOwnershipNoticePrefix(p.Definition(), opts, p.DocAnnotation())
+	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"CREATE OR ALTER PROCEDURE [sg].[usp_X] /* doc */ /* ann */ /* owned */ @AgentID INT AS BEGIN SELECT 1 END",
 		stmt)
 }
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -535,6 +535,77 @@ func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
 	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
 }
 
+// TestViewValidateApplyWithOptions_SQLite_DocAnnotation asserts the
+// declaration-owned per-object doc annotation contract on SQLite.
+//
+// Contract covered:
+//
+//   - apply + validate with the same declared annotation is coherent
+//   - the rendered annotation lands in sqlite_master.sql between the
+//     caller-level DocPreamble and the caller-level OwnershipNotice
+//   - changing the declared annotation in code produces validation drift
+//     against a live view rendered from the prior annotation
+//     (declaration-owned semantics, distinct from apply-owned DocPreamble)
+//   - the annotation also drives drift when used without any caller-level
+//     decoration
+func TestViewValidateApplyWithOptions_SQLite_DocAnnotation(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE vva_da_tasks (id INTEGER PRIMARY KEY, done INTEGER)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS vva_da_tasks`) }()
+
+	v := schema.NewView("v_vva_da_open", "SELECT id FROM vva_da_tasks WHERE done = 0").
+		WithDocAnnotation("v_vva_da_open v1: returns currently-open task ids")
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	opts := schema.CodeObjectOptions{
+		OwnershipNotice: schema.DefaultOwnershipNotice,
+		DocPreamble:     "vva_da: declaration-owned annotation contract probe",
+	}
+
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, opts, v))
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, v),
+		"apply + validate with same opts and same annotation must be coherent")
+
+	var liveSQL string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_da_open").
+		Scan(&liveSQL))
+
+	docIdx := strings.Index(liveSQL, "declaration-owned annotation contract probe")
+	annIdx := strings.Index(liveSQL, "v_vva_da_open v1: returns currently-open task ids")
+	notIdx := strings.Index(liveSQL, "Owned by https://github.com/catgoose/chuck")
+	require.True(t, docIdx >= 0 && annIdx >= 0 && notIdx >= 0,
+		"all three comment segments must be present in the live SQL")
+	assert.Less(t, docIdx, annIdx, "DocPreamble must render before doc annotation")
+	assert.Less(t, annIdx, notIdx, "doc annotation must render before OwnershipNotice")
+
+	// Declaration-owned drift: change the annotation in code and validate
+	// must complain even though the live SQL still carries the prior
+	// annotation that was apply-rendered.
+	vDrifted := schema.NewView("v_vva_da_open", "SELECT id FROM vva_da_tasks WHERE done = 0").
+		WithDocAnnotation("v_vva_da_open v2: SEMANTIC CHANGE — please review caller")
+	err = schema.ValidateViewWithOptions(ctx, db, d, opts, vDrifted)
+	require.Error(t, err, "declared annotation change must surface as body drift")
+	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+
+	// Annotation alone (no caller-level options) still drives drift when
+	// declared annotation disagrees with live.
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, v))
+	err = schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, vDrifted)
+	require.Error(t, err, "annotation-only declaration must drive drift on its own")
+	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+
+	// Same declaration as live still validates clean under annotation-only.
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, v))
+}
+
 // TestProcedureValidateApplyWithOptions_MSSQL gates on a live MSSQL instance
 // because MSSQL is the only engine with first-class procedure ownership in
 // this release. Proves apply-with-options + validate-with-same-options is

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -39,9 +39,10 @@ var ErrProcedureDialectUnsupported = errors.New("schema: stored procedure owners
 // entrypoints layered on top of the table graph; forcing them into a
 // generalized scheduler would add weight without buying clarity.
 type ProcedureDef struct {
-	Name       string
-	schema     string
-	definition string
+	Name          string
+	schema        string
+	definition    string
+	docAnnotation string
 }
 
 // NewProcedure creates an unqualified owned procedure with the given name and
@@ -76,6 +77,24 @@ func (p *ProcedureDef) WithSchema(schema string) *ProcedureDef {
 // none.
 func (p *ProcedureDef) Schema() string {
 	return p.schema
+}
+
+// WithDocAnnotation attaches a declaration-owned doc comment to the procedure.
+// When set, the annotation renders as a SQL block comment as part of the
+// procedure's own SQL output (between any caller-level DocPreamble and any
+// caller-level OwnershipNotice) and participates in definition-drift
+// comparison: changing the annotation in code produces validation drift
+// against a live procedure rendered from the prior annotation. This is the
+// per-object counterpart to CodeObjectOptions.DocPreamble.
+func (p *ProcedureDef) WithDocAnnotation(text string) *ProcedureDef {
+	p.docAnnotation = text
+	return p
+}
+
+// DocAnnotation returns the declared declaration-owned doc annotation for the
+// procedure, or "" if none.
+func (p *ProcedureDef) DocAnnotation() string {
+	return p.docAnnotation
 }
 
 // Definition returns the raw T-SQL definition declared for the procedure —

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -177,8 +177,8 @@ func ValidateProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Diale
 			Reason:  "procedure does not exist",
 		}}}
 	}
-	liveStripped := stripConfiguredApplyPrefix(live, opts)
-	declaredCanon := canonicalizeStatement(p.Definition())
+	liveStripped := stripConfiguredApplyPrefix(live, opts, p.DocAnnotation())
+	declaredCanon := canonicalizeStatement(declaredDefinitionWithAnnotation(p))
 	liveCanon := canonicalizeStatement(liveStripped)
 	if declaredCanon == liveCanon {
 		return nil
@@ -250,7 +250,7 @@ func ApplyProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Procedu
 // should pair it with ValidateProcedureWithOptions (same opts) to keep apply
 // and validate coherent.
 func ApplyProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef) error {
-	definition := applyOwnershipNoticePrefix(p.Definition(), opts)
+	definition := applyOwnershipNoticePrefix(p.Definition(), opts, p.DocAnnotation())
 	stmt, err := p.createOrAlterWithDefinition(d, definition)
 	if err != nil {
 		return err

--- a/schema/view.go
+++ b/schema/view.go
@@ -24,9 +24,10 @@ import (
 // would add weight without buying clarity. Callers wanting explicit ordering
 // can simply create views after their tables and drop them before.
 type ViewDef struct {
-	Name   string
-	schema string
-	body   string
+	Name          string
+	schema        string
+	body          string
+	docAnnotation string
 }
 
 // NewView creates an unqualified owned view with the given name and SELECT
@@ -53,6 +54,25 @@ func (v *ViewDef) WithSchema(schema string) *ViewDef {
 // Schema returns the declared schema namespace for the view, or "" if none.
 func (v *ViewDef) Schema() string {
 	return v.schema
+}
+
+// WithDocAnnotation attaches a declaration-owned doc comment to the view. When
+// set, the annotation renders as a SQL block comment as part of the view's
+// own SQL output (between any caller-level DocPreamble and any caller-level
+// OwnershipNotice) and participates in body-drift comparison: changing the
+// annotation in code produces validation drift against a live view rendered
+// from the prior annotation. This is the per-object counterpart to
+// CodeObjectOptions.DocPreamble, which remains a caller-level apply-owned
+// preamble shared across many objects.
+func (v *ViewDef) WithDocAnnotation(text string) *ViewDef {
+	v.docAnnotation = text
+	return v
+}
+
+// DocAnnotation returns the declared declaration-owned doc annotation for the
+// view, or "" if none.
+func (v *ViewDef) DocAnnotation() string {
+	return v.docAnnotation
 }
 
 // Body returns the raw SELECT body declared for the view.

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -226,6 +226,26 @@ func stripCreateViewPreamble(s string) string {
 	return s[loc[1]:]
 }
 
+// declaredBodyWithAnnotation returns the declared body that participates in
+// canonical drift comparison: when the view carries a declaration-owned doc
+// annotation it is rendered as a SQL block comment immediately before the
+// declared body, matching the slot the apply path injects.
+func declaredBodyWithAnnotation(v *ViewDef) string {
+	if c := renderOwnershipComment(v.DocAnnotation()); c != "" {
+		return c + " " + v.Body()
+	}
+	return v.Body()
+}
+
+// declaredDefinitionWithAnnotation is the procedure-side counterpart to
+// declaredBodyWithAnnotation.
+func declaredDefinitionWithAnnotation(p *ProcedureDef) string {
+	if c := renderOwnershipComment(p.DocAnnotation()); c != "" {
+		return c + " " + p.Definition()
+	}
+	return p.Definition()
+}
+
 // canonicalizeStatement normalizes a SQL statement body for drift comparison.
 // Used for both view bodies and procedure definitions. It trims surrounding
 // whitespace, strips trailing semicolons, and collapses runs of internal
@@ -311,8 +331,8 @@ func ValidateViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, o
 			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
 		}}}
 	}
-	liveStripped := stripConfiguredApplyPrefix(live, opts)
-	declaredCanon := canonicalizeStatement(v.Body())
+	liveStripped := stripConfiguredApplyPrefix(live, opts, v.DocAnnotation())
+	declaredCanon := canonicalizeStatement(declaredBodyWithAnnotation(v))
 	liveCanon := canonicalizeStatement(liveStripped)
 	if declaredCanon == liveCanon {
 		return nil
@@ -379,7 +399,7 @@ func ApplyView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) err
 // see the chuck-owned marker. Callers that use this path should pair it with
 // ValidateViewWithOptions (same opts) to keep apply and validate coherent.
 func ApplyViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef) error {
-	body := applyOwnershipNoticePrefix(v.Body(), opts)
+	body := applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation())
 	for _, stmt := range v.createOrReplaceWithBody(d, body) {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("schema: apply view %q: %w", objectKey(v.Object()), err)


### PR DESCRIPTION
## Summary
- Add `WithDocAnnotation(text)` on `ViewDef` and `ProcedureDef` so callers can attach a per-object doc comment that is **declaration-owned** — it renders into the live SQL **and** participates in body-drift comparison.
- Render order is now: caller-level `DocPreamble` → per-object annotation → caller-level `OwnershipNotice` → payload.
- `Apply*WithOptions` / `Validate*WithOptions` thread the annotation through render / strip / canonicalize so declared canon = `/* annotation */ + body` when set.

## Why declaration-owned, not apply-owned
`CodeObjectOptions.DocPreamble` is shared across many objects and apply-owned (tolerated by Validate). `WithDocAnnotation` is the per-object counterpart that is part of the object's declared identity: changing the text in code is a meaningful signal and Validate must surface it as drift.

## Apply-owned semantics preserved
`DocPreamble` + `OwnershipNotice` continue to strip from live text before canonical compare; absent or different leading comments behave exactly as before.

## Files changed
- `schema/view.go`, `schema/procedure.go` — field + builder + accessor
- `schema/code_object_options.go` — helpers gain `declaredAnnotation` arg + new render slot
- `schema/view_lifecycle.go`, `schema/procedure_lifecycle.go` — thread annotation through Apply/Validate
- `schema/code_object_options_test.go` — extended helper tests + new annotation tests
- `schema/integration_test.go` — SQLite round-trip covering apply, validate, declaration-owned drift
- `README.md` — third comment lane documented with a declaration-owned drift table

Closes #93.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [ ] MSSQL integration test (`TestProcedureValidateApplyWithOptions_MSSQL`) — gated on `CHUCK_MSSQL_URL`, not exercised locally; covered by existing CI path if configured