### PR TITLE
feat(schema): explicit rename/tombstone support for owned code objects (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,30 @@ Declaration-owned drift (per-object `WithDocAnnotation`):
 
 Bare `ApplyView` / `ValidateView` / `ApplyProcedure` / `ValidateProcedure` are unchanged: they neither inject nor tolerate markers.
 
+#### Renaming or retiring an owned view or procedure
+
+Use **`WithReplaces(names ...chuck.ObjectName)`** on `ViewDef` or `ProcedureDef` to declare prior names that the apply path should drop and the validate path should flag as stale if they still exist. Same-type only: views replace views, procedures replace procedures. No schema-wide pruning, no automatic name inference.
+
+```go
+v := schema.NewView("v_open_tasks",
+    "SELECT id FROM tasks WHERE done = 0").
+    WithReplaces(
+        chuck.ObjectName{Name: "v_open_tasks_v1"},
+        chuck.ObjectName{Schema: "legacy", Name: "v_OpenTasks"},
+    )
+
+if err := schema.ApplyViewsWithOptions(ctx, db, dialect, opts, v); err != nil {
+    return err
+}
+if err := schema.ValidateViewsWithOptions(ctx, db, dialect, opts, v); err != nil {
+    return err // unwraps to schema.ErrViewReplacementStillExists if a prior name lingers
+}
+```
+
+Apply semantics: each listed name is dropped with the same dialect-aware `DROP IF EXISTS` pattern as a regular owned-object drop, then the current view (or procedure) is created. Validate semantics: each listed name is queried in the live database; any name still present surfaces as a `ViewDrift` / `ProcedureDrift` entry with `ReplacementStale=true` and the aggregated error unwraps to `schema.ErrViewReplacementStillExists` / `schema.ErrProcedureReplacementStillExists` when stale replacements are the only drift cause.
+
+Batch helpers (`ApplyViewsWithOptions`, `ValidateViewsWithOptions`, and the procedure analogues) dedupe duplicate names across defs by structured `ObjectName` (schema + name match exactly), so the same prior name is only dropped or checked once even when multiple defs name it.
+
 Engine notes:
 
 - **SQLite** stores the view text verbatim in `sqlite_master.sql`, so both comments are fully visible there.

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ if err := schema.ApplyViewsWithOptions(ctx, db, dialect, opts, v); err != nil {
     return err
 }
 if err := schema.ValidateViewsWithOptions(ctx, db, dialect, opts, v); err != nil {
-    return err // unwraps to schema.ErrViewReplacementStillExists if a prior name lingers
+    return err // on SQLite/MSSQL, unwraps to schema.ErrViewReplacementStillExists when stale replacement is sole drift cause
 }
 ```
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -606,6 +606,92 @@ func TestViewValidateApplyWithOptions_SQLite_DocAnnotation(t *testing.T) {
 	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, v))
 }
 
+// TestViewRenameRollout_SQLite_WithReplaces asserts the rename/tombstone
+// contract end-to-end on SQLite, which stores view definitions verbatim and
+// lets us observe both apply-side drops and validate-side stale-replacement
+// drift directly via sqlite_master.
+//
+// Contract covered:
+//
+//   - apply drops each WithReplaces name before creating the current view
+//   - validate is clean after apply when no prior name remains live
+//   - re-creating a prior name out of band surfaces as stale-replacement
+//     drift that unwraps to ErrViewReplacementStillExists
+//   - batch apply / validate dedupe duplicate replacement names across defs
+func TestViewRenameRollout_SQLite_WithReplaces(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE rn_tasks (id INTEGER PRIMARY KEY, done INTEGER)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS rn_tasks`) }()
+
+	// Seed the prior name as if a previous rollout had created it.
+	_, err = db.ExecContext(ctx,
+		`CREATE VIEW v_rn_open_v1 AS SELECT id FROM rn_tasks WHERE done = 0`)
+	require.NoError(t, err)
+
+	v := schema.NewView("v_rn_open", "SELECT id FROM rn_tasks WHERE done = 0").
+		WithReplaces(chuck.ObjectName{Name: "v_rn_open_v1"})
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	require.NoError(t, schema.ApplyView(ctx, db, d, v))
+
+	var oldCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='view' AND name=?`,
+		"v_rn_open_v1").Scan(&oldCount))
+	assert.Equal(t, 0, oldCount, "prior name must be dropped after rollout apply")
+
+	require.NoError(t, schema.ValidateView(ctx, db, d, v),
+		"validate must be clean once the prior name is retired")
+
+	// Simulate an out-of-band resurrection of the prior name (e.g. a
+	// rollback patch or hand-edit). Validate must now flag stale
+	// replacement and unwrap to ErrViewReplacementStillExists.
+	_, err = db.ExecContext(ctx,
+		`CREATE VIEW v_rn_open_v1 AS SELECT id FROM rn_tasks WHERE done = 0`)
+	require.NoError(t, err)
+
+	err = schema.ValidateView(ctx, db, d, v)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schema.ErrViewReplacementStillExists)
+
+	// Batch dedup: two defs naming the same prior name must report it once.
+	a := schema.NewView("v_rn_a", "SELECT id FROM rn_tasks").
+		WithReplaces(chuck.ObjectName{Name: "v_rn_open_v1"})
+	b := schema.NewView("v_rn_b", "SELECT id FROM rn_tasks").
+		WithReplaces(chuck.ObjectName{Name: "v_rn_open_v1"})
+	defer func() {
+		_, _ = db.ExecContext(ctx, a.DropSQL(d))
+		_, _ = db.ExecContext(ctx, b.DropSQL(d))
+	}()
+	require.NoError(t, schema.ApplyViews(ctx, db, d, a, b))
+
+	// Re-seed the prior name to test validate dedup specifically.
+	_, err = db.ExecContext(ctx,
+		`CREATE VIEW v_rn_open_v1 AS SELECT id FROM rn_tasks WHERE done = 0`)
+	require.NoError(t, err)
+
+	err = schema.ValidateViews(ctx, db, d, a, b)
+	require.Error(t, err)
+	var drift *schema.ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	// One drift entry for v_rn_open_v1, deduped across the two defs.
+	staleCount := 0
+	for _, dr := range drift.Drifts {
+		if dr.ReplacementStale && dr.Object.Name == "v_rn_open_v1" {
+			staleCount++
+		}
+	}
+	assert.Equal(t, 1, staleCount,
+		"v_rn_open_v1 must be deduped to one drift entry across the batch")
+}
+
 // TestProcedureValidateApplyWithOptions_MSSQL gates on a live MSSQL instance
 // because MSSQL is the only engine with first-class procedure ownership in
 // this release. Proves apply-with-options + validate-with-same-options is

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -43,6 +43,7 @@ type ProcedureDef struct {
 	schema        string
 	definition    string
 	docAnnotation string
+	replaces      []chuck.ObjectName
 }
 
 // NewProcedure creates an unqualified owned procedure with the given name and
@@ -95,6 +96,28 @@ func (p *ProcedureDef) WithDocAnnotation(text string) *ProcedureDef {
 // procedure, or "" if none.
 func (p *ProcedureDef) DocAnnotation() string {
 	return p.docAnnotation
+}
+
+// WithReplaces declares prior names this procedure supersedes — used to
+// retire renamed or replaced procedures explicitly without schema-wide
+// pruning. Apply*WithOptions drops each listed name (exact schema + name
+// match, same object type) before creating the current procedure;
+// Validate*WithOptions reports each listed name as stale if it still exists
+// in the live database. Cross-type replacement is intentionally not supported.
+//
+// Multiple calls accumulate; batch apply / validate helpers dedupe duplicate
+// names across the batch so the same prior name is only dropped or checked
+// once. Names are matched by structured ObjectName: schema and name must
+// match exactly, with no schema-wide globbing.
+func (p *ProcedureDef) WithReplaces(names ...chuck.ObjectName) *ProcedureDef {
+	p.replaces = append(p.replaces, names...)
+	return p
+}
+
+// Replaces returns the declared prior names this procedure supersedes, in
+// caller-supplied order.
+func (p *ProcedureDef) Replaces() []chuck.ObjectName {
+	return p.replaces
 }
 
 // Definition returns the raw T-SQL definition declared for the procedure —

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -20,6 +20,12 @@ var ErrProcedureMissing = errors.New("schema: declared procedure does not exist 
 // definition differs from the declaration.
 var ErrProcedureDefinitionDrift = errors.New("schema: declared procedure definition differs from live database definition")
 
+// ErrProcedureReplacementStillExists is returned by ValidateProcedure /
+// ValidateProcedures when a name declared via ProcedureDef.WithReplaces still
+// exists in the live database. Callers can errors.Is-detect this to
+// distinguish "old name not yet retired" from current-object drift.
+var ErrProcedureReplacementStillExists = errors.New("schema: declared replaced procedure still exists in live database")
+
 // ProcedureDrift describes one declared procedure whose state in the live
 // database does not match the declared definition. Either Missing is true,
 // or DefinitionMismatch is true with DeclaredDefinition / LiveDefinition
@@ -28,6 +34,11 @@ type ProcedureDrift struct {
 	Object             chuck.ObjectName
 	Missing            bool
 	DefinitionMismatch bool
+	// ReplacementStale is true when Object names a prior procedure declared
+	// via ProcedureDef.WithReplaces that still exists in the live database.
+	// The current procedure may still match; the drift flags a rename
+	// rollout that has not finished cleaning up the prior name.
+	ReplacementStale   bool
 	DeclaredDefinition string
 	LiveDefinition     string
 	Reason             string
@@ -49,6 +60,8 @@ func (e *ProcedureDriftError) Error() string {
 		switch {
 		case d.Missing:
 			parts = append(parts, fmt.Sprintf("procedure %q: missing", obj))
+		case d.ReplacementStale:
+			parts = append(parts, fmt.Sprintf("procedure %q: replacement still exists", obj))
 		case d.DefinitionMismatch:
 			parts = append(parts, fmt.Sprintf("procedure %q: definition drift", obj))
 		default:
@@ -64,6 +77,7 @@ func (e *ProcedureDriftError) Unwrap() error {
 	}
 	onlyMissing := true
 	onlyDefn := true
+	onlyReplStale := true
 	for _, d := range e.Drifts {
 		if !d.Missing {
 			onlyMissing = false
@@ -71,12 +85,17 @@ func (e *ProcedureDriftError) Unwrap() error {
 		if !d.DefinitionMismatch {
 			onlyDefn = false
 		}
+		if !d.ReplacementStale {
+			onlyReplStale = false
+		}
 	}
 	switch {
 	case onlyMissing:
 		return ErrProcedureMissing
 	case onlyDefn:
 		return ErrProcedureDefinitionDrift
+	case onlyReplStale:
+		return ErrProcedureReplacementStillExists
 	default:
 		return nil
 	}
@@ -162,34 +181,78 @@ func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Proc
 // carry the configured markers still validate cleanly against the same
 // declared definition; live definitions that carry a different leading
 // comment (including a stale notice) still report drift.
+//
+// When the procedure declares prior names via WithReplaces, any of those
+// names still present in the live database surface as additional drift
+// entries (ReplacementStale=true), so a rename rollout that has not
+// finished cleaning up old names fails validation explicitly.
 func ValidateProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
-	live, exists, err := LiveProcedureDefinition(ctx, db, d, p)
+	drifts, err := validateProcedureWithOptionsInternal(ctx, db, d, opts, p, nil)
 	if err != nil {
 		return err
 	}
+	if len(drifts) == 0 {
+		return nil
+	}
+	return &ProcedureDriftError{Drifts: drifts}
+}
+
+// validateProcedureWithOptionsInternal performs the per-procedure validate
+// work and returns drifts in caller-supplied order. When checked != nil,
+// replacement names are recorded as they are queried so a batch validator
+// can dedupe repeated names across multiple defs.
+func validateProcedureWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef, checked map[string]struct{}) ([]ProcedureDrift, error) {
+	var drifts []ProcedureDrift
+	live, exists, err := LiveProcedureDefinition(ctx, db, d, p)
+	if err != nil {
+		return nil, err
+	}
 	if !exists {
-		return &ProcedureDriftError{Drifts: []ProcedureDrift{{
+		drifts = append(drifts, ProcedureDrift{
 			Object:  p.Object(),
 			Missing: true,
 			Reason:  "procedure does not exist",
-		}}}
+		})
+	} else {
+		liveStripped := stripConfiguredApplyPrefix(live, opts, p.DocAnnotation())
+		declaredCanon := canonicalizeStatement(declaredDefinitionWithAnnotation(p))
+		liveCanon := canonicalizeStatement(liveStripped)
+		if declaredCanon != liveCanon {
+			drifts = append(drifts, ProcedureDrift{
+				Object:             p.Object(),
+				DefinitionMismatch: true,
+				DeclaredDefinition: declaredCanon,
+				LiveDefinition:     liveCanon,
+				Reason:             "procedure definition differs after canonical normalization",
+			})
+		}
 	}
-	liveStripped := stripConfiguredApplyPrefix(live, opts, p.DocAnnotation())
-	declaredCanon := canonicalizeStatement(declaredDefinitionWithAnnotation(p))
-	liveCanon := canonicalizeStatement(liveStripped)
-	if declaredCanon == liveCanon {
-		return nil
+	for _, repl := range p.Replaces() {
+		key := objectKey(repl)
+		if checked != nil {
+			if _, ok := checked[key]; ok {
+				continue
+			}
+			checked[key] = struct{}{}
+		}
+		tmp := &ProcedureDef{Name: repl.Name, schema: repl.Schema}
+		liveDef, replExists, err := LiveProcedureDefinition(ctx, db, d, tmp)
+		if err != nil {
+			return nil, err
+		}
+		if replExists {
+			drifts = append(drifts, ProcedureDrift{
+				Object:           repl,
+				ReplacementStale: true,
+				LiveDefinition:   liveDef,
+				Reason:           "procedure declared as replaced but still exists in live database",
+			})
+		}
 	}
-	return &ProcedureDriftError{Drifts: []ProcedureDrift{{
-		Object:             p.Object(),
-		DefinitionMismatch: true,
-		DeclaredDefinition: declaredCanon,
-		LiveDefinition:     liveCanon,
-		Reason:             "procedure definition differs after canonical normalization",
-	}}}
+	return drifts, nil
 }
 
 // ValidateProcedures validates each declared procedure in order, aggregating
@@ -202,22 +265,21 @@ func ValidateProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs 
 // ValidateProceduresWithOptions is the option-aware counterpart to
 // ValidateProcedures. See ValidateProcedureWithOptions for the per-procedure
 // semantics; aggregation behavior is identical to ValidateProcedures.
+// Replacement-name checks are deduped across the batch so the same prior
+// name only surfaces once even if it is declared via WithReplaces on
+// multiple defs.
 func ValidateProceduresWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, procs ...*ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
+	checked := map[string]struct{}{}
 	var drifts []ProcedureDrift
 	for _, p := range procs {
-		err := ValidateProcedureWithOptions(ctx, db, d, opts, p)
-		if err == nil {
-			continue
+		ds, err := validateProcedureWithOptionsInternal(ctx, db, d, opts, p, checked)
+		if err != nil {
+			return err
 		}
-		var drift *ProcedureDriftError
-		if errors.As(err, &drift) {
-			drifts = append(drifts, drift.Drifts...)
-			continue
-		}
-		return err
+		drifts = append(drifts, ds...)
 	}
 	if len(drifts) == 0 {
 		return nil
@@ -249,7 +311,40 @@ func ApplyProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Procedu
 // token of the caller's definition payload. Callers that use this path
 // should pair it with ValidateProcedureWithOptions (same opts) to keep apply
 // and validate coherent.
+//
+// When the procedure declares prior names via WithReplaces, each listed
+// name is dropped (same guarded sys.procedures DROP IF EXISTS pattern as a
+// regular procedure drop) before the current procedure is created.
+// Cross-type drops are not attempted.
 func ApplyProcedureWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef) error {
+	return applyProcedureWithOptionsInternal(ctx, db, d, opts, p, nil)
+}
+
+// applyProcedureWithOptionsInternal performs the per-procedure apply work.
+// When dropped != nil, replacement names already dropped earlier in the
+// batch are skipped so the same prior name is only dropped once across a
+// batch.
+func applyProcedureWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, p *ProcedureDef, dropped map[string]struct{}) error {
+	if d.Engine() != chuck.MSSQL {
+		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
+	}
+	for _, repl := range p.Replaces() {
+		key := objectKey(repl)
+		if dropped != nil {
+			if _, ok := dropped[key]; ok {
+				continue
+			}
+			dropped[key] = struct{}{}
+		}
+		tmp := &ProcedureDef{Name: repl.Name, schema: repl.Schema}
+		dropStmt, err := tmp.DropSQL(d)
+		if err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, dropStmt); err != nil {
+			return fmt.Errorf("schema: drop replaced procedure %q: %w", key, err)
+		}
+	}
 	definition := applyOwnershipNoticePrefix(p.Definition(), opts, p.DocAnnotation())
 	stmt, err := p.createOrAlterWithDefinition(d, definition)
 	if err != nil {
@@ -268,13 +363,16 @@ func ApplyProcedures(ctx context.Context, db *sql.DB, d chuck.Dialect, procs ...
 }
 
 // ApplyProceduresWithOptions is the option-aware counterpart to
-// ApplyProcedures.
+// ApplyProcedures. Replacement-name drops are deduped across the batch so
+// the same prior name is only issued one DROP statement even if it is
+// declared via WithReplaces on multiple defs.
 func ApplyProceduresWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, procs ...*ProcedureDef) error {
 	if d.Engine() != chuck.MSSQL {
 		return fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
+	dropped := map[string]struct{}{}
 	for _, p := range procs {
-		if err := ApplyProcedureWithOptions(ctx, db, d, opts, p); err != nil {
+		if err := applyProcedureWithOptionsInternal(ctx, db, d, opts, p, dropped); err != nil {
 			return err
 		}
 	}

--- a/schema/procedure_lifecycle_test.go
+++ b/schema/procedure_lifecycle_test.go
@@ -100,6 +100,31 @@ func TestProcedureDriftError_Unwrap_AllDefinition(t *testing.T) {
 	assert.False(t, errors.Is(e, ErrProcedureMissing))
 }
 
+func TestProcedureDriftError_Unwrap_AllReplacementStale(t *testing.T) {
+	e := &ProcedureDriftError{Drifts: []ProcedureDrift{
+		{Object: chuck.ObjectName{Schema: "sg", Name: "usp_old_a"}, ReplacementStale: true},
+		{Object: chuck.ObjectName{Schema: "sg", Name: "usp_old_b"}, ReplacementStale: true},
+	}}
+	assert.True(t, errors.Is(e, ErrProcedureReplacementStillExists))
+	assert.False(t, errors.Is(e, ErrProcedureMissing))
+	assert.False(t, errors.Is(e, ErrProcedureDefinitionDrift))
+}
+
+func TestProcedureDef_WithReplaces_StoresNamesInOrder(t *testing.T) {
+	p := NewQualifiedProcedure("sg", "usp_X", "AS BEGIN SELECT 1 END").
+		WithReplaces(
+			chuck.ObjectName{Schema: "sg", Name: "usp_OldA"},
+			chuck.ObjectName{Schema: "sg", Name: "usp_OldB"},
+		).
+		WithReplaces(chuck.ObjectName{Name: "usp_LegacyBare"})
+	got := p.Replaces()
+	require.Len(t, got, 3)
+	assert.Equal(t, "usp_OldA", got[0].Name)
+	assert.Equal(t, "usp_OldB", got[1].Name)
+	assert.Equal(t, "usp_LegacyBare", got[2].Name)
+	assert.Equal(t, "", got[2].Schema)
+}
+
 func TestProcedureDriftError_Unwrap_MixedCauses_NoWrap(t *testing.T) {
 	// Mixed missing + definition-drift cases intentionally do not wrap
 	// either sentinel so callers can't branch on a single cause when the

--- a/schema/view.go
+++ b/schema/view.go
@@ -28,6 +28,7 @@ type ViewDef struct {
 	schema        string
 	body          string
 	docAnnotation string
+	replaces      []chuck.ObjectName
 }
 
 // NewView creates an unqualified owned view with the given name and SELECT
@@ -73,6 +74,29 @@ func (v *ViewDef) WithDocAnnotation(text string) *ViewDef {
 // view, or "" if none.
 func (v *ViewDef) DocAnnotation() string {
 	return v.docAnnotation
+}
+
+// WithReplaces declares prior names this view supersedes — used to retire
+// renamed or replaced views explicitly without schema-wide pruning.
+// Apply*WithOptions drops each listed name (exact schema + name match, same
+// object type) before creating the current view; Validate*WithOptions reports
+// each listed name as stale if it still exists in the live database. Cross-
+// type replacement (e.g. a view replacing a procedure) is intentionally not
+// supported.
+//
+// Multiple calls accumulate; batch apply / validate helpers dedupe duplicate
+// names across the batch so the same prior name is only dropped or checked
+// once. Names are matched by structured ObjectName: schema and name must
+// match exactly, with no schema-wide globbing.
+func (v *ViewDef) WithReplaces(names ...chuck.ObjectName) *ViewDef {
+	v.replaces = append(v.replaces, names...)
+	return v
+}
+
+// Replaces returns the declared prior names this view supersedes, in
+// caller-supplied order.
+func (v *ViewDef) Replaces() []chuck.ObjectName {
+	return v.replaces
 }
 
 // Body returns the raw SELECT body declared for the view.

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -23,6 +23,12 @@ var ErrViewMissing = errors.New("schema: declared view does not exist in live da
 // missing-object and from infrastructure errors.
 var ErrViewBodyDrift = errors.New("schema: declared view body differs from live database body")
 
+// ErrViewReplacementStillExists is returned by ValidateView / ValidateViews
+// when a name declared via ViewDef.WithReplaces still exists in the live
+// database. Callers can errors.Is-detect this to distinguish "old name not
+// yet retired" from current-object drift.
+var ErrViewReplacementStillExists = errors.New("schema: declared replaced view still exists in live database")
+
 // ErrViewBodyComparisonUnsupported is returned by ValidateView / ValidateViews
 // when the live engine canonicalizes view definitions enough that body-text
 // drift cannot be honestly compared (today: Postgres `pg_get_viewdef` expands
@@ -49,9 +55,14 @@ type ViewDrift struct {
 	Missing               bool
 	BodyMismatch          bool
 	BodyComparisonSkipped bool
-	DeclaredBody          string
-	LiveBody              string
-	Reason                string
+	// ReplacementStale is true when Object names a prior view declared via
+	// ViewDef.WithReplaces that still exists in the live database. The
+	// current view (Object's caller) may still match; the drift flags a
+	// rename rollout that has not finished cleaning up the prior name.
+	ReplacementStale bool
+	DeclaredBody     string
+	LiveBody         string
+	Reason           string
 }
 
 // ViewDriftError is returned by ValidateView / ValidateViews when one or more
@@ -74,6 +85,8 @@ func (e *ViewDriftError) Error() string {
 		switch {
 		case d.Missing:
 			parts = append(parts, fmt.Sprintf("view %q: missing", obj))
+		case d.ReplacementStale:
+			parts = append(parts, fmt.Sprintf("view %q: replacement still exists", obj))
 		case d.BodyComparisonSkipped:
 			parts = append(parts, fmt.Sprintf("view %q: %s", obj, d.Reason))
 		case d.BodyMismatch:
@@ -92,6 +105,7 @@ func (e *ViewDriftError) Unwrap() error {
 	onlyMissing := true
 	onlyBody := true
 	onlySkipped := true
+	onlyReplStale := true
 	for _, d := range e.Drifts {
 		if !d.Missing {
 			onlyMissing = false
@@ -102,6 +116,9 @@ func (e *ViewDriftError) Unwrap() error {
 		if !d.BodyComparisonSkipped {
 			onlySkipped = false
 		}
+		if !d.ReplacementStale {
+			onlyReplStale = false
+		}
 	}
 	switch {
 	case onlyMissing:
@@ -110,6 +127,8 @@ func (e *ViewDriftError) Unwrap() error {
 		return ErrViewBodyDrift
 	case onlySkipped:
 		return ErrViewBodyComparisonUnsupported
+	case onlyReplStale:
+		return ErrViewReplacementStillExists
 	default:
 		return nil
 	}
@@ -310,40 +329,84 @@ func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) 
 // can pass options without forcing markers into the live object. Live
 // bodies that carry a different leading comment (including a stale notice
 // that no longer matches the configured value) still report drift.
+//
+// When the view declares prior names via WithReplaces, any of those names
+// still present in the live database surface as additional drift entries
+// (ReplacementStale=true), so a rename rollout that has not finished
+// cleaning up old names fails validation explicitly.
 func ValidateViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef) error {
-	live, exists, err := LiveViewBody(ctx, db, d, v)
+	drifts, err := validateViewWithOptionsInternal(ctx, db, d, opts, v, nil)
 	if err != nil {
 		return err
 	}
-	if !exists {
-		return &ViewDriftError{Drifts: []ViewDrift{{
+	if len(drifts) == 0 {
+		return nil
+	}
+	return &ViewDriftError{Drifts: drifts}
+}
+
+// validateViewWithOptionsInternal performs the per-view validate work and
+// returns drifts in caller-supplied order. When checked != nil, replacement
+// names are recorded as they are queried so a batch validator can dedupe
+// repeated names across multiple defs.
+func validateViewWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef, checked map[string]struct{}) ([]ViewDrift, error) {
+	var drifts []ViewDrift
+	live, exists, err := LiveViewBody(ctx, db, d, v)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case !exists:
+		drifts = append(drifts, ViewDrift{
 			Object:  v.Object(),
 			Missing: true,
 			Reason:  "view does not exist",
-		}}}
-	}
-	if d.Engine() == chuck.Postgres {
-		return &ViewDriftError{Drifts: []ViewDrift{{
+		})
+	case d.Engine() == chuck.Postgres:
+		drifts = append(drifts, ViewDrift{
 			Object:                v.Object(),
 			BodyComparisonSkipped: true,
 			DeclaredBody:          v.Body(),
 			LiveBody:              live,
 			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
-		}}}
+		})
+	default:
+		liveStripped := stripConfiguredApplyPrefix(live, opts, v.DocAnnotation())
+		declaredCanon := canonicalizeStatement(declaredBodyWithAnnotation(v))
+		liveCanon := canonicalizeStatement(liveStripped)
+		if declaredCanon != liveCanon {
+			drifts = append(drifts, ViewDrift{
+				Object:       v.Object(),
+				BodyMismatch: true,
+				DeclaredBody: declaredCanon,
+				LiveBody:     liveCanon,
+				Reason:       "view body differs after canonical normalization",
+			})
+		}
 	}
-	liveStripped := stripConfiguredApplyPrefix(live, opts, v.DocAnnotation())
-	declaredCanon := canonicalizeStatement(declaredBodyWithAnnotation(v))
-	liveCanon := canonicalizeStatement(liveStripped)
-	if declaredCanon == liveCanon {
-		return nil
+	for _, repl := range v.Replaces() {
+		key := objectKey(repl)
+		if checked != nil {
+			if _, ok := checked[key]; ok {
+				continue
+			}
+			checked[key] = struct{}{}
+		}
+		tmp := &ViewDef{Name: repl.Name, schema: repl.Schema}
+		liveBody, replExists, err := LiveViewBody(ctx, db, d, tmp)
+		if err != nil {
+			return nil, err
+		}
+		if replExists {
+			drifts = append(drifts, ViewDrift{
+				Object:           repl,
+				ReplacementStale: true,
+				LiveBody:         liveBody,
+				Reason:           "view declared as replaced but still exists in live database",
+			})
+		}
 	}
-	return &ViewDriftError{Drifts: []ViewDrift{{
-		Object:       v.Object(),
-		BodyMismatch: true,
-		DeclaredBody: declaredCanon,
-		LiveBody:     liveCanon,
-		Reason:       "view body differs after canonical normalization",
-	}}}
+	return drifts, nil
 }
 
 // ValidateViews validates each given view in order, aggregating any drift
@@ -355,20 +418,18 @@ func ValidateViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*V
 
 // ValidateViewsWithOptions is the option-aware counterpart to ValidateViews.
 // See ValidateViewWithOptions for the per-view semantics; aggregation behavior
-// is identical to ValidateViews.
+// is identical to ValidateViews. Replacement-name checks are deduped across
+// the batch so the same prior name only surfaces once even if it is declared
+// via WithReplaces on multiple defs.
 func ValidateViewsWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, views ...*ViewDef) error {
+	checked := map[string]struct{}{}
 	var drifts []ViewDrift
 	for _, v := range views {
-		err := ValidateViewWithOptions(ctx, db, d, opts, v)
-		if err == nil {
-			continue
+		ds, err := validateViewWithOptionsInternal(ctx, db, d, opts, v, checked)
+		if err != nil {
+			return err
 		}
-		var drift *ViewDriftError
-		if errors.As(err, &drift) {
-			drifts = append(drifts, drift.Drifts...)
-			continue
-		}
-		return err
+		drifts = append(drifts, ds...)
 	}
 	if len(drifts) == 0 {
 		return nil
@@ -398,7 +459,31 @@ func ApplyView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) err
 // prefixed with the corresponding SQL block comment so DB-side readers can
 // see the chuck-owned marker. Callers that use this path should pair it with
 // ValidateViewWithOptions (same opts) to keep apply and validate coherent.
+//
+// When the view declares prior names via WithReplaces, each listed name is
+// dropped (same dialect-aware DROP IF EXISTS pattern as a regular view drop)
+// before the current view is created. Cross-type drops are not attempted.
 func ApplyViewWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef) error {
+	return applyViewWithOptionsInternal(ctx, db, d, opts, v, nil)
+}
+
+// applyViewWithOptionsInternal performs the per-view apply work. When
+// dropped != nil, replacement names already dropped earlier in the batch are
+// skipped so the same prior name is only dropped once across a batch.
+func applyViewWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, v *ViewDef, dropped map[string]struct{}) error {
+	for _, repl := range v.Replaces() {
+		key := objectKey(repl)
+		if dropped != nil {
+			if _, ok := dropped[key]; ok {
+				continue
+			}
+			dropped[key] = struct{}{}
+		}
+		tmp := &ViewDef{Name: repl.Name, schema: repl.Schema}
+		if _, err := db.ExecContext(ctx, tmp.DropSQL(d)); err != nil {
+			return fmt.Errorf("schema: drop replaced view %q: %w", key, err)
+		}
+	}
 	body := applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation())
 	for _, stmt := range v.createOrReplaceWithBody(d, body) {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
@@ -416,9 +501,13 @@ func ApplyViews(ctx context.Context, db *sql.DB, d chuck.Dialect, views ...*View
 }
 
 // ApplyViewsWithOptions is the option-aware counterpart to ApplyViews.
+// Replacement-name drops are deduped across the batch so the same prior name
+// is only issued one DROP statement even if it is declared via WithReplaces
+// on multiple defs.
 func ApplyViewsWithOptions(ctx context.Context, db *sql.DB, d chuck.Dialect, opts CodeObjectOptions, views ...*ViewDef) error {
+	dropped := map[string]struct{}{}
 	for _, v := range views {
-		if err := ApplyViewWithOptions(ctx, db, d, opts, v); err != nil {
+		if err := applyViewWithOptionsInternal(ctx, db, d, opts, v, dropped); err != nil {
 			return err
 		}
 	}

--- a/schema/view_lifecycle_test.go
+++ b/schema/view_lifecycle_test.go
@@ -207,6 +207,125 @@ func TestViewDriftError_Unwrap_Mixed_SkippedAndMissing_NoWrap(t *testing.T) {
 	assert.False(t, errors.Is(e, ErrViewBodyComparisonUnsupported))
 }
 
+func TestApplyView_SQLite_DropsReplacedViews(t *testing.T) {
+	// ApplyView with WithReplaces must drop each listed prior name before
+	// creating the current view, so a rename rollout retires the old view
+	// without leaving it behind.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	mustExec(t, db, `CREATE VIEW v_old AS SELECT id FROM t`)
+
+	v := NewView("v_new", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+
+	require.NoError(t, ApplyView(ctx, db, d, v))
+
+	var oldCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='view' AND name='v_old'`).
+		Scan(&oldCount))
+	assert.Equal(t, 0, oldCount, "v_old must be dropped by WithReplaces apply")
+
+	require.NoError(t, ValidateView(ctx, db, d, v))
+}
+
+func TestApplyViews_SQLite_DedupesReplacementDrops(t *testing.T) {
+	// Multiple defs naming the same prior name must only drop it once
+	// across the batch, not once per def.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	mustExec(t, db, `CREATE VIEW v_old AS SELECT id FROM t`)
+
+	a := NewView("v_a", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+	b := NewView("v_b", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+
+	require.NoError(t, ApplyViews(ctx, db, d, a, b))
+
+	var oldCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='view' AND name='v_old'`).
+		Scan(&oldCount))
+	assert.Equal(t, 0, oldCount, "v_old must be dropped exactly once across batch")
+}
+
+func TestValidateView_SQLite_StaleReplacementReportsDrift(t *testing.T) {
+	// When a declared replacement still exists in the live DB, validate must
+	// surface it as drift with ReplacementStale=true and unwrap to
+	// ErrViewReplacementStillExists when it is the sole drift cause.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	v := NewView("v_new", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+	require.NoError(t, ApplyView(ctx, db, d, v))
+
+	// Re-create the prior name out of band — apply already dropped it.
+	mustExec(t, db, `CREATE VIEW v_old AS SELECT id FROM t`)
+
+	err := ValidateView(ctx, db, d, v)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrViewReplacementStillExists))
+	var drift *ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	require.Len(t, drift.Drifts, 1)
+	assert.True(t, drift.Drifts[0].ReplacementStale)
+	assert.Equal(t, "v_old", drift.Drifts[0].Object.Name)
+}
+
+func TestValidateViews_SQLite_DedupesReplacementChecks(t *testing.T) {
+	// Multiple defs naming the same prior name must only flag it once in
+	// the aggregated drift error, even though both defs list it.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	mustExec(t, db, `CREATE VIEW v_old AS SELECT id FROM t`)
+	a := NewView("v_a", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+	b := NewView("v_b", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+	require.NoError(t, ApplyView(ctx, db, d, a))
+	require.NoError(t, ApplyView(ctx, db, d, b))
+	// Re-create v_old after apply to simulate a stale prior name.
+	mustExec(t, db, `CREATE VIEW v_old AS SELECT id FROM t`)
+
+	err := ValidateViews(ctx, db, d, a, b)
+	require.Error(t, err)
+	var drift *ViewDriftError
+	require.ErrorAs(t, err, &drift)
+	require.Len(t, drift.Drifts, 1, "v_old must be deduped to one drift entry across the batch")
+	assert.True(t, drift.Drifts[0].ReplacementStale)
+}
+
+func TestValidateView_SQLite_NoReplacementClean(t *testing.T) {
+	// When the declared replacement does not exist live, validate is clean.
+	ctx, db, d := openSQLiteForViewLifecycle(t)
+	defer db.Close()
+
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	v := NewView("v_new", "SELECT id FROM t").
+		WithReplaces(chuck.ObjectName{Name: "v_old"})
+	require.NoError(t, ApplyView(ctx, db, d, v))
+	require.NoError(t, ValidateView(ctx, db, d, v))
+}
+
+func TestViewDriftError_Unwrap_AllReplacementStale(t *testing.T) {
+	e := &ViewDriftError{Drifts: []ViewDrift{
+		{Object: chuck.ObjectName{Name: "v_old_a"}, ReplacementStale: true},
+		{Object: chuck.ObjectName{Name: "v_old_b"}, ReplacementStale: true},
+	}}
+	assert.True(t, errors.Is(e, ErrViewReplacementStillExists))
+	assert.False(t, errors.Is(e, ErrViewMissing))
+	assert.False(t, errors.Is(e, ErrViewBodyDrift))
+}
+
 func TestApplyViews_SQLite_OrderRespected(t *testing.T) {
 	ctx, db, d := openSQLiteForViewLifecycle(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- Add `WithReplaces(names ...chuck.ObjectName)` on `ViewDef` and `ProcedureDef` to retire renamed/replaced owned code objects explicitly.
- Apply drops each listed prior name (same dialect-aware `DROP IF EXISTS` pattern); validate flags any listed prior name still live as `ReplacementStale=true` drift.
- New sentinels `ErrViewReplacementStillExists` / `ErrProcedureReplacementStillExists`; aggregated drift errors unwrap to these when stale replacements are the only cause.
- Batch helpers (`ApplyViews(WithOptions)` / `ValidateViews(WithOptions)` + procedure analogues) dedupe duplicate replacement names across defs by structured `ObjectName`.

## Why explicit-only
The packet calls out "no schema-wide pruning", "no automatic inference", "exact-name only". Implementation honors that — replacements only happen for names the caller lists. Same-type only (views replace views, procedures replace procedures).

## Files changed
- `schema/view.go`, `schema/procedure.go` — `replaces` field + `WithReplaces` + `Replaces` accessor
- `schema/view_lifecycle.go`, `schema/procedure_lifecycle.go` — new sentinels, `ReplacementStale` drift field, error/unwrap branches, internal apply/validate helpers with batch dedup
- `schema/view_lifecycle_test.go`, `schema/procedure_lifecycle_test.go` — SQLite apply/validate tests (view side), unwrap + builder tests (both sides)
- `schema/integration_test.go` — SQLite rename-rollout round trip with out-of-band resurrection and batch dedup
- `README.md` — new section documenting the API and apply / validate semantics

Closes #94.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [ ] MSSQL integration (`TestProcedureValidateApplyWithOptions_MSSQL`) — gated on `CHUCK_MSSQL_URL`, unaffected directly by this PR but procedure replacement code path shares unit-level coverage