### PR TITLE
feat(schema): owned code-object notice points at metadata ledger when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,27 @@ read the ledger and does not produce drift over missing or stale ledger
 rows. Empty provenance fields are stored as SQL `NULL` so the ledger can
 distinguish "not recorded" from "recorded as empty string".
 
+When `OwnershipNotice` and `Metadata` are both set, the rendered chuck-owned
+ownership comment carries an extra single-line pointer to the ledger so DB
+readers inspecting the live view or procedure can jump straight to the row
+that records its provenance:
+
+```sql
+CREATE VIEW "v_open_tasks" AS
+/* Owned by https://github.com/catgoose/chuck. Do not edit in database.
+Out-of-band changes may fail validation or be overwritten by apply/bootstrap.
+Provenance recorded in "ops"."chuck_object_metadata". */
+SELECT id FROM tasks WHERE done = 0
+```
+
+The pointer uses the dialect-quoted, schema-qualified form of
+`chuck_object_metadata` (bare on SQLite; bracketed on MSSQL; double-quoted
+on Postgres). It is only added when an ownership notice is already
+rendering — `Metadata` alone never invents a fresh ownership block — and is
+omitted when `Metadata` is `nil`, so the pointer text stays honest about
+whether the ledger is actually enabled. Comment-only changes do not move
+`last_changed` and do not produce drift.
+
 ### Schema Snapshots
 
 Export the declared schema in structured or text format for diffing:

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -894,3 +894,87 @@ func readDatabaseMetadataRow(t *testing.T, ctx context.Context, db *sql.DB, owne
 		  WHERE owner = ?`, owner).Scan(&firstApplied, &lastApplied))
 	return firstApplied, lastApplied
 }
+
+// TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice asserts the
+// metadata-pointer augmentation contract end-to-end on SQLite.
+//
+// Contract covered:
+//
+//   - ApplyViewWithOptions with both OwnershipNotice and Metadata renders a
+//     provenance pointer line inside the ownership block comment, naming the
+//     dialect-quoted chuck_object_metadata table
+//   - apply + validate with the same opts stay coherent — the strict
+//     configured-prefix strip recognises the augmented notice
+//   - bare validate (no opts) still passes because leading comment-only
+//     front matter is ignored
+//   - metadata-only (no OwnershipNotice) does NOT invent a fresh ownership
+//     block; nothing chuck-related lands in the leading comments
+//   - notice-only (no Metadata) does NOT include the provenance pointer
+func TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE vva_ptr_tasks (id INTEGER PRIMARY KEY, done INTEGER)`)
+	require.NoError(t, err)
+	defer func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS vva_ptr_tasks`) }()
+
+	cfg := schema.MetadataConfig{
+		Owner: "bootstrap",
+		Now:   (&integrationFakeClock{cur: time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)}).Now,
+	}
+	require.NoError(t, schema.EnsureMetadataTables(ctx, db, d, cfg))
+
+	v := schema.NewView("v_vva_ptr_open", "SELECT id FROM vva_ptr_tasks WHERE done = 0")
+	defer func() { _, _ = db.ExecContext(ctx, v.DropSQL(d)) }()
+
+	// Notice + metadata: pointer line lands inside the ownership block.
+	opts := schema.CodeObjectOptions{
+		OwnershipNotice: schema.DefaultOwnershipNotice,
+		Metadata:        &cfg,
+	}
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, opts, v))
+	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, opts, v),
+		"apply + validate with same opts must be coherent against the augmented notice")
+	require.NoError(t, schema.ValidateView(ctx, db, d, v),
+		"bare validate must still pass: comment-only front matter is ignored")
+
+	var liveSQL string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_ptr_open").
+		Scan(&liveSQL))
+	assert.Contains(t, liveSQL, `Provenance recorded in "chuck_object_metadata".`,
+		"ownership notice must carry the metadata pointer when both notice and Metadata are set")
+	assert.Contains(t, liveSQL, "Owned by https://github.com/catgoose/chuck",
+		"base ownership text must still be present")
+	noticeIdx := strings.Index(liveSQL, "Owned by https://github.com/catgoose/chuck")
+	pointerIdx := strings.Index(liveSQL, "Provenance recorded in")
+	require.True(t, noticeIdx >= 0 && pointerIdx >= 0)
+	assert.Less(t, noticeIdx, pointerIdx, "provenance pointer must follow the base notice text")
+
+	// Metadata-only (no OwnershipNotice) must NOT invent a fresh ownership
+	// block. The view is re-applied so we observe a fresh leading comment
+	// surface in sqlite_master.
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d,
+		schema.CodeObjectOptions{Metadata: &cfg}, v))
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_ptr_open").
+		Scan(&liveSQL))
+	assert.NotContains(t, liveSQL, "Provenance recorded in",
+		"metadata-only must not emit a provenance comment when no ownership notice rides along")
+	assert.NotContains(t, liveSQL, "Owned by https://github.com/catgoose/chuck")
+
+	// Notice-only (no Metadata): pointer must NOT be present.
+	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d,
+		schema.CodeObjectOptions{OwnershipNotice: schema.DefaultOwnershipNotice}, v))
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_ptr_open").
+		Scan(&liveSQL))
+	assert.Contains(t, liveSQL, "Owned by https://github.com/catgoose/chuck",
+		"notice-only must still emit the base ownership notice")
+	assert.NotContains(t, liveSQL, "Provenance recorded in",
+		"notice-only must not carry a metadata pointer when no ledger is enabled")
+}

--- a/schema/metadata.go
+++ b/schema/metadata.go
@@ -224,6 +224,39 @@ func recordCodeObjectMetadata(
 	return upsertDatabaseRow(ctx, db, d, cfg, now)
 }
 
+// metadataNoticePointer returns the single-line ledger pointer sentence the
+// ownership-notice augmentation appends to the rendered chuck-owned comment
+// when snapshot metadata is enabled. The pointer references the dialect-
+// qualified, quoted form of the chuck_object_metadata table so DB readers
+// reading the live SQL can jump straight to the ledger row that records
+// this object's provenance. SQLite drops the schema component per the
+// standard QualifyTable contract; Postgres / MSSQL render schema-qualified
+// when cfg.Schema is set and bare otherwise.
+//
+// Lives next to MetadataConfig so the table-name rendering stays close to
+// the ledger's own DDL.
+func metadataNoticePointer(d chuck.Dialect, cfg MetadataConfig) string {
+	return "Provenance recorded in " + qualifyTable(d, cfg.objectMetadataObject()) + "."
+}
+
+// effectiveOptionsForRender returns opts with OwnershipNotice augmented by a
+// metadata-ledger pointer line when both OwnershipNotice is non-empty and
+// opts.Metadata is non-nil. Apply and validate paths both call this so the
+// rendered comment text and the strict-strip configured-prefix recognition
+// stay symmetric — what apply writes, the validate strict-strip sees and
+// removes intact rather than relying on the broader leading-comment strip.
+//
+// When OwnershipNotice is empty no pointer is added: the contract is that a
+// metadata pointer rides along with an existing ownership notice rather than
+// inventing a fresh ownership block on metadata's behalf.
+func effectiveOptionsForRender(d chuck.Dialect, opts CodeObjectOptions) CodeObjectOptions {
+	if opts.OwnershipNotice == "" || opts.Metadata == nil {
+		return opts
+	}
+	opts.OwnershipNotice = opts.OwnershipNotice + "\n" + metadataNoticePointer(d, *opts.Metadata)
+	return opts
+}
+
 // metadataObjectColumns returns the (object_schema, object_name) pair used to
 // key chuck_object_metadata rows for the given owned object. The schema
 // component reuses the same default-resolution contract as the live-database

--- a/schema/metadata_test.go
+++ b/schema/metadata_test.go
@@ -156,6 +156,97 @@ func TestRecordCodeObjectMetadata_NilProvenanceWritesNull_SQLite(t *testing.T) {
 	assert.False(t, row.toolVersion.Valid, "empty ToolVersion must write SQL NULL")
 }
 
+func TestMetadataNoticePointer_QualifiesAcrossDialects(t *testing.T) {
+	cases := []struct {
+		name    string
+		dialect chuck.Dialect
+		schema  string
+		want    string
+	}{
+		{
+			name:    "sqlite drops schema even when configured",
+			dialect: chuck.SQLiteDialect{},
+			schema:  "ops",
+			want:    `Provenance recorded in "chuck_object_metadata".`,
+		},
+		{
+			name:    "sqlite bare unqualified",
+			dialect: chuck.SQLiteDialect{},
+			schema:  "",
+			want:    `Provenance recorded in "chuck_object_metadata".`,
+		},
+		{
+			name:    "postgres unqualified renders bare",
+			dialect: chuck.PostgresDialect{},
+			schema:  "",
+			want:    `Provenance recorded in "chuck_object_metadata".`,
+		},
+		{
+			name:    "postgres explicit schema renders qualified",
+			dialect: chuck.PostgresDialect{},
+			schema:  "ops",
+			want:    `Provenance recorded in "ops"."chuck_object_metadata".`,
+		},
+		{
+			name:    "mssql unqualified renders bracketed bare",
+			dialect: chuck.MSSQLDialect{},
+			schema:  "",
+			want:    `Provenance recorded in [chuck_object_metadata].`,
+		},
+		{
+			name:    "mssql explicit schema renders bracketed qualified",
+			dialect: chuck.MSSQLDialect{},
+			schema:  "ops",
+			want:    `Provenance recorded in [ops].[chuck_object_metadata].`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := MetadataConfig{Owner: "t", Schema: tc.schema}
+			assert.Equal(t, tc.want, metadataNoticePointer(tc.dialect, cfg))
+		})
+	}
+}
+
+func TestEffectiveOptionsForRender_AugmentsOnlyWhenNoticeAndMetadataBothSet(t *testing.T) {
+	d := chuck.SQLiteDialect{}
+	cfg := MetadataConfig{Owner: "t"}
+
+	t.Run("both nil-like: opts unchanged", func(t *testing.T) {
+		opts := CodeObjectOptions{}
+		got := effectiveOptionsForRender(d, opts)
+		assert.Equal(t, "", got.OwnershipNotice)
+		assert.Nil(t, got.Metadata)
+	})
+
+	t.Run("notice set, metadata nil: opts unchanged", func(t *testing.T) {
+		opts := CodeObjectOptions{OwnershipNotice: "owned"}
+		got := effectiveOptionsForRender(d, opts)
+		assert.Equal(t, "owned", got.OwnershipNotice, "notice unchanged when no metadata pointer to add")
+	})
+
+	t.Run("notice empty, metadata set: opts unchanged (no fresh ownership block invented)", func(t *testing.T) {
+		opts := CodeObjectOptions{Metadata: &cfg}
+		got := effectiveOptionsForRender(d, opts)
+		assert.Equal(t, "", got.OwnershipNotice, "metadata alone must not invent an OwnershipNotice")
+	})
+
+	t.Run("both set: notice augmented with provenance pointer", func(t *testing.T) {
+		opts := CodeObjectOptions{OwnershipNotice: "owned", Metadata: &cfg}
+		got := effectiveOptionsForRender(d, opts)
+		assert.Equal(t,
+			"owned\nProvenance recorded in \"chuck_object_metadata\".",
+			got.OwnershipNotice)
+	})
+
+	t.Run("does not mutate caller's CodeObjectOptions value", func(t *testing.T) {
+		opts := CodeObjectOptions{OwnershipNotice: "owned", Metadata: &cfg}
+		_ = effectiveOptionsForRender(d, opts)
+		assert.Equal(t, "owned", opts.OwnershipNotice,
+			"caller's opts must remain unchanged — effective opts is a value copy")
+	})
+}
+
 func TestMetadataObjectColumns_DefaultsMatchLiveInspectionSchema(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/schema/procedure_lifecycle.go
+++ b/schema/procedure_lifecycle.go
@@ -216,7 +216,8 @@ func validateProcedureWithOptionsInternal(ctx context.Context, db *sql.DB, d chu
 			Reason:  "procedure does not exist",
 		})
 	} else {
-		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, opts, p.DocAnnotation()))
+		effOpts := effectiveOptionsForRender(d, opts)
+		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, effOpts, p.DocAnnotation()))
 		declaredCanon := canonicalizeStatement(stripLeadingBlockComments(p.Definition()))
 		liveCanon := canonicalizeStatement(liveStripped)
 		if declaredCanon != liveCanon {
@@ -344,7 +345,8 @@ func applyProcedureWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.
 			return fmt.Errorf("schema: drop replaced procedure %q: %w", key, err)
 		}
 	}
-	definition := applyOwnershipNoticePrefix(p.Definition(), opts, p.DocAnnotation())
+	effOpts := effectiveOptionsForRender(d, opts)
+	definition := applyOwnershipNoticePrefix(p.Definition(), effOpts, p.DocAnnotation())
 	stmt, err := p.createOrAlterWithDefinition(d, definition)
 	if err != nil {
 		return err

--- a/schema/view_lifecycle.go
+++ b/schema/view_lifecycle.go
@@ -365,7 +365,8 @@ func validateViewWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Di
 			Reason:                "pg_get_viewdef canonicalization (star expansion, fully-qualified identifiers, inserted casts) makes textual body comparison unreliable; existence confirmed",
 		})
 	default:
-		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, opts, v.DocAnnotation()))
+		effOpts := effectiveOptionsForRender(d, opts)
+		liveStripped := stripLeadingBlockComments(stripConfiguredApplyPrefix(live, effOpts, v.DocAnnotation()))
 		declaredCanon := canonicalizeStatement(stripLeadingBlockComments(v.Body()))
 		liveCanon := canonicalizeStatement(liveStripped)
 		if declaredCanon != liveCanon {
@@ -478,7 +479,8 @@ func applyViewWithOptionsInternal(ctx context.Context, db *sql.DB, d chuck.Diale
 			return fmt.Errorf("schema: drop replaced view %q: %w", key, err)
 		}
 	}
-	body := applyOwnershipNoticePrefix(v.Body(), opts, v.DocAnnotation())
+	effOpts := effectiveOptionsForRender(d, opts)
+	body := applyOwnershipNoticePrefix(v.Body(), effOpts, v.DocAnnotation())
 	for _, stmt := range v.createOrReplaceWithBody(d, body) {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("schema: apply view %q: %w", objectKey(v.Object()), err)


### PR DESCRIPTION
## Summary

- When `CodeObjectOptions.OwnershipNotice` renders and `CodeObjectOptions.Metadata` is non-nil, the rendered ownership block comment now ends with a single-line `Provenance recorded in <qualified-table>.` pointer.
- Pointer uses dialect-quoted, schema-qualified form of `chuck_object_metadata` (bare on SQLite; `[ops].[chuck_object_metadata]` on MSSQL; `"ops"."chuck_object_metadata"` on Postgres).
- `DefaultOwnershipNotice` constant unchanged — augmentation happens at render time.
- Apply and validate both route opts through `effectiveOptionsForRender(d, opts)` so the strict configured-prefix strip recognises the augmented notice intact.
- Honest: no pointer when `OwnershipNotice` is empty (metadata alone does not invent a fresh ownership block); no pointer when `Metadata` is nil.

## Test plan

- [x] `go test ./...` — all green
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] Unit: `metadataNoticePointer` across SQLite / Postgres / MSSQL with and without explicit `cfg.Schema`
- [x] Unit: `effectiveOptionsForRender` — both empty, notice-only, metadata-only, both set, caller `opts` value not mutated
- [x] Integration (SQLite): `TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice` — apply + validate symmetry, bare validate still passes, metadata-only emits no notice, notice-only emits no pointer
- [ ] MSSQL / Postgres exercise via integration harness (no `CHUCK_*_URL` available locally; dialect quoting covered by unit tests)