### PR TITLE
refactor(schema): shrink snapshot metadata ledger to object-only PascalCase core

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,22 +683,19 @@ Engine notes:
 #### Opt-in snapshot operational metadata
 
 For provenance — when an owned object was first applied, last applied, last
-changed, what the current definition hashes to, and which source rev/tool
-version applied it — chuck can record one row per owned object in a small
-snapshot ledger alongside your data. The ledger is **opt-in** and **snapshot
-only**: one current row per owned object, no append-only history table in
-this first pass.
+changed, and what the current definition hashes to — chuck can record one row
+per owned object in a small snapshot ledger alongside your data. The ledger
+is **opt-in**, **snapshot only**, and **object-only**: one current row per
+owned object, no append-only history table, and no database-level summary
+table in chuck core.
 
 ```go
 cfg := schema.MetadataConfig{
-    Owner:       "bootstrap",                         // required
-    Schema:      "ops",                               // optional; ignored on SQLite
-    SourceRepo:  "https://github.com/example/repo",   // optional provenance
-    SourceRev:   commitSHA,                           // optional provenance
-    ToolVersion: "v1.4.2",                            // optional provenance
+    Owner:  "bootstrap",   // required
+    Schema: "ops",         // optional; ignored on SQLite
 }
 
-// Create the ledger tables once, in your own bootstrap. Chuck does NOT
+// Create the ledger table once, in your own bootstrap. Chuck does NOT
 // implicitly CREATE SCHEMA for you when cfg.Schema is set.
 if err := schema.EnsureMetadataTables(ctx, db, dialect, cfg); err != nil {
     return err
@@ -717,33 +714,36 @@ if err := schema.ApplyViewsWithOptions(ctx, db, dialect, opts, views...); err !=
 }
 ```
 
-Two tables are written:
+One table is written:
 
-- **`chuck_database_metadata`** — one row per `Owner`, tracking when that
-  owner first applied anything and when it last applied anything.
-- **`chuck_object_metadata`** — one row per `(owner, object_type,
-  object_schema, object_name)` with `first_applied_at_utc`,
-  `last_applied_at_utc`, `last_changed_at_utc`, `definition_hash`, and the
-  optional `source_repo` / `source_rev` / `tool_version` provenance columns.
+- **`ChuckObjectMetadata`** — one row per
+  `(Owner, ObjectType, ObjectSchema, ObjectName)` with `FirstAppliedAtUtc`,
+  `LastAppliedAtUtc`, `LastChangedAtUtc`, and `DefinitionHash`.
+
+Naming is fixed PascalCase in chuck core. Richer or app-specific provenance
+(source repo, commit SHA, tool version, environment, ticket, request id, …)
+belongs in a caller-owned sibling table outside chuck — keep the chuck core
+ledger a small, stable object-only contract and let your application table
+join to it on `(Owner, ObjectType, ObjectSchema, ObjectName)` when you need
+extra columns.
 
 Snapshot semantics on each successful apply:
 
-- **New row**: `first_applied = last_applied = last_changed = now`.
-- **Same hash as last apply**: only `last_applied` advances. `last_changed`
-  and `first_applied` stay frozen.
-- **Different hash**: `last_applied` and `last_changed` advance,
-  `definition_hash` is replaced, `first_applied` stays frozen.
+- **New row**: `FirstAppliedAtUtc = LastAppliedAtUtc = LastChangedAtUtc = now`.
+- **Same hash as last apply**: only `LastAppliedAtUtc` advances.
+  `LastChangedAtUtc` and `FirstAppliedAtUtc` stay frozen.
+- **Different hash**: `LastAppliedAtUtc` and `LastChangedAtUtc` advance,
+  `DefinitionHash` is replaced, `FirstAppliedAtUtc` stays frozen.
 
 The hash is computed over the canonical form of the rendered body or
 definition — leading block-comment front matter (ownership notice, doc
 preamble, per-object annotation) is stripped before hashing. Comment-only
-changes therefore do not move `last_changed`, matching the comment-insensitive
-validation contract.
+changes therefore do not move `LastChangedAtUtc`, matching the
+comment-insensitive validation contract.
 
 The ledger is independent of drift detection: `Validate*WithOptions` does not
 read the ledger and does not produce drift over missing or stale ledger
-rows. Empty provenance fields are stored as SQL `NULL` so the ledger can
-distinguish "not recorded" from "recorded as empty string".
+rows.
 
 When `OwnershipNotice` and `Metadata` are both set, the rendered chuck-owned
 ownership comment carries an extra single-line pointer to the ledger so DB
@@ -754,17 +754,17 @@ that records its provenance:
 CREATE VIEW "v_open_tasks" AS
 /* Owned by https://github.com/catgoose/chuck. Do not edit in database.
 Out-of-band changes may fail validation or be overwritten by apply/bootstrap.
-Provenance recorded in "ops"."chuck_object_metadata". */
+Provenance recorded in "ops"."ChuckObjectMetadata". */
 SELECT id FROM tasks WHERE done = 0
 ```
 
 The pointer uses the dialect-quoted, schema-qualified form of
-`chuck_object_metadata` (bare on SQLite; bracketed on MSSQL; double-quoted
-on Postgres). It is only added when an ownership notice is already
-rendering — `Metadata` alone never invents a fresh ownership block — and is
-omitted when `Metadata` is `nil`, so the pointer text stays honest about
-whether the ledger is actually enabled. Comment-only changes do not move
-`last_changed` and do not produce drift.
+`ChuckObjectMetadata` (double-quoted on SQLite and Postgres; bracketed on
+MSSQL). It is only added when an ownership notice is already rendering —
+`Metadata` alone never invents a fresh ownership block — and is omitted when
+`Metadata` is `nil`, so the pointer text stays honest about whether the
+ledger is actually enabled. Comment-only changes do not move
+`LastChangedAtUtc` and do not produce drift.
 
 ### Schema Snapshots
 

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -765,14 +765,13 @@ func (c *integrationFakeClock) advance(by time.Duration) { c.cur = c.cur.Add(by)
 // Contract covered:
 //
 //   - bare apply (no Metadata) does not touch the ledger
-//   - apply-with-Metadata creates the row on first apply; first_applied =
-//     last_applied = last_changed
-//   - re-applying the same body advances last_applied only; last_changed and
-//     first_applied stay frozen
-//   - applying a different body advances last_applied AND last_changed;
-//     first_applied stays frozen; definition_hash is replaced
-//   - chuck_database_metadata.first_applied stays frozen across repeat
-//     applies for the same owner
+//   - apply-with-Metadata creates the row on first apply; FirstAppliedAtUtc =
+//     LastAppliedAtUtc = LastChangedAtUtc
+//   - re-applying the same body advances LastAppliedAtUtc only;
+//     LastChangedAtUtc and FirstAppliedAtUtc stay frozen
+//   - applying a different body advances LastAppliedAtUtc AND
+//     LastChangedAtUtc; FirstAppliedAtUtc stays frozen; DefinitionHash is
+//     replaced
 //   - Validate*WithOptions remains clean regardless of ledger state — the
 //     ledger is independent of drift comparison
 func TestViewApplyWithOptions_SQLite_MetadataLedger(t *testing.T) {
@@ -789,11 +788,8 @@ func TestViewApplyWithOptions_SQLite_MetadataLedger(t *testing.T) {
 
 	clock := &integrationFakeClock{cur: time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)}
 	cfg := schema.MetadataConfig{
-		Owner:       "bootstrap",
-		SourceRepo:  "https://github.com/catgoose/chuck",
-		SourceRev:   "rev-1",
-		ToolVersion: "v0.0.1-test",
-		Now:         clock.Now,
+		Owner: "bootstrap",
+		Now:   clock.Now,
 	}
 	require.NoError(t, schema.EnsureMetadataTables(ctx, db, d, cfg))
 
@@ -814,30 +810,30 @@ func TestViewApplyWithOptions_SQLite_MetadataLedger(t *testing.T) {
 	assert.True(t, row.lastApplied.Equal(t0))
 	assert.True(t, row.lastChanged.Equal(t0))
 	firstHash := row.definitionHash
-	require.NotEmpty(t, firstHash, "definition_hash must be written")
+	require.NotEmpty(t, firstHash, "DefinitionHash must be written")
 
-	// Second apply, same body: last_applied advances, last_changed unchanged.
+	// Second apply, same body: LastAppliedAtUtc advances, LastChangedAtUtc unchanged.
 	clock.advance(time.Hour)
 	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, opts, v))
 	row = readObjectMetadataRow(t, ctx, db, "bootstrap", "v_vva_md_open")
-	assert.True(t, row.firstApplied.Equal(t0), "first_applied must stay frozen on same-hash reapply")
+	assert.True(t, row.firstApplied.Equal(t0), "FirstAppliedAtUtc must stay frozen on same-hash reapply")
 	assert.True(t, row.lastApplied.Equal(t0.Add(time.Hour)))
-	assert.True(t, row.lastChanged.Equal(t0), "last_changed must not move when hash matches")
+	assert.True(t, row.lastChanged.Equal(t0), "LastChangedAtUtc must not move when hash matches")
 	assert.Equal(t, firstHash, row.definitionHash)
 
-	// Third apply, executable text changed: last_applied AND last_changed
-	// advance, first_applied still frozen, hash replaced.
+	// Third apply, executable text changed: LastAppliedAtUtc AND
+	// LastChangedAtUtc advance, FirstAppliedAtUtc still frozen, hash replaced.
 	clock.advance(time.Hour)
 	v2 := schema.NewView("v_vva_md_open", "SELECT id FROM vva_md_tasks WHERE done = 1")
 	defer func() { _, _ = db.ExecContext(ctx, v2.DropSQL(d)) }()
 	require.NoError(t, schema.ApplyViewWithOptions(ctx, db, d, opts, v2))
 	row = readObjectMetadataRow(t, ctx, db, "bootstrap", "v_vva_md_open")
-	assert.True(t, row.firstApplied.Equal(t0), "first_applied stays frozen on hash change")
+	assert.True(t, row.firstApplied.Equal(t0), "FirstAppliedAtUtc stays frozen on hash change")
 	assert.True(t, row.lastApplied.Equal(t0.Add(2*time.Hour)))
-	assert.True(t, row.lastChanged.Equal(t0.Add(2*time.Hour)), "last_changed must move on hash change")
-	assert.NotEqual(t, firstHash, row.definitionHash, "definition_hash must update on executable text change")
+	assert.True(t, row.lastChanged.Equal(t0.Add(2*time.Hour)), "LastChangedAtUtc must move on hash change")
+	assert.NotEqual(t, firstHash, row.definitionHash, "DefinitionHash must update on executable text change")
 
-	// Comment-only change (different DocPreamble) must not move last_changed.
+	// Comment-only change (different DocPreamble) must not move LastChangedAtUtc.
 	clock.advance(time.Hour)
 	optsWithDoc := schema.CodeObjectOptions{
 		DocPreamble: "different preamble text",
@@ -847,12 +843,7 @@ func TestViewApplyWithOptions_SQLite_MetadataLedger(t *testing.T) {
 	row = readObjectMetadataRow(t, ctx, db, "bootstrap", "v_vva_md_open")
 	assert.True(t, row.lastApplied.Equal(t0.Add(3*time.Hour)))
 	assert.True(t, row.lastChanged.Equal(t0.Add(2*time.Hour)),
-		"comment-only change must not advance last_changed because hash ignores leading comments")
-
-	// Per-owner database row tracks first/last apply.
-	dbFirst, dbLast := readDatabaseMetadataRow(t, ctx, db, "bootstrap")
-	assert.True(t, dbFirst.Equal(t0))
-	assert.True(t, dbLast.Equal(t0.Add(3*time.Hour)))
+		"comment-only change must not advance LastChangedAtUtc because hash ignores leading comments")
 
 	// Validate path must remain agnostic of the ledger.
 	require.NoError(t, schema.ValidateViewWithOptions(ctx, db, d, optsWithDoc, v2),
@@ -863,7 +854,7 @@ func countObjectMetadataRows(t *testing.T, ctx context.Context, db *sql.DB, owne
 	t.Helper()
 	var n int
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM chuck_object_metadata WHERE owner = ? AND object_name = ?`,
+		`SELECT COUNT(*) FROM "ChuckObjectMetadata" WHERE "Owner" = ? AND "ObjectName" = ?`,
 		owner, name).Scan(&n))
 	return n
 }
@@ -879,20 +870,11 @@ func readObjectMetadataRow(t *testing.T, ctx context.Context, db *sql.DB, owner,
 	t.Helper()
 	var row liveObjectMetadataRow
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT first_applied_at_utc, last_applied_at_utc, last_changed_at_utc, definition_hash
-		   FROM chuck_object_metadata
-		  WHERE owner = ? AND object_name = ?`,
+		`SELECT "FirstAppliedAtUtc", "LastAppliedAtUtc", "LastChangedAtUtc", "DefinitionHash"
+		   FROM "ChuckObjectMetadata"
+		  WHERE "Owner" = ? AND "ObjectName" = ?`,
 		owner, name).Scan(&row.firstApplied, &row.lastApplied, &row.lastChanged, &row.definitionHash))
 	return row
-}
-
-func readDatabaseMetadataRow(t *testing.T, ctx context.Context, db *sql.DB, owner string) (firstApplied, lastApplied time.Time) {
-	t.Helper()
-	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT first_applied_at_utc, last_applied_at_utc
-		   FROM chuck_database_metadata
-		  WHERE owner = ?`, owner).Scan(&firstApplied, &lastApplied))
-	return firstApplied, lastApplied
 }
 
 // TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice asserts the
@@ -902,7 +884,7 @@ func readDatabaseMetadataRow(t *testing.T, ctx context.Context, db *sql.DB, owne
 //
 //   - ApplyViewWithOptions with both OwnershipNotice and Metadata renders a
 //     provenance pointer line inside the ownership block comment, naming the
-//     dialect-quoted chuck_object_metadata table
+//     dialect-quoted ChuckObjectMetadata table
 //   - apply + validate with the same opts stay coherent — the strict
 //     configured-prefix strip recognises the augmented notice
 //   - bare validate (no opts) still passes because leading comment-only
@@ -946,7 +928,7 @@ func TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice(t *testing
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT sql FROM sqlite_master WHERE type='view' AND name=?`, "v_vva_ptr_open").
 		Scan(&liveSQL))
-	assert.Contains(t, liveSQL, `Provenance recorded in "chuck_object_metadata".`,
+	assert.Contains(t, liveSQL, `Provenance recorded in "ChuckObjectMetadata".`,
 		"ownership notice must carry the metadata pointer when both notice and Metadata are set")
 	assert.Contains(t, liveSQL, "Owned by https://github.com/catgoose/chuck",
 		"base ownership text must still be present")

--- a/schema/metadata.go
+++ b/schema/metadata.go
@@ -19,7 +19,7 @@ import (
 // the helper fails loud rather than recording an ambiguous row.
 var ErrMetadataOwnerMissing = errors.New("schema: metadata owner is required")
 
-// Object-type constants used in chuck_object_metadata.object_type. Kept as
+// Object-type constants used in ChuckObjectMetadata.ObjectType. Kept as
 // stable strings rather than an enum so the ledger stays human-readable when
 // inspected directly in the database.
 const (
@@ -27,13 +27,23 @@ const (
 	MetadataObjectTypeProcedure = "procedure"
 )
 
-// Default unqualified table names for the snapshot ledger. Callers can set
-// MetadataConfig.Schema to namespace these under an owned schema; when Schema
-// is empty the tables land in the engine's default namespace (e.g. "main" on
-// SQLite, "public" on Postgres, "dbo" on MSSQL).
+// DefaultObjectMetadataTableName is the fixed PascalCase name of the snapshot
+// ledger table. Naming is fixed in chuck core; richer or app-specific
+// provenance belongs in caller-owned sibling tables outside chuck.
+const DefaultObjectMetadataTableName = "ChuckObjectMetadata"
+
+// Column names of the snapshot ledger. Fixed PascalCase. Apps wanting
+// alternate naming/layout should manage their own sibling table rather than
+// remap chuck core.
 const (
-	DefaultDatabaseMetadataTableName = "chuck_database_metadata"
-	DefaultObjectMetadataTableName   = "chuck_object_metadata"
+	metadataColOwner             = "Owner"
+	metadataColObjectType        = "ObjectType"
+	metadataColObjectSchema      = "ObjectSchema"
+	metadataColObjectName        = "ObjectName"
+	metadataColFirstAppliedAtUtc = "FirstAppliedAtUtc"
+	metadataColLastAppliedAtUtc  = "LastAppliedAtUtc"
+	metadataColLastChangedAtUtc  = "LastChangedAtUtc"
+	metadataColDefinitionHash    = "DefinitionHash"
 )
 
 // MetadataConfig opts an apply-helper call into recording an entry in chuck's
@@ -43,34 +53,29 @@ const (
 // The ledger is **opt-in** and **snapshot only**. ApplyViewsWithOptions and
 // ApplyProceduresWithOptions write rows when opts.Metadata is non-nil and a
 // successful apply has just happened; otherwise the ledger is not touched.
-// Validate* helpers do not read or compare metadata rows in this first pass.
+// Validate* helpers do not read or compare metadata rows.
 //
 // Tables are caller-bootstrapped: call EnsureMetadataTables(ctx, db, d, cfg)
 // once during your own bootstrap before the first opt-in apply. The apply
-// path assumes the tables exist and surfaces driver errors verbatim if they
-// do not.
+// path assumes the table exists and surfaces driver errors verbatim if it
+// does not.
 //
-// Provenance fields (SourceRepo, SourceRev, ToolVersion) are optional. When
-// empty they are stored as SQL NULL so the ledger can distinguish "not
-// recorded" from "recorded as empty string".
+// Richer provenance (source repo, source rev, tool version, environment, etc.)
+// belongs in caller-owned sibling tables outside chuck so the chuck core
+// ledger stays a small, stable object-only contract.
 type MetadataConfig struct {
-	// Owner identifies the caller writing rows into the ledger. Recorded
-	// on every row in both ledger tables. Required.
+	// Owner identifies the caller writing rows into the ledger. Recorded on
+	// every row. Required.
 	Owner string
 
-	// Schema namespaces the ledger tables. Empty means the engine's default
-	// namespace. SQLite ignores this because it has no schema namespace.
+	// Schema namespaces the ledger table. Empty means the engine's default
+	// namespace; chuck does not impose a default schema. SQLite ignores
+	// this because it has no schema namespace.
 	Schema string
 
-	// SourceRepo, SourceRev, ToolVersion are optional provenance recorded
-	// on each row. Empty values are stored as SQL NULL.
-	SourceRepo  string
-	SourceRev   string
-	ToolVersion string
-
-	// Now is the clock used for first_applied_at_utc / last_applied_at_utc /
-	// last_changed_at_utc. When nil, time.Now().UTC() is used. Tests use
-	// this seam to assert deterministic snapshot rows.
+	// Now is the clock used for FirstAppliedAtUtc / LastAppliedAtUtc /
+	// LastChangedAtUtc. When nil, time.Now().UTC() is used. Tests use this
+	// seam to assert deterministic snapshot rows.
 	Now func() time.Time
 }
 
@@ -88,29 +93,19 @@ func (c MetadataConfig) validate() error {
 	return nil
 }
 
-// databaseMetadataObject returns the ObjectName the ledger uses for the
-// per-owner snapshot row table.
-func (c MetadataConfig) databaseMetadataObject() chuck.ObjectName {
-	return chuck.ObjectName{Schema: c.Schema, Name: DefaultDatabaseMetadataTableName}
-}
-
-// objectMetadataObject returns the ObjectName the ledger uses for the
-// per-owned-object snapshot row table.
-func (c MetadataConfig) objectMetadataObject() chuck.ObjectName {
-	return chuck.ObjectName{Schema: c.Schema, Name: DefaultObjectMetadataTableName}
-}
-
-// EnsureMetadataTables creates chuck_database_metadata and
-// chuck_object_metadata if absent. Safe to run repeatedly; uses
-// CREATE TABLE IF NOT EXISTS semantics on every engine. Returns
-// ErrMetadataOwnerMissing if Owner is empty so callers see the same
+// EnsureMetadataTables creates ChuckObjectMetadata if absent. Safe to run
+// repeatedly; uses CREATE TABLE IF NOT EXISTS semantics on every engine.
+// Returns ErrMetadataOwnerMissing if Owner is empty so callers see the same
 // loud-failure shape as the apply path.
 //
-// Tables are created in cfg.Schema when set; on engines that lack schema
+// The table is created in cfg.Schema when set; on engines that lack schema
 // namespacing (SQLite) the schema is dropped silently to match how the rest
 // of chuck handles unscoped identifiers. Callers running an opt-in apply
 // path against a schema-scoped ledger are responsible for creating the
 // schema itself first — chuck does not implicitly CREATE SCHEMA.
+//
+// The function name retains its plural form for API compatibility with
+// earlier preview releases; it now provisions a single ledger table.
 func EnsureMetadataTables(ctx context.Context, db *sql.DB, d chuck.Dialect, cfg MetadataConfig) error {
 	if err := cfg.validate(); err != nil {
 		return err
@@ -124,45 +119,66 @@ func EnsureMetadataTables(ctx context.Context, db *sql.DB, d chuck.Dialect, cfg 
 }
 
 // metadataCreateStatements returns the dialect-correct CREATE TABLE IF NOT
-// EXISTS statements for both ledger tables, in the order they should be
-// executed.
+// EXISTS statement for the snapshot ledger.
 func metadataCreateStatements(d chuck.Dialect, cfg MetadataConfig) []string {
 	ts := d.TimestampType()
 	textPK := metadataTextPKType(d)
-	textCol := d.TextType()
-
-	dbBody := strings.Join([]string{
-		fmt.Sprintf("\t\t\t%s %s NOT NULL PRIMARY KEY", d.QuoteIdentifier("owner"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("first_applied_at_utc"), ts),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("last_applied_at_utc"), ts),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("source_repo"), textCol),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("source_rev"), textCol),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("tool_version"), textCol),
-	}, ",\n")
 
 	objBody := strings.Join([]string{
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("owner"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("object_type"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("object_schema"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("object_name"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("first_applied_at_utc"), ts),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("last_applied_at_utc"), ts),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("last_changed_at_utc"), ts),
-		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier("definition_hash"), textPK),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("source_repo"), textCol),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("source_rev"), textCol),
-		fmt.Sprintf("\t\t\t%s %s NULL", d.QuoteIdentifier("tool_version"), textCol),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColOwner), textPK),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColObjectType), textPK),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColObjectSchema), textPK),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColObjectName), textPK),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColFirstAppliedAtUtc), ts),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColLastAppliedAtUtc), ts),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColLastChangedAtUtc), ts),
+		fmt.Sprintf("\t\t\t%s %s NOT NULL", d.QuoteIdentifier(metadataColDefinitionHash), textPK),
 		fmt.Sprintf("\t\t\tPRIMARY KEY (%s, %s, %s, %s)",
-			d.QuoteIdentifier("owner"),
-			d.QuoteIdentifier("object_type"),
-			d.QuoteIdentifier("object_schema"),
-			d.QuoteIdentifier("object_name"),
+			d.QuoteIdentifier(metadataColOwner),
+			d.QuoteIdentifier(metadataColObjectType),
+			d.QuoteIdentifier(metadataColObjectSchema),
+			d.QuoteIdentifier(metadataColObjectName),
 		),
 	}, ",\n")
 
 	return []string{
-		createTableIfNotExistsSQL(d, cfg.databaseMetadataObject(), dbBody),
-		createTableIfNotExistsSQL(d, cfg.objectMetadataObject(), objBody),
+		metadataCreateTableSQL(d, cfg, objBody),
+	}
+}
+
+// metadataQualifyTable renders the ledger table identifier verbatim,
+// schema-qualified when cfg.Schema is set and the engine supports schemas.
+// Unlike qualifyTable / chuck.QualifyTable it deliberately does NOT route
+// the literal name through dialect NormalizeIdentifier, because Postgres'
+// camelToSnake convention would rewrite ChuckObjectMetadata to
+// chuck_object_metadata. The plan fixes the ledger name as PascalCase across
+// every dialect, so identity renders consistently.
+//
+// SQLite drops any cfg.Schema component because SQLite has no schema
+// namespace.
+func metadataQualifyTable(d chuck.Dialect, cfg MetadataConfig) string {
+	if cfg.Schema == "" || d.Engine() == chuck.SQLite {
+		return d.QuoteIdentifier(DefaultObjectMetadataTableName)
+	}
+	return d.QuoteIdentifier(cfg.Schema) + "." + d.QuoteIdentifier(DefaultObjectMetadataTableName)
+}
+
+// metadataCreateTableSQL renders the CREATE TABLE IF NOT EXISTS statement for
+// the ledger using metadataQualifyTable, so the PascalCase identifier stays
+// intact on Postgres. MSSQL uses the same IF NOT EXISTS / sys.objects guard
+// as createTableIfNotExistsSQL.
+func metadataCreateTableSQL(d chuck.Dialect, cfg MetadataConfig, body string) string {
+	qt := metadataQualifyTable(d, cfg)
+	switch d.Engine() {
+	case chuck.MSSQL:
+		objArg := qt
+		objLit := strings.ReplaceAll(objArg, "'", "''")
+		return fmt.Sprintf(
+			"IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'%s') AND type in (N'U')) BEGIN CREATE TABLE %s (\n%s\n\t\t) END",
+			objLit, qt, body,
+		)
+	default:
+		return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", qt, body)
 	}
 }
 
@@ -182,28 +198,27 @@ func metadataTextPKType(d chuck.Dialect) string {
 // block-comment front matter is stripped, then whitespace is collapsed. This
 // keeps the hash stable across comment-only changes — matching the
 // validation contract introduced in PR #98 — so writes only update
-// last_changed_at_utc when the executable text actually differs.
+// LastChangedAtUtc when the executable text actually differs.
 func hashCodeObjectDefinition(body string) string {
 	canon := canonicalizeStatement(stripLeadingBlockComments(body))
 	sum := sha256.Sum256([]byte(canon))
 	return hex.EncodeToString(sum[:])
 }
 
-// recordCodeObjectMetadata writes one row into chuck_object_metadata and
-// upserts the per-owner row in chuck_database_metadata. Called by the apply
-// path after a successful Exec, never on failure.
+// recordCodeObjectMetadata writes one row into ChuckObjectMetadata. Called by
+// the apply path after a successful Exec, never on failure.
 //
 // Snapshot semantics:
-//   - new row: first_applied = last_applied = last_changed = now
-//   - existing row, same hash: only last_applied advances
-//   - existing row, different hash: last_applied AND last_changed advance,
-//     definition_hash is replaced; first_applied is preserved.
+//   - new row: FirstAppliedAtUtc = LastAppliedAtUtc = LastChangedAtUtc = now
+//   - existing row, same hash: only LastAppliedAtUtc advances
+//   - existing row, different hash: LastAppliedAtUtc AND LastChangedAtUtc
+//     advance, DefinitionHash is replaced; FirstAppliedAtUtc is preserved.
 //
 // The two-step read-then-upsert is intentional: it keeps the per-engine SQL
 // readable instead of stuffing CASE/MERGE conditional updates inline. The
 // ledger is best-effort accounting, not a coordination primitive — callers
 // running concurrent applies against the same owner accept that two writers
-// may stomp on each other's last_applied.
+// may stomp on each other's LastAppliedAtUtc.
 func recordCodeObjectMetadata(
 	ctx context.Context,
 	db *sql.DB,
@@ -218,16 +233,13 @@ func recordCodeObjectMetadata(
 	}
 	now := cfg.clock().UTC()
 	schemaCol, nameCol := metadataObjectColumns(d, obj)
-	if err := upsertObjectRow(ctx, db, d, cfg, objectType, schemaCol, nameCol, definitionHash, now); err != nil {
-		return err
-	}
-	return upsertDatabaseRow(ctx, db, d, cfg, now)
+	return upsertObjectRow(ctx, db, d, cfg, objectType, schemaCol, nameCol, definitionHash, now)
 }
 
 // metadataNoticePointer returns the single-line ledger pointer sentence the
 // ownership-notice augmentation appends to the rendered chuck-owned comment
 // when snapshot metadata is enabled. The pointer references the dialect-
-// qualified, quoted form of the chuck_object_metadata table so DB readers
+// qualified, quoted form of the ChuckObjectMetadata table so DB readers
 // reading the live SQL can jump straight to the ledger row that records
 // this object's provenance. SQLite drops the schema component per the
 // standard QualifyTable contract; Postgres / MSSQL render schema-qualified
@@ -236,7 +248,7 @@ func recordCodeObjectMetadata(
 // Lives next to MetadataConfig so the table-name rendering stays close to
 // the ledger's own DDL.
 func metadataNoticePointer(d chuck.Dialect, cfg MetadataConfig) string {
-	return "Provenance recorded in " + qualifyTable(d, cfg.objectMetadataObject()) + "."
+	return "Provenance recorded in " + metadataQualifyTable(d, cfg) + "."
 }
 
 // effectiveOptionsForRender returns opts with OwnershipNotice augmented by a
@@ -257,8 +269,8 @@ func effectiveOptionsForRender(d chuck.Dialect, opts CodeObjectOptions) CodeObje
 	return opts
 }
 
-// metadataObjectColumns returns the (object_schema, object_name) pair used to
-// key chuck_object_metadata rows for the given owned object. The schema
+// metadataObjectColumns returns the (ObjectSchema, ObjectName) pair used to
+// key ChuckObjectMetadata rows for the given owned object. The schema
 // component reuses the same default-resolution contract as the live-database
 // inspection paths (resolveSchemaForInspection): unqualified declarations
 // resolve to "public" on Postgres and "dbo" on MSSQL so the ledger row keys
@@ -267,7 +279,7 @@ func effectiveOptionsForRender(d chuck.Dialect, opts CodeObjectOptions) CodeObje
 // component is dialect-normalized identically to inspection.
 //
 // Without this resolution an unqualified declaration on Postgres or MSSQL
-// would record object_schema="" even though the live object lives under
+// would record ObjectSchema="" even though the live object lives under
 // "public" / "dbo". That would misstate identity and split one physical
 // object across two ledger rows if a caller later switched from a bare name
 // to the explicit default schema.
@@ -277,7 +289,7 @@ func metadataObjectColumns(d chuck.Dialect, obj chuck.ObjectName) (objectSchema,
 	return
 }
 
-// upsertObjectRow performs the read-then-write for chuck_object_metadata.
+// upsertObjectRow performs the read-then-write for ChuckObjectMetadata.
 func upsertObjectRow(
 	ctx context.Context,
 	db *sql.DB,
@@ -286,16 +298,16 @@ func upsertObjectRow(
 	objectType, objectSchema, objectName, definitionHash string,
 	now time.Time,
 ) error {
-	qt := qualifyTable(d, cfg.objectMetadataObject())
+	qt := metadataQualifyTable(d, cfg)
 	selectSQL := fmt.Sprintf(
 		"SELECT %s, %s FROM %s WHERE %s = %s AND %s = %s AND %s = %s AND %s = %s",
-		d.QuoteIdentifier("first_applied_at_utc"),
-		d.QuoteIdentifier("definition_hash"),
+		d.QuoteIdentifier(metadataColFirstAppliedAtUtc),
+		d.QuoteIdentifier(metadataColDefinitionHash),
 		qt,
-		d.QuoteIdentifier("owner"), d.Placeholder(1),
-		d.QuoteIdentifier("object_type"), d.Placeholder(2),
-		d.QuoteIdentifier("object_schema"), d.Placeholder(3),
-		d.QuoteIdentifier("object_name"), d.Placeholder(4),
+		d.QuoteIdentifier(metadataColOwner), d.Placeholder(1),
+		d.QuoteIdentifier(metadataColObjectType), d.Placeholder(2),
+		d.QuoteIdentifier(metadataColObjectSchema), d.Placeholder(3),
+		d.QuoteIdentifier(metadataColObjectName), d.Placeholder(4),
 	)
 	var (
 		existingFirst sql.NullTime
@@ -322,11 +334,11 @@ func insertObjectRow(
 	objectType, objectSchema, objectName, definitionHash string,
 	now time.Time,
 ) error {
-	qt := qualifyTable(d, cfg.objectMetadataObject())
+	qt := metadataQualifyTable(d, cfg)
 	cols := []string{
-		"owner", "object_type", "object_schema", "object_name",
-		"first_applied_at_utc", "last_applied_at_utc", "last_changed_at_utc",
-		"definition_hash", "source_repo", "source_rev", "tool_version",
+		metadataColOwner, metadataColObjectType, metadataColObjectSchema, metadataColObjectName,
+		metadataColFirstAppliedAtUtc, metadataColLastAppliedAtUtc, metadataColLastChangedAtUtc,
+		metadataColDefinitionHash,
 	}
 	placeholders := make([]string, len(cols))
 	for i := range cols {
@@ -344,7 +356,6 @@ func insertObjectRow(
 		cfg.Owner, objectType, objectSchema, objectName,
 		now, now, now,
 		definitionHash,
-		nullableString(cfg.SourceRepo), nullableString(cfg.SourceRev), nullableString(cfg.ToolVersion),
 	)
 	if err != nil {
 		return fmt.Errorf("schema: insert object metadata row: %w", err)
@@ -361,22 +372,16 @@ func updateObjectRow(
 	now time.Time,
 	hashChanged bool,
 ) error {
-	qt := qualifyTable(d, cfg.objectMetadataObject())
+	qt := metadataQualifyTable(d, cfg)
 	sets := []string{
-		fmt.Sprintf("%s = %s", d.QuoteIdentifier("last_applied_at_utc"), d.Placeholder(1)),
-		fmt.Sprintf("%s = %s", d.QuoteIdentifier("source_repo"), d.Placeholder(2)),
-		fmt.Sprintf("%s = %s", d.QuoteIdentifier("source_rev"), d.Placeholder(3)),
-		fmt.Sprintf("%s = %s", d.QuoteIdentifier("tool_version"), d.Placeholder(4)),
+		fmt.Sprintf("%s = %s", d.QuoteIdentifier(metadataColLastAppliedAtUtc), d.Placeholder(1)),
 	}
-	args := []any{
-		now,
-		nullableString(cfg.SourceRepo), nullableString(cfg.SourceRev), nullableString(cfg.ToolVersion),
-	}
-	next := 5
+	args := []any{now}
+	next := 2
 	if hashChanged {
 		sets = append(sets,
-			fmt.Sprintf("%s = %s", d.QuoteIdentifier("last_changed_at_utc"), d.Placeholder(next)),
-			fmt.Sprintf("%s = %s", d.QuoteIdentifier("definition_hash"), d.Placeholder(next+1)),
+			fmt.Sprintf("%s = %s", d.QuoteIdentifier(metadataColLastChangedAtUtc), d.Placeholder(next)),
+			fmt.Sprintf("%s = %s", d.QuoteIdentifier(metadataColDefinitionHash), d.Placeholder(next+1)),
 		)
 		args = append(args, now, definitionHash)
 		next += 2
@@ -384,85 +389,14 @@ func updateObjectRow(
 	stmt := fmt.Sprintf(
 		"UPDATE %s SET %s WHERE %s = %s AND %s = %s AND %s = %s AND %s = %s",
 		qt, strings.Join(sets, ", "),
-		d.QuoteIdentifier("owner"), d.Placeholder(next),
-		d.QuoteIdentifier("object_type"), d.Placeholder(next+1),
-		d.QuoteIdentifier("object_schema"), d.Placeholder(next+2),
-		d.QuoteIdentifier("object_name"), d.Placeholder(next+3),
+		d.QuoteIdentifier(metadataColOwner), d.Placeholder(next),
+		d.QuoteIdentifier(metadataColObjectType), d.Placeholder(next+1),
+		d.QuoteIdentifier(metadataColObjectSchema), d.Placeholder(next+2),
+		d.QuoteIdentifier(metadataColObjectName), d.Placeholder(next+3),
 	)
 	args = append(args, cfg.Owner, objectType, objectSchema, objectName)
 	if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
 		return fmt.Errorf("schema: update object metadata row: %w", err)
 	}
 	return nil
-}
-
-// upsertDatabaseRow does the same read-then-write pattern for the per-owner
-// chuck_database_metadata row.
-func upsertDatabaseRow(
-	ctx context.Context,
-	db *sql.DB,
-	d chuck.Dialect,
-	cfg MetadataConfig,
-	now time.Time,
-) error {
-	qt := qualifyTable(d, cfg.databaseMetadataObject())
-	selectSQL := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s = %s",
-		d.QuoteIdentifier("first_applied_at_utc"), qt,
-		d.QuoteIdentifier("owner"), d.Placeholder(1),
-	)
-	var existingFirst sql.NullTime
-	err := db.QueryRowContext(ctx, selectSQL, cfg.Owner).Scan(&existingFirst)
-	switch err {
-	case sql.ErrNoRows:
-		stmt := fmt.Sprintf(
-			"INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES (%s, %s, %s, %s, %s, %s)",
-			qt,
-			d.QuoteIdentifier("owner"),
-			d.QuoteIdentifier("first_applied_at_utc"),
-			d.QuoteIdentifier("last_applied_at_utc"),
-			d.QuoteIdentifier("source_repo"),
-			d.QuoteIdentifier("source_rev"),
-			d.QuoteIdentifier("tool_version"),
-			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3),
-			d.Placeholder(4), d.Placeholder(5), d.Placeholder(6),
-		)
-		if _, err := db.ExecContext(ctx, stmt,
-			cfg.Owner, now, now,
-			nullableString(cfg.SourceRepo), nullableString(cfg.SourceRev), nullableString(cfg.ToolVersion),
-		); err != nil {
-			return fmt.Errorf("schema: insert database metadata row: %w", err)
-		}
-		return nil
-	case nil:
-		stmt := fmt.Sprintf(
-			"UPDATE %s SET %s = %s, %s = %s, %s = %s, %s = %s WHERE %s = %s",
-			qt,
-			d.QuoteIdentifier("last_applied_at_utc"), d.Placeholder(1),
-			d.QuoteIdentifier("source_repo"), d.Placeholder(2),
-			d.QuoteIdentifier("source_rev"), d.Placeholder(3),
-			d.QuoteIdentifier("tool_version"), d.Placeholder(4),
-			d.QuoteIdentifier("owner"), d.Placeholder(5),
-		)
-		if _, err := db.ExecContext(ctx, stmt,
-			now,
-			nullableString(cfg.SourceRepo), nullableString(cfg.SourceRev), nullableString(cfg.ToolVersion),
-			cfg.Owner,
-		); err != nil {
-			return fmt.Errorf("schema: update database metadata row: %w", err)
-		}
-		return nil
-	default:
-		return fmt.Errorf("schema: read database metadata row: %w", err)
-	}
-}
-
-// nullableString returns sql.NullString that is invalid (NULL) when s is empty,
-// so empty provenance values write as SQL NULL and round-trip cleanly back to
-// "" via sql.NullString.
-func nullableString(s string) sql.NullString {
-	if s == "" {
-		return sql.NullString{}
-	}
-	return sql.NullString{String: s, Valid: true}
 }

--- a/schema/metadata_test.go
+++ b/schema/metadata_test.go
@@ -29,7 +29,7 @@ func TestEnsureMetadataTables_RequiresOwner(t *testing.T) {
 		"empty Owner must surface as ErrMetadataOwnerMissing")
 }
 
-func TestEnsureMetadataTables_CreatesBothTables_SQLite(t *testing.T) {
+func TestEnsureMetadataTables_CreatesObjectTable_SQLite(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
@@ -40,17 +40,20 @@ func TestEnsureMetadataTables_CreatesBothTables_SQLite(t *testing.T) {
 
 	require.NoError(t, EnsureMetadataTables(ctx, db, d, cfg))
 
-	for _, name := range []string{
-		DefaultDatabaseMetadataTableName,
-		DefaultObjectMetadataTableName,
-	} {
-		var got string
-		err := db.QueryRowContext(ctx,
-			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name).
-			Scan(&got)
-		require.NoError(t, err, "expected table %q to exist", name)
-		assert.Equal(t, name, got)
-	}
+	var got string
+	err = db.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, DefaultObjectMetadataTableName).
+		Scan(&got)
+	require.NoError(t, err, "expected ChuckObjectMetadata to exist")
+	assert.Equal(t, DefaultObjectMetadataTableName, got)
+
+	// Slim ledger: no database-level table is created.
+	var legacy string
+	err = db.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, "chuck_database_metadata").
+		Scan(&legacy)
+	assert.ErrorIs(t, err, sql.ErrNoRows,
+		"chuck_database_metadata must not be created — feature shrunk to object-only core")
 
 	require.NoError(t, EnsureMetadataTables(ctx, db, d, cfg),
 		"second invocation must be a no-op (CREATE TABLE IF NOT EXISTS)")
@@ -85,11 +88,8 @@ func TestRecordCodeObjectMetadata_SnapshotSemantics_SQLite(t *testing.T) {
 
 	clock := newFakeClock(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
 	cfg := MetadataConfig{
-		Owner:       "owner-a",
-		SourceRepo:  "https://github.com/catgoose/chuck",
-		SourceRev:   "deadbeef",
-		ToolVersion: "v0.0.1-test",
-		Now:         clock.Now,
+		Owner: "owner-a",
+		Now:   clock.Now,
 	}
 	require.NoError(t, EnsureMetadataTables(ctx, db, d, cfg))
 
@@ -101,59 +101,28 @@ func TestRecordCodeObjectMetadata_SnapshotSemantics_SQLite(t *testing.T) {
 	require.NoError(t, recordCodeObjectMetadata(ctx, db, d, cfg, MetadataObjectTypeView, obj, hash1))
 	row := readObjectRow(t, ctx, db, d, cfg, MetadataObjectTypeView, obj)
 	t0 := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
-	assert.True(t, row.firstApplied.Equal(t0), "first apply: first_applied = t0, got %v", row.firstApplied)
+	assert.True(t, row.firstApplied.Equal(t0), "first apply: FirstAppliedAtUtc = t0, got %v", row.firstApplied)
 	assert.True(t, row.lastApplied.Equal(t0))
 	assert.True(t, row.lastChanged.Equal(t0))
 	assert.Equal(t, hash1, row.definitionHash)
-	assert.Equal(t, "https://github.com/catgoose/chuck", row.sourceRepo.String)
-	assert.Equal(t, "deadbeef", row.sourceRev.String)
-	assert.Equal(t, "v0.0.1-test", row.toolVersion.String)
 
-	// Second apply, same hash: last_applied advances, last_changed unchanged.
+	// Second apply, same hash: LastAppliedAtUtc advances, LastChangedAtUtc unchanged.
 	clock.Advance(time.Hour)
 	require.NoError(t, recordCodeObjectMetadata(ctx, db, d, cfg, MetadataObjectTypeView, obj, hash1))
 	row = readObjectRow(t, ctx, db, d, cfg, MetadataObjectTypeView, obj)
-	assert.True(t, row.firstApplied.Equal(t0), "second apply same-hash: first_applied frozen")
-	assert.True(t, row.lastApplied.Equal(t0.Add(time.Hour)), "last_applied advances")
-	assert.True(t, row.lastChanged.Equal(t0), "last_changed unchanged when hash matches")
+	assert.True(t, row.firstApplied.Equal(t0), "second apply same-hash: FirstAppliedAtUtc frozen")
+	assert.True(t, row.lastApplied.Equal(t0.Add(time.Hour)), "LastAppliedAtUtc advances")
+	assert.True(t, row.lastChanged.Equal(t0), "LastChangedAtUtc unchanged when hash matches")
 
-	// Third apply, different hash: last_applied AND last_changed advance,
-	// first_applied still frozen at t0.
+	// Third apply, different hash: LastAppliedAtUtc AND LastChangedAtUtc
+	// advance, FirstAppliedAtUtc still frozen at t0.
 	clock.Advance(time.Hour)
 	require.NoError(t, recordCodeObjectMetadata(ctx, db, d, cfg, MetadataObjectTypeView, obj, hash2))
 	row = readObjectRow(t, ctx, db, d, cfg, MetadataObjectTypeView, obj)
-	assert.True(t, row.firstApplied.Equal(t0), "third apply: first_applied still frozen")
+	assert.True(t, row.firstApplied.Equal(t0), "third apply: FirstAppliedAtUtc still frozen")
 	assert.True(t, row.lastApplied.Equal(t0.Add(2*time.Hour)))
-	assert.True(t, row.lastChanged.Equal(t0.Add(2*time.Hour)), "last_changed must advance on hash change")
+	assert.True(t, row.lastChanged.Equal(t0.Add(2*time.Hour)), "LastChangedAtUtc must advance on hash change")
 	assert.Equal(t, hash2, row.definitionHash)
-
-	// Database row tracks first/last apply too.
-	dbRow := readDatabaseRow(t, ctx, db, d, cfg)
-	assert.True(t, dbRow.firstApplied.Equal(t0), "database first_applied frozen at first record")
-	assert.True(t, dbRow.lastApplied.Equal(t0.Add(2*time.Hour)))
-}
-
-func TestRecordCodeObjectMetadata_NilProvenanceWritesNull_SQLite(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
-	require.NoError(t, err)
-	defer db.Close()
-
-	ctx := context.Background()
-	d := chuck.SQLiteDialect{}
-
-	cfg := MetadataConfig{
-		Owner: "owner-b",
-		Now:   newFakeClock(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)).Now,
-	}
-	require.NoError(t, EnsureMetadataTables(ctx, db, d, cfg))
-
-	obj := chuck.ObjectName{Name: "v_null_provenance"}
-	require.NoError(t, recordCodeObjectMetadata(ctx, db, d, cfg, MetadataObjectTypeView, obj, "h"))
-
-	row := readObjectRow(t, ctx, db, d, cfg, MetadataObjectTypeView, obj)
-	assert.False(t, row.sourceRepo.Valid, "empty SourceRepo must write SQL NULL")
-	assert.False(t, row.sourceRev.Valid, "empty SourceRev must write SQL NULL")
-	assert.False(t, row.toolVersion.Valid, "empty ToolVersion must write SQL NULL")
 }
 
 func TestMetadataNoticePointer_QualifiesAcrossDialects(t *testing.T) {
@@ -167,37 +136,37 @@ func TestMetadataNoticePointer_QualifiesAcrossDialects(t *testing.T) {
 			name:    "sqlite drops schema even when configured",
 			dialect: chuck.SQLiteDialect{},
 			schema:  "ops",
-			want:    `Provenance recorded in "chuck_object_metadata".`,
+			want:    `Provenance recorded in "ChuckObjectMetadata".`,
 		},
 		{
 			name:    "sqlite bare unqualified",
 			dialect: chuck.SQLiteDialect{},
 			schema:  "",
-			want:    `Provenance recorded in "chuck_object_metadata".`,
+			want:    `Provenance recorded in "ChuckObjectMetadata".`,
 		},
 		{
 			name:    "postgres unqualified renders bare",
 			dialect: chuck.PostgresDialect{},
 			schema:  "",
-			want:    `Provenance recorded in "chuck_object_metadata".`,
+			want:    `Provenance recorded in "ChuckObjectMetadata".`,
 		},
 		{
 			name:    "postgres explicit schema renders qualified",
 			dialect: chuck.PostgresDialect{},
 			schema:  "ops",
-			want:    `Provenance recorded in "ops"."chuck_object_metadata".`,
+			want:    `Provenance recorded in "ops"."ChuckObjectMetadata".`,
 		},
 		{
 			name:    "mssql unqualified renders bracketed bare",
 			dialect: chuck.MSSQLDialect{},
 			schema:  "",
-			want:    `Provenance recorded in [chuck_object_metadata].`,
+			want:    `Provenance recorded in [ChuckObjectMetadata].`,
 		},
 		{
 			name:    "mssql explicit schema renders bracketed qualified",
 			dialect: chuck.MSSQLDialect{},
 			schema:  "ops",
-			want:    `Provenance recorded in [ops].[chuck_object_metadata].`,
+			want:    `Provenance recorded in [ops].[ChuckObjectMetadata].`,
 		},
 	}
 	for _, tc := range cases {
@@ -235,7 +204,7 @@ func TestEffectiveOptionsForRender_AugmentsOnlyWhenNoticeAndMetadataBothSet(t *t
 		opts := CodeObjectOptions{OwnershipNotice: "owned", Metadata: &cfg}
 		got := effectiveOptionsForRender(d, opts)
 		assert.Equal(t,
-			"owned\nProvenance recorded in \"chuck_object_metadata\".",
+			"owned\nProvenance recorded in \"ChuckObjectMetadata\".",
 			got.OwnershipNotice)
 	})
 
@@ -301,8 +270,8 @@ func TestMetadataObjectColumns_DefaultsMatchLiveInspectionSchema(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotSchema, gotName := metadataObjectColumns(tc.dialect, tc.obj)
-			assert.Equal(t, tc.wantSchema, gotSchema, "object_schema")
-			assert.Equal(t, tc.wantName, gotName, "object_name")
+			assert.Equal(t, tc.wantSchema, gotSchema, "ObjectSchema")
+			assert.Equal(t, tc.wantName, gotName, "ObjectName")
 		})
 	}
 }
@@ -326,11 +295,11 @@ func TestRecordCodeObjectMetadata_UnqualifiedRowKeyedByEmptySchema_SQLite(t *tes
 
 	var storedSchema, storedName string
 	err = db.QueryRowContext(ctx,
-		`SELECT object_schema, object_name FROM `+DefaultObjectMetadataTableName+
-			` WHERE owner = ? AND object_name = ?`, cfg.Owner, "v_keying").
+		`SELECT "ObjectSchema", "ObjectName" FROM "`+DefaultObjectMetadataTableName+
+			`" WHERE "Owner" = ? AND "ObjectName" = ?`, cfg.Owner, "v_keying").
 		Scan(&storedSchema, &storedName)
 	require.NoError(t, err)
-	assert.Equal(t, "", storedSchema, "SQLite must continue recording empty object_schema")
+	assert.Equal(t, "", storedSchema, "SQLite must continue recording empty ObjectSchema")
 	assert.Equal(t, "v_keying", storedName)
 }
 
@@ -343,28 +312,28 @@ func TestMetadataCreateStatements_AllDialectsRender(t *testing.T) {
 	}
 	for _, d := range dialects {
 		stmts := metadataCreateStatements(d, cfg)
-		require.Lenf(t, stmts, 2, "%s: expected 2 create statements", d.Engine())
-		for _, s := range stmts {
-			assert.Containsf(t, s, "first_applied_at_utc", "%s: stmt missing first_applied_at_utc: %s", d.Engine(), s)
-			assert.Containsf(t, s, "last_applied_at_utc", "%s: stmt missing last_applied_at_utc: %s", d.Engine(), s)
-		}
-		assert.Containsf(t, stmts[0], DefaultDatabaseMetadataTableName, "%s: db table name", d.Engine())
-		assert.Containsf(t, stmts[1], DefaultObjectMetadataTableName, "%s: object table name", d.Engine())
-		assert.Containsf(t, stmts[1], "definition_hash", "%s: definition_hash column", d.Engine())
-		assert.Containsf(t, stmts[1], "last_changed_at_utc", "%s: last_changed_at_utc column", d.Engine())
+		require.Lenf(t, stmts, 1, "%s: expected exactly 1 create statement (object-only ledger)", d.Engine())
+		s := stmts[0]
+		assert.Containsf(t, s, DefaultObjectMetadataTableName, "%s: object table name", d.Engine())
+		assert.Containsf(t, s, "FirstAppliedAtUtc", "%s: stmt missing FirstAppliedAtUtc: %s", d.Engine(), s)
+		assert.Containsf(t, s, "LastAppliedAtUtc", "%s: stmt missing LastAppliedAtUtc: %s", d.Engine(), s)
+		assert.Containsf(t, s, "LastChangedAtUtc", "%s: stmt missing LastChangedAtUtc: %s", d.Engine(), s)
+		assert.Containsf(t, s, "DefinitionHash", "%s: stmt missing DefinitionHash: %s", d.Engine(), s)
+		assert.NotContainsf(t, s, "source_repo", "%s: source_repo must not be rendered", d.Engine())
+		assert.NotContainsf(t, s, "source_rev", "%s: source_rev must not be rendered", d.Engine())
+		assert.NotContainsf(t, s, "tool_version", "%s: tool_version must not be rendered", d.Engine())
+		assert.NotContainsf(t, s, "chuck_database_metadata", "%s: legacy db-level table must not appear", d.Engine())
+		assert.NotContainsf(t, s, "chuck_object_metadata", "%s: legacy lowercase table must not appear", d.Engine())
 	}
 }
 
 func TestMetadataCreateStatements_SchemaQualifiedOnNonSQLite(t *testing.T) {
 	cfg := MetadataConfig{Owner: "test", Schema: "metaschema"}
 	stmts := metadataCreateStatements(chuck.PostgresDialect{}, cfg)
-	require.Len(t, stmts, 2)
-	for _, s := range stmts {
-		assert.True(t,
-			strings.Contains(s, `"metaschema"."chuck_database_metadata"`) ||
-				strings.Contains(s, `"metaschema"."chuck_object_metadata"`),
-			"postgres schema-qualified table name expected: %s", s)
-	}
+	require.Len(t, stmts, 1)
+	assert.True(t,
+		strings.Contains(stmts[0], `"metaschema"."ChuckObjectMetadata"`),
+		"postgres schema-qualified table name expected: %s", stmts[0])
 }
 
 // --- helpers ----------------------------------------------------------------
@@ -390,9 +359,6 @@ type objectMetadataRow struct {
 	lastApplied    time.Time
 	lastChanged    time.Time
 	definitionHash string
-	sourceRepo     sql.NullString
-	sourceRev      sql.NullString
-	toolVersion    sql.NullString
 }
 
 func readObjectRow(
@@ -406,38 +372,13 @@ func readObjectRow(
 ) objectMetadataRow {
 	t.Helper()
 	schemaCol, nameCol := metadataObjectColumns(d, obj)
-	q := `SELECT first_applied_at_utc, last_applied_at_utc, last_changed_at_utc,
-	             definition_hash, source_repo, source_rev, tool_version
-	      FROM ` + DefaultObjectMetadataTableName + `
-	      WHERE owner = ? AND object_type = ? AND object_schema = ? AND object_name = ?`
+	q := `SELECT "FirstAppliedAtUtc", "LastAppliedAtUtc", "LastChangedAtUtc", "DefinitionHash"
+	      FROM "` + DefaultObjectMetadataTableName + `"
+	      WHERE "Owner" = ? AND "ObjectType" = ? AND "ObjectSchema" = ? AND "ObjectName" = ?`
 	var row objectMetadataRow
 	err := db.QueryRowContext(ctx, q, cfg.Owner, objectType, schemaCol, nameCol).Scan(
-		&row.firstApplied, &row.lastApplied, &row.lastChanged,
-		&row.definitionHash, &row.sourceRepo, &row.sourceRev, &row.toolVersion,
+		&row.firstApplied, &row.lastApplied, &row.lastChanged, &row.definitionHash,
 	)
-	require.NoError(t, err)
-	return row
-}
-
-type databaseMetadataRow struct {
-	firstApplied time.Time
-	lastApplied  time.Time
-}
-
-func readDatabaseRow(
-	t *testing.T,
-	ctx context.Context,
-	db *sql.DB,
-	d chuck.Dialect,
-	cfg MetadataConfig,
-) databaseMetadataRow {
-	t.Helper()
-	_ = d
-	q := `SELECT first_applied_at_utc, last_applied_at_utc
-	      FROM ` + DefaultDatabaseMetadataTableName + `
-	      WHERE owner = ?`
-	var row databaseMetadataRow
-	err := db.QueryRowContext(ctx, q, cfg.Owner).Scan(&row.firstApplied, &row.lastApplied)
 	require.NoError(t, err)
 	return row
 }


### PR DESCRIPTION
## Summary

- Drop `chuck_database_metadata` and the `SourceRepo` / `SourceRev` / `ToolVersion` provenance fields and columns. Richer or app-specific provenance belongs in caller-owned sibling tables outside chuck.
- Rename the surviving snapshot ledger to fixed PascalCase `ChuckObjectMetadata` with columns `Owner`, `ObjectType`, `ObjectSchema`, `ObjectName`, `FirstAppliedAtUtc`, `LastAppliedAtUtc`, `LastChangedAtUtc`, `DefinitionHash`.
- Preserve `MetadataConfig.Schema` as a caller-owned namespace override; chuck imposes no default schema and never `CREATE SCHEMA`s implicitly.
- Bypass dialect `NormalizeIdentifier` for the ledger table so the PascalCase identifier renders verbatim on Postgres (which would otherwise camelToSnake the table name). Pointer text and DDL/DML all run through one helper so apply/validate stay symmetric.
- Tests and README updated to match the slimmer surface; ownership-notice pointer test now expects `"ChuckObjectMetadata"` across dialects.

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`

Source: `plans/plan-026-shrink-snapshot-metadata-ledger-to-object-only-core.md`