### PR TITLE
fix(schema): format code object comments and ignore comment-only drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ if dialect.Engine() == chuck.MSSQL {
 
 A third lane is **declaration-owned** and lives on the object itself:
 
-- **`ViewDef.WithDocAnnotation(text)` / `ProcedureDef.WithDocAnnotation(text)`** — per-object doc comment carried by the declaration. Unlike `DocPreamble` (which is shared across many objects and apply-owned), the annotation is part of the object's own declared identity: it renders into the live SQL **and** participates in body-drift comparison, so changing the text in code produces validation drift against a live object rendered from the prior annotation.
+- **`ViewDef.WithDocAnnotation(text)` / `ProcedureDef.WithDocAnnotation(text)`** — per-object doc comment carried by the declaration. Unlike `DocPreamble` (which is shared across many objects and caller-controlled), the annotation hangs directly off the owned object and renders into the live SQL. Validation ignores leading comment-only front matter, so changing the text in code does **not** by itself produce drift.
 
 ```go
 v := schema.NewView("v_open_tasks",
@@ -628,7 +628,7 @@ v := schema.NewView("v_open_tasks",
     WithDocAnnotation("v_open_tasks v1: returns currently-open task ids")
 ```
 
-When all three are set the rendered order is **`DocPreamble`, then declaration-owned annotation, then `OwnershipNotice`**, then the payload. Each non-empty segment becomes a `/* ... */` SQL block comment followed by a single space. `Validate*WithOptions` strips the apply-owned segments (`DocPreamble` + `OwnershipNotice`) in their declared slots, retains the declaration-owned annotation in canonical comparison, and reports drift when the annotation in live SQL differs from the annotation in code. Live text that begins with a different leading comment still reports drift.
+When all three are set the rendered order is **`DocPreamble`, then per-object annotation, then `OwnershipNotice`**, then the payload. Each non-empty segment becomes its own `/* ... */` SQL block comment, with a blank line between comment blocks, and the payload starts on the next line after the final block. `Validate*WithOptions` strips configured front matter and then ignores any remaining leading block comments on both sides before comparing the executable statement body/definition, so comment-only changes do not report drift.
 
 Apply-owned tolerance, summarized:
 
@@ -636,17 +636,17 @@ Apply-owned tolerance, summarized:
 | --- | --- | --- |
 | Raw declared body (no comment) | pass | pass |
 | Raw declared body + configured prefix (preamble + notice) | drift | pass |
-| Raw declared body + a different leading comment | drift | drift |
+| Raw declared body + a different leading comment | pass | pass |
 | Raw declared body + stale configured prefix that no longer matches `opts` | drift | drift |
 
-Declaration-owned drift (per-object `WithDocAnnotation`):
+Per-object annotation behavior (`WithDocAnnotation`):
 
 | Declared annotation vs. live annotation | `ValidateViewWithOptions(opts)` |
 | --- | --- |
 | Same text in code and live SQL | pass |
-| Annotation changed in code (live still has prior text) | drift |
-| Annotation added in code (live has no annotation) | drift |
-| Annotation removed in code (live still carries old annotation) | drift |
+| Annotation changed in code (live still has prior text) | pass |
+| Annotation added in code (live has no annotation) | pass |
+| Annotation removed in code (live still carries old annotation) | pass |
 
 Bare `ApplyView` / `ValidateView` / `ApplyProcedure` / `ValidateProcedure` are unchanged: they neither inject nor tolerate markers.
 

--- a/schema/code_object_options.go
+++ b/schema/code_object_options.go
@@ -13,11 +13,11 @@ import "strings"
 // Validate*WithOptions. Validate-only callers may pass options without
 // forcing the markers to exist in the live database.
 //
-// For per-object documentation that should be declaration-owned — part of
-// the object's own SQL identity and a drift signal when changed — use
-// ViewDef.WithDocAnnotation / ProcedureDef.WithDocAnnotation instead. The
-// declaration-owned annotation renders between DocPreamble and
-// OwnershipNotice in the live SQL and is included in body-drift comparison.
+// For per-object documentation carried on the declaration itself, use
+// ViewDef.WithDocAnnotation / ProcedureDef.WithDocAnnotation instead. That
+// annotation renders between DocPreamble and OwnershipNotice in the live SQL.
+// Validation ignores leading block-comment front matter, so comment-only
+// changes do not participate in drift comparison.
 //
 // Intended usage is one central config built once in bootstrap and passed
 // to ApplyViewsWithOptions / ValidateViewsWithOptions /
@@ -36,12 +36,13 @@ import "strings"
 //	}
 //
 // Render order when fields are set: DocPreamble first, then any per-object
-// declaration-owned doc annotation, then OwnershipNotice, then payload. Each
-// non-empty segment is rendered as a `/* ... */` SQL block comment followed
-// by a single space. Validate*WithOptions strips this exact ordered prefix
-// from the live text before canonical comparison (keeping the
-// declaration-owned annotation, which participates in comparison); live text
-// that begins with a different leading comment will still report drift.
+// doc annotation, then OwnershipNotice, then payload. Each
+// non-empty segment is rendered as its own `/* ... */` SQL block comment;
+// comment blocks are separated by a blank line and the payload starts on the
+// next line after the final block. Validate*WithOptions strips this exact
+// ordered prefix from the live text before canonical comparison, then ignores
+// any remaining leading block-comment front matter on both sides; comment-only
+// changes therefore do not report drift.
 type CodeObjectOptions struct {
 	// OwnershipNotice is an opt-in apply-owned marker the option-aware Apply*
 	// helpers prepend to the rendered view body or procedure definition as a
@@ -50,8 +51,10 @@ type CodeObjectOptions struct {
 	// Validate*WithOptions tolerates absence of the marker in live text:
 	// stripping is best-effort, and live objects applied by bare helpers (or
 	// out-of-band with no notice) still validate cleanly against the same
-	// declared body. Different leading comments — including a stale notice
-	// that no longer matches the configured value — still report drift.
+	// declared body. Validation ignores leading block-comment front matter
+	// entirely, so different leading comments — including a stale notice
+	// that no longer matches the configured value — do not by themselves
+	// report drift.
 	//
 	// Engine notes:
 	//   - SQLite: comment survives in sqlite_master.sql.
@@ -71,8 +74,9 @@ type CodeObjectOptions struct {
 	// ownership — it is metadata only.
 	//
 	// Validate*WithOptions strips the exact configured DocPreamble from live
-	// text alongside OwnershipNotice. Absent or different leading comments
-	// follow the same tolerance/drift rules as OwnershipNotice.
+	// text alongside OwnershipNotice. Validation then ignores any remaining
+	// leading block-comment front matter, so absent or different leading
+	// comments follow the same comment-insensitive rules as OwnershipNotice.
 	DocPreamble string
 }
 
@@ -100,33 +104,35 @@ func renderOwnershipComment(notice string) string {
 
 // renderApplyPrefix returns the full configured comment prefix that
 // Apply*WithOptions prepends to the rendered body / definition payload.
-// Render order: DocPreamble (apply-owned), declared per-object annotation
-// (declaration-owned), OwnershipNotice (apply-owned). Each non-empty
-// segment contributes a `/* ... */ ` chunk (block comment plus single
-// trailing space). When all three are empty, returns "".
+// Render order: DocPreamble (apply-owned), declared per-object annotation,
+// OwnershipNotice (apply-owned). Each non-empty
+// segment becomes its own `/* ... */` block comment. Comment blocks are
+// separated by a blank line, and the returned prefix ends with a single
+// newline so the payload starts on the next line. When all three are
+// empty, returns "".
 func renderApplyPrefix(opts CodeObjectOptions, declaredAnnotation string) string {
-	var b strings.Builder
+	var comments []string
 	if c := renderOwnershipComment(opts.DocPreamble); c != "" {
-		b.WriteString(c)
-		b.WriteByte(' ')
+		comments = append(comments, c)
 	}
 	if c := renderOwnershipComment(declaredAnnotation); c != "" {
-		b.WriteString(c)
-		b.WriteByte(' ')
+		comments = append(comments, c)
 	}
 	if c := renderOwnershipComment(opts.OwnershipNotice); c != "" {
-		b.WriteString(c)
-		b.WriteByte(' ')
+		comments = append(comments, c)
 	}
-	return b.String()
+	if len(comments) == 0 {
+		return ""
+	}
+	return "\n" + strings.Join(comments, "\n\n") + "\n"
 }
 
 // applyOwnershipNoticePrefix returns the body or definition payload prefixed
 // with the rendered apply-comment prefix when one is set, otherwise the
-// payload unchanged. A single space separates each comment from the next
-// segment to keep the resulting statement well-formed regardless of whether
-// the payload starts with a SELECT keyword (views), a parameter declaration
-// (procedures), or an AS keyword (zero-parameter procedures).
+// payload unchanged. Comments render one-per-line with a blank line between
+// blocks so DB readers can scan stacked annotations more easily, regardless
+// of whether the payload starts with a SELECT keyword (views), a parameter
+// declaration (procedures), or an AS keyword (zero-parameter procedures).
 //
 // declaredAnnotation is the per-object declaration-owned doc annotation
 // (ViewDef.DocAnnotation / ProcedureDef.DocAnnotation); pass "" when not
@@ -141,15 +147,31 @@ func applyOwnershipNoticePrefix(payload string, opts CodeObjectOptions, declared
 	return prefix + payload
 }
 
+// joinSQLHeadPayload concatenates a DDL head (e.g. `CREATE VIEW ... AS`) with
+// a caller-supplied body or definition. When the payload already begins with
+// whitespace/newline (as option-aware comment prefixes do), it is appended
+// directly so the generated SQL stays clean; otherwise a single space is
+// inserted.
+func joinSQLHeadPayload(head, payload string) string {
+	if payload == "" {
+		return head
+	}
+	switch payload[0] {
+	case ' ', '\t', '\r', '\n':
+		return head + payload
+	default:
+		return head + " " + payload
+	}
+}
+
 // stripConfiguredApplyPrefix strips the exact configured DocPreamble and
 // OwnershipNotice comment prefixes from the front of live text in their
 // declared render order, plus any leading whitespace. When a per-object
-// declaration-owned doc annotation is declared, it is recognized in its
-// natural slot (between DocPreamble and OwnershipNotice) and retained in
-// the returned string so it can participate in canonical drift comparison.
-// Configured-but-absent apply-owned markers are tolerated; an absent or
-// mismatched declaration-owned annotation reports as body drift because
-// declared identity has changed.
+// doc annotation is declared, it is recognized in its natural slot (between
+// DocPreamble and OwnershipNotice) and retained in the returned string.
+// Configured-but-absent apply-owned markers are tolerated. Callers that want
+// comment-insensitive comparison can run broader leading-comment
+// normalization after this helper.
 func stripConfiguredApplyPrefix(live string, opts CodeObjectOptions, declaredAnnotation string) string {
 	docComment := renderOwnershipComment(opts.DocPreamble)
 	annComment := renderOwnershipComment(declaredAnnotation)

--- a/schema/code_object_options_test.go
+++ b/schema/code_object_options_test.go
@@ -41,45 +41,45 @@ func TestApplyOwnershipNoticePrefix(t *testing.T) {
 		assert.Equal(t, "SELECT 1", got)
 	})
 
-	t.Run("notice-only is prepended with single space separator", func(t *testing.T) {
+	t.Run("notice-only is prepended on its own line", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
 			CodeObjectOptions{OwnershipNotice: "owned"}, "")
-		assert.Equal(t, "/* owned */ SELECT 1", got)
+		assert.Equal(t, "\n/* owned */\nSELECT 1", got)
 	})
 
-	t.Run("doc-preamble-only is prepended with single space separator", func(t *testing.T) {
+	t.Run("doc-preamble-only is prepended on its own line", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
 			CodeObjectOptions{DocPreamble: "doc"}, "")
-		assert.Equal(t, "/* doc */ SELECT 1", got)
+		assert.Equal(t, "\n/* doc */\nSELECT 1", got)
 	})
 
 	t.Run("both fields render in preamble-then-notice order", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
 			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "")
-		assert.Equal(t, "/* doc */ /* owned */ SELECT 1", got)
+		assert.Equal(t, "\n/* doc */\n\n/* owned */\nSELECT 1", got)
 	})
 
 	t.Run("proc-style payload (leading param) is preserved verbatim", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("@AgentID INT AS BEGIN SELECT 1 END",
 			CodeObjectOptions{OwnershipNotice: "owned"}, "")
-		assert.Equal(t, "/* owned */ @AgentID INT AS BEGIN SELECT 1 END", got)
+		assert.Equal(t, "\n/* owned */\n@AgentID INT AS BEGIN SELECT 1 END", got)
 	})
 
 	t.Run("declared annotation alone is prepended", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1", CodeObjectOptions{}, "ann")
-		assert.Equal(t, "/* ann */ SELECT 1", got)
+		assert.Equal(t, "\n/* ann */\nSELECT 1", got)
 	})
 
 	t.Run("annotation renders between DocPreamble and OwnershipNotice", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
 			CodeObjectOptions{OwnershipNotice: "owned", DocPreamble: "doc"}, "ann")
-		assert.Equal(t, "/* doc */ /* ann */ /* owned */ SELECT 1", got)
+		assert.Equal(t, "\n/* doc */\n\n/* ann */\n\n/* owned */\nSELECT 1", got)
 	})
 
 	t.Run("annotation + notice (no preamble)", func(t *testing.T) {
 		got := applyOwnershipNoticePrefix("SELECT 1",
 			CodeObjectOptions{OwnershipNotice: "owned"}, "ann")
-		assert.Equal(t, "/* ann */ /* owned */ SELECT 1", got)
+		assert.Equal(t, "\n/* ann */\n\n/* owned */\nSELECT 1", got)
 	})
 }
 
@@ -144,16 +144,13 @@ func TestStripConfiguredApplyPrefix(t *testing.T) {
 		assert.Equal(t, "/* ann */ SELECT 1", got)
 	})
 
-	t.Run("declared annotation missing in live yields drift signal", func(t *testing.T) {
-		// Live lacks the declared annotation entirely. Strip leaves the
-		// payload alone so canonical compare against
-		// `annotation + body` reports drift.
+	t.Run("declared annotation missing in live leaves payload untouched", func(t *testing.T) {
 		got := stripConfiguredApplyPrefix("SELECT 1",
 			CodeObjectOptions{}, "ann")
 		assert.Equal(t, "SELECT 1", got)
 	})
 
-	t.Run("declared annotation mismatched in live yields drift signal", func(t *testing.T) {
+	t.Run("declared annotation mismatched in live is left in place", func(t *testing.T) {
 		// Live carries a different annotation comment in the annotation
 		// slot; strip leaves it in place (not matching the declared
 		// annotation) and OwnershipNotice strip cannot proceed past it.
@@ -182,7 +179,7 @@ func TestApplyViewWithOptions_NoticeRendersIntoBody(t *testing.T) {
 		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
-		"CREATE VIEW \"v_x\" AS /* owned */ SELECT 1",
+		"CREATE VIEW \"v_x\" AS\n/* owned */\nSELECT 1",
 	}
 	assert.Equal(t, want, got)
 }
@@ -194,7 +191,7 @@ func TestApplyViewWithOptions_DocPreambleAndNoticeRender(t *testing.T) {
 		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
-		"CREATE VIEW \"v_x\" AS /* doc */ /* owned */ SELECT 1",
+		"CREATE VIEW \"v_x\" AS\n/* doc */\n\n/* owned */\nSELECT 1",
 	}
 	assert.Equal(t, want, got)
 }
@@ -205,10 +202,10 @@ func TestApplyViewWithOptions_NoticeRendersForMSSQLAndPostgres(t *testing.T) {
 	body := applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation())
 
 	mssql := v.createOrReplaceWithBody(chuck.MSSQLDialect{}, body)
-	assert.Equal(t, []string{"CREATE OR ALTER VIEW [sg].[v_x] AS /* owned */ SELECT 1"}, mssql)
+	assert.Equal(t, []string{"CREATE OR ALTER VIEW [sg].[v_x] AS\n/* owned */\nSELECT 1"}, mssql)
 
 	pg := v.createOrReplaceWithBody(chuck.PostgresDialect{}, body)
-	assert.Equal(t, []string{`CREATE OR REPLACE VIEW "sg"."v_x" AS /* owned */ SELECT 1`}, pg)
+	assert.Equal(t, []string{"CREATE OR REPLACE VIEW \"sg\".\"v_x\" AS\n/* owned */\nSELECT 1"}, pg)
 }
 
 func TestApplyViewWithOptions_DocAnnotationRendersBetweenPreambleAndNotice(t *testing.T) {
@@ -218,7 +215,7 @@ func TestApplyViewWithOptions_DocAnnotationRendersBetweenPreambleAndNotice(t *te
 		applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
-		"CREATE VIEW \"v_x\" AS /* doc */ /* ann */ /* owned */ SELECT 1",
+		"CREATE VIEW \"v_x\" AS\n/* doc */\n\n/* ann */\n\n/* owned */\nSELECT 1",
 	}
 	assert.Equal(t, want, got)
 }
@@ -229,7 +226,7 @@ func TestApplyViewWithOptions_DocAnnotationAlone(t *testing.T) {
 		applyOwnershipNoticePrefix(v.Body(), CodeObjectOptions{}, v.DocAnnotation()))
 	want := []string{
 		"DROP VIEW IF EXISTS \"v_x\"",
-		"CREATE VIEW \"v_x\" AS /* ann */ SELECT 1",
+		"CREATE VIEW \"v_x\" AS\n/* ann */\nSELECT 1",
 	}
 	assert.Equal(t, want, got)
 }
@@ -242,7 +239,7 @@ func TestApplyProcedureWithOptions_NoticeRendersIntoDefinition(t *testing.T) {
 	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"CREATE OR ALTER PROCEDURE [sg].[usp_X] /* owned */ @AgentID INT AS BEGIN SET NOCOUNT ON; SELECT 1 END",
+		"CREATE OR ALTER PROCEDURE [sg].[usp_X]\n/* owned */\n@AgentID INT AS BEGIN SET NOCOUNT ON; SELECT 1 END",
 		stmt)
 }
 
@@ -264,7 +261,7 @@ func TestApplyProcedureWithOptions_DocAnnotationRendersBetweenPreambleAndNotice(
 	stmt, err := p.createOrAlterWithDefinition(chuck.MSSQLDialect{}, definition)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"CREATE OR ALTER PROCEDURE [sg].[usp_X] /* doc */ /* ann */ /* owned */ @AgentID INT AS BEGIN SELECT 1 END",
+		"CREATE OR ALTER PROCEDURE [sg].[usp_X]\n/* doc */\n\n/* ann */\n\n/* owned */\n@AgentID INT AS BEGIN SELECT 1 END",
 		stmt)
 }
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -468,8 +468,8 @@ func TestProcedureValidateApply_MSSQL(t *testing.T) {
 //   - bare ApplyView strips the markers; validate-with-options against the
 //     bare live body is clean (apply-owned tolerance — markers are not
 //     required to exist live)
-//   - live body with a different leading comment still reports drift under
-//     validate-with-options
+//   - live body with a different leading comment still validates cleanly
+//     because comment-only front matter is ignored
 func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
@@ -510,11 +510,9 @@ func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
 	require.True(t, docIdx >= 0 && notIdx >= 0)
 	assert.Less(t, docIdx, notIdx, "DocPreamble must render before OwnershipNotice")
 
-	// Bare ValidateView (no opts) must see the live comments as body drift —
-	// raw declared body has no leading comment.
-	err = schema.ValidateView(ctx, db, d, v)
-	require.Error(t, err, "bare ValidateView must report drift when live body carries apply-only markers")
-	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+	// Bare ValidateView (no opts) also passes: leading comment-only front
+	// matter is ignored during body comparison.
+	require.NoError(t, schema.ValidateView(ctx, db, d, v))
 
 	// Bare ApplyView strips the markers; validate-with-options against the
 	// bare live body must be clean — apply-owned tolerance lets validate
@@ -525,28 +523,27 @@ func TestViewValidateApplyWithOptions_SQLite_OwnershipNotice(t *testing.T) {
 	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, v),
 		"apply-owned: validate-with-options must tolerate live body without markers")
 
-	// Different leading comment must still report drift under validate-with-options.
+	// Different leading comment still validates: comment-only front matter
+	// does not participate in body drift.
 	_, err = db.ExecContext(ctx,
 		`DROP VIEW IF EXISTS v_vva_on_open; `+
 			`CREATE VIEW v_vva_on_open AS /* unexpected stale notice */ SELECT id FROM vva_on_tasks WHERE done = 0`)
 	require.NoError(t, err)
-	err = schema.ValidateViewWithOptions(ctx, db, d, opts, v)
-	require.Error(t, err, "validate-with-options must report drift when live body has a different leading comment")
-	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, v),
+		"validate-with-options must ignore comment-only front matter drift")
 }
 
-// TestViewValidateApplyWithOptions_SQLite_DocAnnotation asserts the
-// declaration-owned per-object doc annotation contract on SQLite.
+// TestViewValidateApplyWithOptions_SQLite_DocAnnotation asserts the per-object
+// doc annotation render contract on SQLite.
 //
 // Contract covered:
 //
 //   - apply + validate with the same declared annotation is coherent
 //   - the rendered annotation lands in sqlite_master.sql between the
 //     caller-level DocPreamble and the caller-level OwnershipNotice
-//   - changing the declared annotation in code produces validation drift
-//     against a live view rendered from the prior annotation
-//     (declaration-owned semantics, distinct from apply-owned DocPreamble)
-//   - the annotation also drives drift when used without any caller-level
+//   - changing the declared annotation in code does not produce validation
+//     drift because comment-only front matter is ignored
+//   - the same ignore-comments rule holds even without any caller-level
 //     decoration
 func TestViewValidateApplyWithOptions_SQLite_DocAnnotation(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
@@ -586,21 +583,17 @@ func TestViewValidateApplyWithOptions_SQLite_DocAnnotation(t *testing.T) {
 	assert.Less(t, docIdx, annIdx, "DocPreamble must render before doc annotation")
 	assert.Less(t, annIdx, notIdx, "doc annotation must render before OwnershipNotice")
 
-	// Declaration-owned drift: change the annotation in code and validate
-	// must complain even though the live SQL still carries the prior
-	// annotation that was apply-rendered.
+	// Change annotation text in code. Validation still passes because
+	// leading comments are documentation, not executable view semantics.
 	vDrifted := schema.NewView("v_vva_da_open", "SELECT id FROM vva_da_tasks WHERE done = 0").
 		WithDocAnnotation("v_vva_da_open v2: SEMANTIC CHANGE — please review caller")
-	err = schema.ValidateViewWithOptions(ctx, db, d, opts, vDrifted)
-	require.Error(t, err, "declared annotation change must surface as body drift")
-	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, vDrifted),
+		"declared annotation change must not surface as body drift")
 
-	// Annotation alone (no caller-level options) still drives drift when
-	// declared annotation disagrees with live.
+	// Same for annotation-only rendering with no caller-level options.
 	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, v))
-	err = schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, vDrifted)
-	require.Error(t, err, "annotation-only declaration must drive drift on its own")
-	assert.ErrorIs(t, err, schema.ErrViewBodyDrift)
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, vDrifted),
+		"annotation-only declaration must not drive drift on its own")
 
 	// Same declaration as live still validates clean under annotation-only.
 	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, schema.CodeObjectOptions{}, v))
@@ -737,10 +730,9 @@ func TestProcedureValidateApplyWithOptions_MSSQL(t *testing.T) {
 	require.Contains(t, live, "may fail validation or be overwritten")
 	require.Contains(t, live, "probe procedure for VVA notice contract")
 
-	// Bare ValidateProcedure (no opts) must see the live markers as drift.
-	err = schema.ValidateProcedure(ctx, db, d, proc)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, schema.ErrProcedureDefinitionDrift)
+	// Bare ValidateProcedure (no opts) also passes: leading comments do not
+	// participate in executable-definition drift.
+	require.NoError(t, schema.ValidateProcedure(ctx, db, d, proc))
 
 	// Bare ApplyProcedure strips the markers; validate-with-options against
 	// the bare live definition must be clean — apply-owned tolerance.

--- a/schema/procedure.go
+++ b/schema/procedure.go
@@ -80,13 +80,13 @@ func (p *ProcedureDef) Schema() string {
 	return p.schema
 }
 
-// WithDocAnnotation attaches a declaration-owned doc comment to the procedure.
+// WithDocAnnotation attaches a per-procedure doc comment to the declaration.
 // When set, the annotation renders as a SQL block comment as part of the
-// procedure's own SQL output (between any caller-level DocPreamble and any
-// caller-level OwnershipNotice) and participates in definition-drift
-// comparison: changing the annotation in code produces validation drift
-// against a live procedure rendered from the prior annotation. This is the
-// per-object counterpart to CodeObjectOptions.DocPreamble.
+// procedure's live SQL output (between any caller-level DocPreamble and any
+// caller-level OwnershipNotice). Validation intentionally ignores leading
+// block-comment front matter, so changing this annotation does not by itself
+// produce drift. This is the per-object counterpart to
+// CodeObjectOptions.DocPreamble.
 func (p *ProcedureDef) WithDocAnnotation(text string) *ProcedureDef {
 	p.docAnnotation = text
 	return p
@@ -172,7 +172,7 @@ func (p *ProcedureDef) createOrAlterWithDefinition(d chuck.Dialect, definition s
 	if d.Engine() != chuck.MSSQL {
 		return "", fmt.Errorf("%w: %s", ErrProcedureDialectUnsupported, d.Engine())
 	}
-	return fmt.Sprintf("CREATE OR ALTER PROCEDURE %s %s", p.QualifiedNameFor(d), definition), nil
+	return joinSQLHeadPayload(fmt.Sprintf("CREATE OR ALTER PROCEDURE %s", p.QualifiedNameFor(d)), definition), nil
 }
 
 // DropSQL returns a single safe `DROP PROCEDURE` statement that probes

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -174,13 +174,12 @@ func ValidateProcedure(ctx context.Context, db *sql.DB, d chuck.Dialect, p *Proc
 }
 
 // ValidateProcedureWithOptions is the option-aware counterpart to
-// ValidateProcedure. Ownership decoration is apply-owned, not
-// declaration-owned: when opts.OwnershipNotice or opts.DocPreamble are
-// configured, the exact rendered prefix is stripped from the live
-// definition before canonical comparison. Live definitions that do not
-// carry the configured markers still validate cleanly against the same
-// declared definition; live definitions that carry a different leading
-// comment (including a stale notice) still report drift.
+// ValidateProcedure. Leading block comments are treated as documentation, not
+// executable procedure semantics: validation strips any leading block-comment
+// stack from both the declared definition and the live definition before
+// canonical comparison. This means ownership notices, doc preambles,
+// per-object annotations, and other leading `/* ... */` front matter do not
+// cause drift on their own.
 //
 // When the procedure declares prior names via WithReplaces, any of those
 // names still present in the live database surface as additional drift
@@ -217,8 +216,8 @@ func validateProcedureWithOptionsInternal(ctx context.Context, db *sql.DB, d chu
 			Reason:  "procedure does not exist",
 		})
 	} else {
-		liveStripped := stripConfiguredApplyPrefix(live, opts, p.DocAnnotation())
-		declaredCanon := canonicalizeStatement(declaredDefinitionWithAnnotation(p))
+		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, opts, p.DocAnnotation()))
+		declaredCanon := canonicalizeStatement(stripLeadingBlockComments(p.Definition()))
 		liveCanon := canonicalizeStatement(liveStripped)
 		if declaredCanon != liveCanon {
 			drifts = append(drifts, ProcedureDrift{

--- a/schema/view.go
+++ b/schema/view.go
@@ -57,12 +57,12 @@ func (v *ViewDef) Schema() string {
 	return v.schema
 }
 
-// WithDocAnnotation attaches a declaration-owned doc comment to the view. When
-// set, the annotation renders as a SQL block comment as part of the view's
-// own SQL output (between any caller-level DocPreamble and any caller-level
-// OwnershipNotice) and participates in body-drift comparison: changing the
-// annotation in code produces validation drift against a live view rendered
-// from the prior annotation. This is the per-object counterpart to
+// WithDocAnnotation attaches a per-view doc comment to the view declaration.
+// When set, the annotation renders as a SQL block comment as part of the
+// view's live SQL output (between any caller-level DocPreamble and any
+// caller-level OwnershipNotice). Validation intentionally ignores leading
+// block-comment front matter, so changing this annotation does not by itself
+// produce drift. This is the per-object counterpart to
 // CodeObjectOptions.DocPreamble, which remains a caller-level apply-owned
 // preamble shared across many objects.
 func (v *ViewDef) WithDocAnnotation(text string) *ViewDef {
@@ -148,18 +148,18 @@ func (v *ViewDef) createOrReplaceWithBody(d chuck.Dialect, body string) []string
 	qt := v.QualifiedNameFor(d)
 	switch d.Engine() {
 	case chuck.Postgres:
-		return []string{fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", qt, body)}
+		return []string{joinSQLHeadPayload(fmt.Sprintf("CREATE OR REPLACE VIEW %s AS", qt), body)}
 	case chuck.MSSQL:
-		return []string{fmt.Sprintf("CREATE OR ALTER VIEW %s AS %s", qt, body)}
+		return []string{joinSQLHeadPayload(fmt.Sprintf("CREATE OR ALTER VIEW %s AS", qt), body)}
 	case chuck.SQLite:
 		return []string{
 			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
-			fmt.Sprintf("CREATE VIEW %s AS %s", qt, body),
+			joinSQLHeadPayload(fmt.Sprintf("CREATE VIEW %s AS", qt), body),
 		}
 	default:
 		return []string{
 			fmt.Sprintf("DROP VIEW IF EXISTS %s", qt),
-			fmt.Sprintf("CREATE VIEW %s AS %s", qt, body),
+			joinSQLHeadPayload(fmt.Sprintf("CREATE VIEW %s AS", qt), body),
 		}
 	}
 }

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -245,24 +245,21 @@ func stripCreateViewPreamble(s string) string {
 	return s[loc[1]:]
 }
 
-// declaredBodyWithAnnotation returns the declared body that participates in
-// canonical drift comparison: when the view carries a declaration-owned doc
-// annotation it is rendered as a SQL block comment immediately before the
-// declared body, matching the slot the apply path injects.
-func declaredBodyWithAnnotation(v *ViewDef) string {
-	if c := renderOwnershipComment(v.DocAnnotation()); c != "" {
-		return c + " " + v.Body()
+// stripLeadingBlockComments removes any number of leading SQL block comments
+// plus surrounding leading whitespace. Used by validation so stacked doc /
+// ownership annotations do not participate in drift comparison; callers want
+// the actual executable statement body/definition checked, not front-matter
+// comments.
+func stripLeadingBlockComments(s string) string {
+	out := strings.TrimLeftFunc(s, unicode.IsSpace)
+	for strings.HasPrefix(out, "/*") {
+		end := strings.Index(out, "*/")
+		if end < 0 {
+			return out
+		}
+		out = strings.TrimLeftFunc(out[end+2:], unicode.IsSpace)
 	}
-	return v.Body()
-}
-
-// declaredDefinitionWithAnnotation is the procedure-side counterpart to
-// declaredBodyWithAnnotation.
-func declaredDefinitionWithAnnotation(p *ProcedureDef) string {
-	if c := renderOwnershipComment(p.DocAnnotation()); c != "" {
-		return c + " " + p.Definition()
-	}
-	return p.Definition()
+	return out
 }
 
 // canonicalizeStatement normalizes a SQL statement body for drift comparison.
@@ -321,14 +318,11 @@ func ValidateView(ctx context.Context, db *sql.DB, d chuck.Dialect, v *ViewDef) 
 }
 
 // ValidateViewWithOptions is the option-aware counterpart to ValidateView.
-// Ownership decoration is apply-owned, not declaration-owned: when
-// opts.OwnershipNotice or opts.DocPreamble are configured, the exact
-// rendered prefix is stripped from the live body before canonical
-// comparison. Live bodies that do not carry the configured markers still
-// validate cleanly against the same declared body, so validate-only callers
-// can pass options without forcing markers into the live object. Live
-// bodies that carry a different leading comment (including a stale notice
-// that no longer matches the configured value) still report drift.
+// Leading block comments are treated as documentation, not executable view
+// semantics: validation strips any leading block-comment stack from both the
+// declared body and the live body before canonical comparison. This means
+// ownership notices, doc preambles, per-object annotations, and other leading
+// `/* ... */` front matter do not cause drift on their own.
 //
 // When the view declares prior names via WithReplaces, any of those names
 // still present in the live database surface as additional drift entries
@@ -371,8 +365,8 @@ func validateViewWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Di
 			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
 		})
 	default:
-		liveStripped := stripConfiguredApplyPrefix(live, opts, v.DocAnnotation())
-		declaredCanon := canonicalizeStatement(declaredBodyWithAnnotation(v))
+		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, opts, v.DocAnnotation()))
+		declaredCanon := canonicalizeStatement(stripLeadingBlockComments(v.Body()))
 		liveCanon := canonicalizeStatement(liveStripped)
 		if declaredCanon != liveCanon {
 			drifts = append(drifts, ViewDrift{


### PR DESCRIPTION
## Summary
- render stacked view/procedure comments on separate lines with blank lines between blocks
- ignore leading block-comment front matter during view/procedure validation
- update tests and docs to reflect comment-insensitive validation

## Validation
- go test ./...
- golangci-lint run --timeout=5m ./...