### PR TITLE
feat(schema,dbrepo): typed audit actor columns via AuditTrailSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Traits add columns and behavior in one call. They're composable -- use as many o
 | --------------------- | ------------------------------------- | ---------------------------------- |
 | `WithTimestamps()`    | `CreatedAt` (immutable), `UpdatedAt`  | Creation and modification tracking |
 | `WithSoftDelete()`    | `DeletedAt`                           | Soft delete (nullable timestamp)   |
-| `WithAuditTrail(spec)`| `CreatedBy`, `UpdatedBy`, `DeletedBy` | Actor attribution (spec-driven)    |
+| `WithAuditTrail(spec)`| Caller-supplied actor columns         | Actor attribution (spec-driven)    |
 | `WithVersion()`       | `Version` (default 1)                 | Optimistic concurrency control     |
 | `WithStatus(default)` | `Status`                              | Workflow state                     |
 | `WithSortOrder()`     | `SortOrder`                           | Manual ordering                    |

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Traits add columns and behavior in one call. They're composable -- use as many o
 | --------------------- | ------------------------------------- | ---------------------------------- |
 | `WithTimestamps()`    | `CreatedAt` (immutable), `UpdatedAt`  | Creation and modification tracking |
 | `WithSoftDelete()`    | `DeletedAt`                           | Soft delete (nullable timestamp)   |
-| `WithAuditTrail()`    | `CreatedBy`, `UpdatedBy`, `DeletedBy` | User attribution                   |
+| `WithAuditTrail(spec)`| `CreatedBy`, `UpdatedBy`, `DeletedBy` | Actor attribution (spec-driven)    |
 | `WithVersion()`       | `Version` (default 1)                 | Optimistic concurrency control     |
 | `WithStatus(default)` | `Status`                              | Workflow state                     |
 | `WithSortOrder()`     | `SortOrder`                           | Manual ordering                    |
@@ -298,6 +298,53 @@ Traits add columns and behavior in one call. They're composable -- use as many o
 Traits use PascalCase column names internally. For Postgres, these are automatically normalized to snake_case (`CreatedAt` becomes `created_at`). SQLite and MSSQL preserve the original casing.
 
 Each trait has a corresponding `ColumnDefs()` function (e.g., `TimestampColumnDefs()`, `SoftDeleteColumnDefs()`) if you need the column definitions without attaching them to a table.
+
+#### Audit trail: spec-driven actor columns
+
+`WithAuditTrail` takes an explicit `AuditTrailSpec` so actor identity can be
+typed however the caller stores it — free-form string, integer FK to a
+`Users` table, UUID, etc. Chuck never imposes a type, nullability, or
+mutability on actor columns; each field on the spec is the caller's own
+`ColumnDef`.
+
+```go
+// Historical string shape — convenience preset for callers that store
+// actor identity as a free-form string (username, email, opaque id).
+// CreatedBy is marked immutable in the preset; UpdatedBy and DeletedBy
+// remain mutable.
+tasks := schema.NewTable("Tasks").
+    Columns(/* ... */).
+    WithTimestamps().
+    WithSoftDelete().
+    WithAuditTrail(schema.DefaultStringAuditTrail())
+
+// Typed actor identity — store the foreign key to your Users table.
+// The caller decides type, nullability, mutability, and FK behavior.
+tasks := schema.NewTable("Tasks").
+    Columns(/* ... */).
+    WithTimestamps().
+    WithSoftDelete().
+    WithAuditTrail(schema.AuditTrailSpec{
+        CreatedBy: schema.Col("CreatedByID", schema.TypeInt()).NotNull().
+            References("Users", "ID").Immutable(),
+        UpdatedBy: schema.Col("UpdatedByID", schema.TypeInt()).NotNull().
+            References("Users", "ID"),
+        DeletedBy: schema.Col("DeletedByID", schema.TypeInt()).
+            References("Users", "ID"),
+    })
+```
+
+The dbrepo audit helpers (`SetCreateAudit`, `SetUpdateAudit`,
+`SetDeleteAudit`) are generic over the actor type, so the same helper works
+for string actors and typed actors alike:
+
+```go
+// String actor
+dbrepo.SetCreateAudit(&row.CreatedBy, &row.UpdatedBy, "admin@example.com")
+
+// Typed actor (e.g. int64 user id)
+dbrepo.SetCreateAudit(&row.CreatedByID, &row.UpdatedByID, currentUserID)
+```
 
 ### Table Factories
 
@@ -1395,7 +1442,10 @@ Same pattern -- `.Where()`, `.WithDialect()`, `.Returning()`, `.Build()`.
 Domain patterns as plain functions -- no base class, no embedded struct. Each function corresponds to a schema trait: `WithTimestamps()` declares the columns, these helpers set the values.
 
 ```go
-// Creating a record (pairs with WithTimestamps, WithVersion, WithAuditTrail)
+// Creating a record (pairs with WithTimestamps, WithVersion, WithAuditTrail).
+// SetCreateAudit / SetUpdateAudit / SetDeleteAudit are generic over the actor
+// type — pass a string actor or a typed actor (int64 user id, uuid.UUID,
+// etc.) and Go infers T from the value.
 dbrepo.SetCreateTimestamps(&t.CreatedAt, &t.UpdatedAt)
 dbrepo.InitVersion(&t.Version)
 dbrepo.SetCreateAudit(&t.CreatedBy, &t.UpdatedBy, currentUser)

--- a/dbrepo/audit.go
+++ b/dbrepo/audit.go
@@ -41,28 +41,35 @@ func SetSoftDelete(deletedAt *time.Time) {
 	}
 }
 
-// SetDeleteAudit sets DeletedAt and DeletedBy for a soft-delete with audit trail.
-func SetDeleteAudit(deletedAt *time.Time, deletedBy *string, user string) {
+// SetDeleteAudit sets DeletedAt to the current time and writes the actor
+// into deletedBy for a soft-delete with audit trail. T is the caller's
+// actor-identity type (string, int64, uuid.UUID, etc). Both pointers are
+// nil-safe and skipped when nil.
+func SetDeleteAudit[T any](deletedAt *time.Time, deletedBy *T, actor T) {
 	SetSoftDelete(deletedAt)
 	if deletedBy != nil {
-		*deletedBy = user
+		*deletedBy = actor
 	}
 }
 
-// SetCreateAudit sets CreatedBy and UpdatedBy for a new record.
-func SetCreateAudit(createdBy, updatedBy *string, user string) {
+// SetCreateAudit writes the actor into createdBy and updatedBy for a new
+// record. T is the caller's actor-identity type (string, int64, uuid.UUID,
+// etc). Each pointer is nil-safe and skipped when nil.
+func SetCreateAudit[T any](createdBy, updatedBy *T, actor T) {
 	if createdBy != nil {
-		*createdBy = user
+		*createdBy = actor
 	}
 	if updatedBy != nil {
-		*updatedBy = user
+		*updatedBy = actor
 	}
 }
 
-// SetUpdateAudit sets UpdatedBy for an updated record.
-func SetUpdateAudit(updatedBy *string, user string) {
+// SetUpdateAudit writes the actor into updatedBy for an updated record.
+// T is the caller's actor-identity type. The pointer is nil-safe and
+// skipped when nil.
+func SetUpdateAudit[T any](updatedBy *T, actor T) {
 	if updatedBy != nil {
-		*updatedBy = user
+		*updatedBy = actor
 	}
 }
 

--- a/dbrepo/audit_test.go
+++ b/dbrepo/audit_test.go
@@ -52,7 +52,7 @@ func TestSetSortOrder(t *testing.T) {
 	assert.Equal(t, 5, o)
 }
 
-func TestAuditHelpers(t *testing.T) {
+func TestAuditHelpers_StringActor(t *testing.T) {
 	var createdBy, updatedBy string
 	SetCreateAudit(&createdBy, &updatedBy, "admin")
 	assert.Equal(t, "admin", createdBy)
@@ -62,12 +62,30 @@ func TestAuditHelpers(t *testing.T) {
 	assert.Equal(t, "user1", updatedBy)
 }
 
-func TestDeleteAudit(t *testing.T) {
+func TestAuditHelpers_TypedActor_Int64(t *testing.T) {
+	var createdBy, updatedBy int64
+	SetCreateAudit(&createdBy, &updatedBy, int64(42))
+	assert.Equal(t, int64(42), createdBy)
+	assert.Equal(t, int64(42), updatedBy)
+
+	SetUpdateAudit(&updatedBy, int64(7))
+	assert.Equal(t, int64(7), updatedBy)
+}
+
+func TestDeleteAudit_StringActor(t *testing.T) {
 	var deletedAt time.Time
 	var deletedBy string
 	SetDeleteAudit(&deletedAt, &deletedBy, "admin")
 	assert.False(t, deletedAt.IsZero())
 	assert.Equal(t, "admin", deletedBy)
+}
+
+func TestDeleteAudit_TypedActor_Int64(t *testing.T) {
+	var deletedAt time.Time
+	var deletedBy int64
+	SetDeleteAudit(&deletedAt, &deletedBy, int64(99))
+	assert.False(t, deletedAt.IsZero())
+	assert.Equal(t, int64(99), deletedBy)
 }
 
 func TestArchive(t *testing.T) {
@@ -125,9 +143,15 @@ func TestNilSafety(t *testing.T) {
 	var nilNullTime *sql.NullTime
 	ClearArchive(nilNullTime)
 	ClearExpiry(nilNullTime)
-	SetCreateAudit(nil, nil, "")
-	SetUpdateAudit(nil, "")
-	SetDeleteAudit(nil, nil, "")
+	var nilString *string
+	SetCreateAudit(nilString, nilString, "")
+	SetUpdateAudit(nilString, "")
+	SetDeleteAudit(nil, nilString, "")
+	// Typed variants must be equally nil-safe.
+	var nilInt64 *int64
+	SetCreateAudit(nilInt64, nilInt64, int64(0))
+	SetUpdateAudit(nilInt64, int64(0))
+	SetDeleteAudit(nil, nilInt64, int64(0))
 }
 
 func TestNowFuncOverride(t *testing.T) {

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -42,7 +42,7 @@ func ExampleNewTable_traits() {
 		WithVersion().
 		WithSoftDelete().
 		WithTimestamps().
-		WithAuditTrail()
+		WithAuditTrail(schema.DefaultStringAuditTrail())
 
 	// The table knows which columns are mutable vs immutable
 	fmt.Println("Select:", strings.Join(projects.SelectColumns(), ", "))
@@ -115,7 +115,7 @@ func ExampleNewTable_allTraits() {
 		).
 		WithTimestamps().
 		WithSoftDelete().
-		WithAuditTrail().
+		WithAuditTrail(schema.DefaultStringAuditTrail()).
 		WithVersion().
 		WithStatus("draft").
 		WithSortOrder().
@@ -149,6 +149,33 @@ func ExampleNewTable_allTraits() {
 	//   ReplacedByID
 	//   ArchivedAt
 	//   ExpiresAt
+}
+
+func ExampleTableDef_WithAuditTrail_typedActor() {
+	// Audit actor identity stored as an integer FK to Users instead of the
+	// historical free-form string. Caller-controlled ColumnDef wins: chuck
+	// does not impose type, nullability, or mutability.
+	tasks := schema.NewTable("Tasks").
+		Columns(
+			schema.AutoIncrCol("ID"),
+			schema.Col("Title", schema.TypeString(255)).NotNull(),
+		).
+		WithTimestamps().
+		WithSoftDelete().
+		WithAuditTrail(schema.AuditTrailSpec{
+			CreatedBy: schema.Col("CreatedByID", schema.TypeInt()).NotNull().
+				References("Users", "ID").Immutable(),
+			UpdatedBy: schema.Col("UpdatedByID", schema.TypeInt()).NotNull().
+				References("Users", "ID"),
+			DeletedBy: schema.Col("DeletedByID", schema.TypeInt()).
+				References("Users", "ID"),
+		})
+
+	fmt.Println("Select:", strings.Join(tasks.SelectColumns(), ", "))
+	fmt.Println("Update:", strings.Join(tasks.UpdateColumns(), ", "))
+	// Output:
+	// Select: ID, Title, CreatedAt, UpdatedAt, DeletedAt, CreatedByID, UpdatedByID, DeletedByID
+	// Update: Title, UpdatedAt, DeletedAt, UpdatedByID, DeletedByID
 }
 
 func ExampleNewLookupTable() {

--- a/schema/table.go
+++ b/schema/table.go
@@ -112,9 +112,14 @@ func (t *TableDef) WithSoftDelete() *TableDef {
 	return t
 }
 
-// WithAuditTrail appends CreatedBy, UpdatedBy, and DeletedBy columns.
-func (t *TableDef) WithAuditTrail() *TableDef {
-	t.cols = append(t.cols, AuditColumnDefs()...)
+// WithAuditTrail appends the audit-trail actor columns from spec to the
+// table. The spec carries the caller's own ColumnDefs for CreatedBy,
+// UpdatedBy, and DeletedBy — chuck does not impose type, nullability, or
+// mutability defaults. Use DefaultStringAuditTrail() for the historical
+// VARCHAR(255) shape, or build an AuditTrailSpec with typed/FK-style
+// ColumnDefs for typed actor identity.
+func (t *TableDef) WithAuditTrail(spec AuditTrailSpec) *TableDef {
+	t.cols = append(t.cols, AuditColumnDefs(spec)...)
 	return t
 }
 

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -103,7 +103,7 @@ func TestTableTraits(t *testing.T) {
 		WithReplacement().
 		WithTimestamps().
 		WithSoftDelete().
-		WithAuditTrail()
+		WithAuditTrail(DefaultStringAuditTrail())
 
 	cols := table.SelectColumns()
 	assert.Contains(t, cols, "UUID")

--- a/schema/traits.go
+++ b/schema/traits.go
@@ -19,12 +19,41 @@ func SoftDeleteColumnDefs() []ColumnDef {
 	}
 }
 
-// AuditColumnDefs returns CreatedBy, UpdatedBy, and DeletedBy columns.
-func AuditColumnDefs() []ColumnDef {
-	return []ColumnDef{
-		Col("CreatedBy", TypeString(255)).Immutable(),
-		Col("UpdatedBy", TypeString(255)),
-		Col("DeletedBy", TypeString(255)),
+// AuditTrailSpec carries the explicit ColumnDefs the audit trail trait
+// appends to a TableDef. Each field is the caller's own ColumnDef, including
+// type, nullability, default, and mutability — chuck does not silently
+// override any of them. Callers that want the historical string-based shape
+// should use DefaultStringAuditTrail; integer/UUID/FK-style actor columns
+// just pass a ColumnDef built with the caller's chosen type and constraints.
+//
+// The created-by column is intentionally not forced immutable here; the
+// caller's ColumnDef wins. Presets that want the historical "created-by is
+// frozen at insert time" behavior should call .Immutable() themselves
+// (DefaultStringAuditTrail does).
+type AuditTrailSpec struct {
+	CreatedBy ColumnDef
+	UpdatedBy ColumnDef
+	DeletedBy ColumnDef
+}
+
+// AuditColumnDefs returns the CreatedBy / UpdatedBy / DeletedBy ColumnDefs
+// from the spec, in the order the audit trait appends them to a TableDef.
+func AuditColumnDefs(spec AuditTrailSpec) []ColumnDef {
+	return []ColumnDef{spec.CreatedBy, spec.UpdatedBy, spec.DeletedBy}
+}
+
+// DefaultStringAuditTrail returns the historical chuck audit shape: three
+// VARCHAR(255) actor columns named CreatedBy / UpdatedBy / DeletedBy, with
+// CreatedBy marked Immutable() so it is frozen at insert time and UpdatedBy /
+// DeletedBy left mutable. Use this when the caller stores actor identity as
+// a free-form string (username, email, opaque id) and wants the original
+// chuck defaults. Callers wanting typed actor identity (e.g. UserID INT
+// referencing Users) should build their own AuditTrailSpec.
+func DefaultStringAuditTrail() AuditTrailSpec {
+	return AuditTrailSpec{
+		CreatedBy: Col("CreatedBy", TypeString(255)).Immutable(),
+		UpdatedBy: Col("UpdatedBy", TypeString(255)),
+		DeletedBy: Col("DeletedBy", TypeString(255)),
 	}
 }
 


### PR DESCRIPTION
Closes #104.

## Summary

- Replace no-arg `WithAuditTrail()` with a spec-driven `WithAuditTrail(spec AuditTrailSpec)` so audit actor identity can be typed however the caller stores it (free-form string, integer FK to a `Users` table, UUID, etc.). Each `ColumnDef` on the spec is the caller's own — chuck never imposes a type, nullability, or mutability on actor columns.
- Ship `schema.DefaultStringAuditTrail()` as a convenience preset that preserves the historical `VARCHAR(255)` shape with `CreatedBy` immutable.
- Convert `dbrepo.SetCreateAudit` / `SetUpdateAudit` / `SetDeleteAudit` to generics over the actor type `T`, so the same helper works for string and typed actors. Nil safety preserved; tests cover both string and `int64` cases.
- Break clean per the plan: no compatibility shim for the no-arg form.

## Test plan

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`

Source: `plans/plan-027-redesign-audit-trail-for-typed-actor-columns.md`