### PR TITLE
feat(schema,dbrepo): split audit trail into timestamps, actors, and delete actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ Traits add columns and behavior in one call. They're composable -- use as many o
 | --------------------- | ------------------------------------- | ---------------------------------- |
 | `WithTimestamps()`    | `CreatedAt` (immutable), `UpdatedAt`  | Creation and modification tracking |
 | `WithSoftDelete()`    | `DeletedAt`                           | Soft delete (nullable timestamp)   |
-| `WithAuditTrail(spec)`| Caller-supplied actor columns         | Actor attribution (spec-driven)    |
+| `WithAuditActors(spec)` | Caller-supplied `CreatedBy`, `UpdatedBy` | Create/update actor attribution |
+| `WithDeleteActor(col)` | Caller-supplied `DeletedBy`           | Soft-delete actor attribution      |
+| `WithAuditTrail(spec)`| Bundle: `WithTimestamps()` + `WithAuditActors(spec)` | Common create/update audit combo |
 | `WithVersion()`       | `Version` (default 1)                 | Optimistic concurrency control     |
 | `WithStatus(default)` | `Status`                              | Workflow state                     |
 | `WithSortOrder()`     | `SortOrder`                           | Manual ordering                    |
@@ -299,51 +301,70 @@ Traits use PascalCase column names internally. For Postgres, these are automatic
 
 Each trait has a corresponding `ColumnDefs()` function (e.g., `TimestampColumnDefs()`, `SoftDeleteColumnDefs()`) if you need the column definitions without attaching them to a table.
 
-#### Audit trail: spec-driven actor columns
+#### Audit trail: timestamps, actors, and delete actor are separate
 
-`WithAuditTrail` takes an explicit `AuditTrailSpec` so actor identity can be
-typed however the caller stores it — free-form string, integer FK to a
-`Users` table, UUID, etc. Chuck never imposes a type, nullability, or
-mutability on actor columns; each field on the spec is the caller's own
-`ColumnDef`.
+Audit traits split along three orthogonal axes so tables only pay for what
+they need:
+
+| Axis             | Schema trait               | dbrepo helper                                   |
+| ---------------- | -------------------------- | ----------------------------------------------- |
+| Create/update timestamps | `WithTimestamps()`         | `SetCreateTimestamps`, `SetUpdateTimestamp`     |
+| Create/update actors     | `WithAuditActors(spec)`    | `SetCreateActor`, `SetUpdateActor`              |
+| Soft-delete timestamp    | `WithSoftDelete()`         | `SetSoftDelete`                                 |
+| Soft-delete actor        | `WithDeleteActor(col)`     | `SetDeleteActor`                                |
+
+`WithAuditTrail(spec)` is a convenience bundle equivalent to
+`WithTimestamps().WithAuditActors(spec)` — the common create/update audit
+combo. It does not touch delete semantics, so a non-soft-deleting table
+never grows a `DeletedBy` column it does not need.
+
+Actor identity can be typed however the caller stores it — free-form string,
+integer FK to a `Users` table, UUID, etc. Chuck never imposes a type,
+nullability, or mutability on actor columns; each field on the spec is the
+caller's own `ColumnDef`.
 
 ```go
-// Historical string shape — convenience preset for callers that store
+// Historical string shape — convenience presets for callers that store
 // actor identity as a free-form string (username, email, opaque id).
-// CreatedBy is marked immutable in the preset; UpdatedBy and DeletedBy
-// remain mutable.
+// CreatedBy is marked immutable in DefaultStringAuditActors; UpdatedBy and
+// DeletedBy remain mutable.
+notes := schema.NewTable("Notes").
+    Columns(/* ... */).
+    WithAuditTrail(schema.DefaultStringAuditActors()) // timestamps + actors bundle
+
 tasks := schema.NewTable("Tasks").
     Columns(/* ... */).
     WithTimestamps().
     WithSoftDelete().
-    WithAuditTrail(schema.DefaultStringAuditTrail())
+    WithAuditActors(schema.DefaultStringAuditActors()).
+    WithDeleteActor(schema.DefaultStringDeleteActor())
 
 // Typed actor identity — store the foreign key to your Users table.
 // The caller decides type, nullability, mutability, and FK behavior.
-tasks := schema.NewTable("Tasks").
+tasks = schema.NewTable("Tasks").
     Columns(/* ... */).
     WithTimestamps().
     WithSoftDelete().
-    WithAuditTrail(schema.AuditTrailSpec{
+    WithAuditActors(schema.AuditActorsSpec{
         CreatedBy: schema.Col("CreatedByID", schema.TypeInt()).NotNull().
             References("Users", "ID").Immutable(),
         UpdatedBy: schema.Col("UpdatedByID", schema.TypeInt()).NotNull().
             References("Users", "ID"),
-        DeletedBy: schema.Col("DeletedByID", schema.TypeInt()).
-            References("Users", "ID"),
-    })
+    }).
+    WithDeleteActor(schema.Col("DeletedByID", schema.TypeInt()).
+        References("Users", "ID"))
 ```
 
-The dbrepo audit helpers (`SetCreateAudit`, `SetUpdateAudit`,
-`SetDeleteAudit`) are generic over the actor type, so the same helper works
+The dbrepo actor helpers (`SetCreateActor`, `SetUpdateActor`,
+`SetDeleteActor`) are generic over the actor type, so the same helper works
 for string actors and typed actors alike:
 
 ```go
 // String actor
-dbrepo.SetCreateAudit(&row.CreatedBy, &row.UpdatedBy, "admin@example.com")
+dbrepo.SetCreateActor(&row.CreatedBy, &row.UpdatedBy, "admin@example.com")
 
 // Typed actor (e.g. int64 user id)
-dbrepo.SetCreateAudit(&row.CreatedByID, &row.UpdatedByID, currentUserID)
+dbrepo.SetCreateActor(&row.CreatedByID, &row.UpdatedByID, currentUserID)
 ```
 
 ### Table Factories
@@ -1442,22 +1463,22 @@ Same pattern -- `.Where()`, `.WithDialect()`, `.Returning()`, `.Build()`.
 Domain patterns as plain functions -- no base class, no embedded struct. Each function corresponds to a schema trait: `WithTimestamps()` declares the columns, these helpers set the values.
 
 ```go
-// Creating a record (pairs with WithTimestamps, WithVersion, WithAuditTrail).
-// SetCreateAudit / SetUpdateAudit / SetDeleteAudit are generic over the actor
-// type — pass a string actor or a typed actor (int64 user id, uuid.UUID,
-// etc.) and Go infers T from the value.
+// Creating a record (pairs with WithTimestamps + WithAuditActors, or the
+// bundled WithAuditTrail). SetCreateActor / SetUpdateActor / SetDeleteActor
+// are generic over the actor type — pass a string actor or a typed actor
+// (int64 user id, uuid.UUID, etc.) and Go infers T from the value.
 dbrepo.SetCreateTimestamps(&t.CreatedAt, &t.UpdatedAt)
 dbrepo.InitVersion(&t.Version)
-dbrepo.SetCreateAudit(&t.CreatedBy, &t.UpdatedBy, currentUser)
+dbrepo.SetCreateActor(&t.CreatedBy, &t.UpdatedBy, currentUser)
 
-// Updating (pairs with WithTimestamps, WithVersion, WithAuditTrail)
+// Updating (pairs with WithTimestamps + WithAuditActors)
 dbrepo.SetUpdateTimestamp(&t.UpdatedAt)
 dbrepo.IncrementVersion(&t.Version)
-dbrepo.SetUpdateAudit(&t.UpdatedBy, currentUser)
+dbrepo.SetUpdateActor(&t.UpdatedBy, currentUser)
 
-// Soft delete (pairs with WithSoftDelete, WithAuditTrail)
+// Soft delete (pairs with WithSoftDelete + WithDeleteActor)
 dbrepo.SetSoftDelete(&t.DeletedAt)
-dbrepo.SetDeleteAudit(&t.DeletedAt, &t.DeletedBy, currentUser)
+dbrepo.SetDeleteActor(&t.DeletedAt, &t.DeletedBy, currentUser)
 
 // State management (pairs with WithStatus, WithArchive, WithExpiry, WithReplacement)
 dbrepo.SetStatus(&t.Status, "published")

--- a/dbrepo/audit.go
+++ b/dbrepo/audit.go
@@ -41,21 +41,23 @@ func SetSoftDelete(deletedAt *time.Time) {
 	}
 }
 
-// SetDeleteAudit sets DeletedAt to the current time and writes the actor
-// into deletedBy for a soft-delete with audit trail. T is the caller's
-// actor-identity type (string, int64, uuid.UUID, etc). Both pointers are
-// nil-safe and skipped when nil.
-func SetDeleteAudit[T any](deletedAt *time.Time, deletedBy *T, actor T) {
+// SetDeleteActor sets DeletedAt to the current time and writes the actor
+// into deletedBy for a soft-delete with delete-actor attribution. T is the
+// caller's actor-identity type (string, int64, uuid.UUID, etc). Both
+// pointers are nil-safe and skipped when nil. Pairs with the schema-side
+// WithSoftDelete() + WithDeleteActor(...) trait composition.
+func SetDeleteActor[T any](deletedAt *time.Time, deletedBy *T, actor T) {
 	SetSoftDelete(deletedAt)
 	if deletedBy != nil {
 		*deletedBy = actor
 	}
 }
 
-// SetCreateAudit writes the actor into createdBy and updatedBy for a new
+// SetCreateActor writes the actor into createdBy and updatedBy for a new
 // record. T is the caller's actor-identity type (string, int64, uuid.UUID,
-// etc). Each pointer is nil-safe and skipped when nil.
-func SetCreateAudit[T any](createdBy, updatedBy *T, actor T) {
+// etc). Each pointer is nil-safe and skipped when nil. Pairs with the
+// schema-side WithAuditActors(...) trait.
+func SetCreateActor[T any](createdBy, updatedBy *T, actor T) {
 	if createdBy != nil {
 		*createdBy = actor
 	}
@@ -64,10 +66,10 @@ func SetCreateAudit[T any](createdBy, updatedBy *T, actor T) {
 	}
 }
 
-// SetUpdateAudit writes the actor into updatedBy for an updated record.
+// SetUpdateActor writes the actor into updatedBy for an updated record.
 // T is the caller's actor-identity type. The pointer is nil-safe and
-// skipped when nil.
-func SetUpdateAudit[T any](updatedBy *T, actor T) {
+// skipped when nil. Pairs with the schema-side WithAuditActors(...) trait.
+func SetUpdateActor[T any](updatedBy *T, actor T) {
 	if updatedBy != nil {
 		*updatedBy = actor
 	}

--- a/dbrepo/audit_test.go
+++ b/dbrepo/audit_test.go
@@ -52,38 +52,38 @@ func TestSetSortOrder(t *testing.T) {
 	assert.Equal(t, 5, o)
 }
 
-func TestAuditHelpers_StringActor(t *testing.T) {
+func TestActorHelpers_StringActor(t *testing.T) {
 	var createdBy, updatedBy string
-	SetCreateAudit(&createdBy, &updatedBy, "admin")
+	SetCreateActor(&createdBy, &updatedBy, "admin")
 	assert.Equal(t, "admin", createdBy)
 	assert.Equal(t, "admin", updatedBy)
 
-	SetUpdateAudit(&updatedBy, "user1")
+	SetUpdateActor(&updatedBy, "user1")
 	assert.Equal(t, "user1", updatedBy)
 }
 
-func TestAuditHelpers_TypedActor_Int64(t *testing.T) {
+func TestActorHelpers_TypedActor_Int64(t *testing.T) {
 	var createdBy, updatedBy int64
-	SetCreateAudit(&createdBy, &updatedBy, int64(42))
+	SetCreateActor(&createdBy, &updatedBy, int64(42))
 	assert.Equal(t, int64(42), createdBy)
 	assert.Equal(t, int64(42), updatedBy)
 
-	SetUpdateAudit(&updatedBy, int64(7))
+	SetUpdateActor(&updatedBy, int64(7))
 	assert.Equal(t, int64(7), updatedBy)
 }
 
-func TestDeleteAudit_StringActor(t *testing.T) {
+func TestDeleteActor_StringActor(t *testing.T) {
 	var deletedAt time.Time
 	var deletedBy string
-	SetDeleteAudit(&deletedAt, &deletedBy, "admin")
+	SetDeleteActor(&deletedAt, &deletedBy, "admin")
 	assert.False(t, deletedAt.IsZero())
 	assert.Equal(t, "admin", deletedBy)
 }
 
-func TestDeleteAudit_TypedActor_Int64(t *testing.T) {
+func TestDeleteActor_TypedActor_Int64(t *testing.T) {
 	var deletedAt time.Time
 	var deletedBy int64
-	SetDeleteAudit(&deletedAt, &deletedBy, int64(99))
+	SetDeleteActor(&deletedAt, &deletedBy, int64(99))
 	assert.False(t, deletedAt.IsZero())
 	assert.Equal(t, int64(99), deletedBy)
 }
@@ -144,14 +144,14 @@ func TestNilSafety(t *testing.T) {
 	ClearArchive(nilNullTime)
 	ClearExpiry(nilNullTime)
 	var nilString *string
-	SetCreateAudit(nilString, nilString, "")
-	SetUpdateAudit(nilString, "")
-	SetDeleteAudit(nil, nilString, "")
+	SetCreateActor(nilString, nilString, "")
+	SetUpdateActor(nilString, "")
+	SetDeleteActor(nil, nilString, "")
 	// Typed variants must be equally nil-safe.
 	var nilInt64 *int64
-	SetCreateAudit(nilInt64, nilInt64, int64(0))
-	SetUpdateAudit(nilInt64, int64(0))
-	SetDeleteAudit(nil, nilInt64, int64(0))
+	SetCreateActor(nilInt64, nilInt64, int64(0))
+	SetUpdateActor(nilInt64, int64(0))
+	SetDeleteActor(nil, nilInt64, int64(0))
 }
 
 func TestNowFuncOverride(t *testing.T) {

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -42,7 +42,8 @@ func ExampleNewTable_traits() {
 		WithVersion().
 		WithSoftDelete().
 		WithTimestamps().
-		WithAuditTrail(schema.DefaultStringAuditTrail())
+		WithAuditActors(schema.DefaultStringAuditActors()).
+		WithDeleteActor(schema.DefaultStringDeleteActor())
 
 	// The table knows which columns are mutable vs immutable
 	fmt.Println("Select:", strings.Join(projects.SelectColumns(), ", "))
@@ -115,7 +116,8 @@ func ExampleNewTable_allTraits() {
 		).
 		WithTimestamps().
 		WithSoftDelete().
-		WithAuditTrail(schema.DefaultStringAuditTrail()).
+		WithAuditActors(schema.DefaultStringAuditActors()).
+		WithDeleteActor(schema.DefaultStringDeleteActor()).
 		WithVersion().
 		WithStatus("draft").
 		WithSortOrder().
@@ -151,10 +153,30 @@ func ExampleNewTable_allTraits() {
 	//   ExpiresAt
 }
 
-func ExampleTableDef_WithAuditTrail_typedActor() {
-	// Audit actor identity stored as an integer FK to Users instead of the
+func ExampleTableDef_WithAuditTrail_bundled() {
+	// WithAuditTrail bundles WithTimestamps + WithAuditActors — the common
+	// create/update audit combo for tables that always track timestamps and
+	// actors together but do not soft-delete.
+	notes := schema.NewTable("Notes").
+		Columns(
+			schema.AutoIncrCol("ID"),
+			schema.Col("Body", schema.TypeText()).NotNull(),
+		).
+		WithAuditTrail(schema.DefaultStringAuditActors())
+
+	fmt.Println("Select:", strings.Join(notes.SelectColumns(), ", "))
+	fmt.Println("Update:", strings.Join(notes.UpdateColumns(), ", "))
+	// Output:
+	// Select: ID, Body, CreatedAt, UpdatedAt, CreatedBy, UpdatedBy
+	// Update: Body, UpdatedAt, UpdatedBy
+}
+
+func ExampleTableDef_WithAuditActors_typedActor() {
+	// Actor identity stored as an integer FK to Users instead of the
 	// historical free-form string. Caller-controlled ColumnDef wins: chuck
-	// does not impose type, nullability, or mutability.
+	// does not impose type, nullability, or mutability. Delete-actor
+	// attribution is composed independently via WithDeleteActor so tables
+	// that do not soft-delete never carry a DeletedBy column.
 	tasks := schema.NewTable("Tasks").
 		Columns(
 			schema.AutoIncrCol("ID"),
@@ -162,14 +184,14 @@ func ExampleTableDef_WithAuditTrail_typedActor() {
 		).
 		WithTimestamps().
 		WithSoftDelete().
-		WithAuditTrail(schema.AuditTrailSpec{
+		WithAuditActors(schema.AuditActorsSpec{
 			CreatedBy: schema.Col("CreatedByID", schema.TypeInt()).NotNull().
 				References("Users", "ID").Immutable(),
 			UpdatedBy: schema.Col("UpdatedByID", schema.TypeInt()).NotNull().
 				References("Users", "ID"),
-			DeletedBy: schema.Col("DeletedByID", schema.TypeInt()).
-				References("Users", "ID"),
-		})
+		}).
+		WithDeleteActor(schema.Col("DeletedByID", schema.TypeInt()).
+			References("Users", "ID"))
 
 	fmt.Println("Select:", strings.Join(tasks.SelectColumns(), ", "))
 	fmt.Println("Update:", strings.Join(tasks.UpdateColumns(), ", "))

--- a/schema/table.go
+++ b/schema/table.go
@@ -112,15 +112,45 @@ func (t *TableDef) WithSoftDelete() *TableDef {
 	return t
 }
 
-// WithAuditTrail appends the audit-trail actor columns from spec to the
-// table. The spec carries the caller's own ColumnDefs for CreatedBy,
-// UpdatedBy, and DeletedBy — chuck does not impose type, nullability, or
-// mutability defaults. Use DefaultStringAuditTrail() for the historical
-// VARCHAR(255) shape, or build an AuditTrailSpec with typed/FK-style
-// ColumnDefs for typed actor identity.
-func (t *TableDef) WithAuditTrail(spec AuditTrailSpec) *TableDef {
-	t.cols = append(t.cols, AuditColumnDefs(spec)...)
+// WithAuditActors appends the create/update actor columns from spec
+// (CreatedBy, UpdatedBy) to the table. The spec carries the caller's own
+// ColumnDefs — chuck does not impose type, nullability, or mutability
+// defaults. Use DefaultStringAuditActors() for the historical VARCHAR(255)
+// shape, or build an AuditActorsSpec with typed / FK-style ColumnDefs for
+// typed actor identity.
+//
+// Delete-actor attribution is intentionally not bundled here. Tables that
+// soft-delete and want to record who deleted should pair WithSoftDelete()
+// with WithDeleteActor(...); tables without soft-delete pay no DeletedBy
+// column.
+func (t *TableDef) WithAuditActors(spec AuditActorsSpec) *TableDef {
+	t.cols = append(t.cols, AuditActorColumnDefs(spec)...)
 	return t
+}
+
+// WithDeleteActor appends a single DeletedBy actor column to the table.
+// Intended to be paired with WithSoftDelete (which appends DeletedAt); the
+// two are independent so callers can compose actor attribution into any
+// soft-delete table without forcing every audited table to carry a
+// DeletedBy column. The caller's ColumnDef wins on type, nullability, and
+// mutability — chuck does not impose defaults. Use
+// DefaultStringDeleteActor() for the historical VARCHAR(255) shape.
+func (t *TableDef) WithDeleteActor(col ColumnDef) *TableDef {
+	t.cols = append(t.cols, DeleteActorColumnDef(col))
+	return t
+}
+
+// WithAuditTrail is a convenience bundle equivalent to
+// WithTimestamps().WithAuditActors(spec). It appends CreatedAt, UpdatedAt,
+// CreatedBy, and UpdatedBy in that order — the common create/update audit
+// combo for tables that always track both timestamps and actors together.
+//
+// WithAuditTrail intentionally does NOT touch delete semantics; callers that
+// soft-delete should compose WithSoftDelete and WithDeleteActor explicitly.
+// This keeps the convenience helper from smuggling delete columns into
+// tables that never soft-delete.
+func (t *TableDef) WithAuditTrail(spec AuditActorsSpec) *TableDef {
+	return t.WithTimestamps().WithAuditActors(spec)
 }
 
 // WithVersion appends a Version column for optimistic concurrency control.

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -103,7 +103,8 @@ func TestTableTraits(t *testing.T) {
 		WithReplacement().
 		WithTimestamps().
 		WithSoftDelete().
-		WithAuditTrail(DefaultStringAuditTrail())
+		WithAuditActors(DefaultStringAuditActors()).
+		WithDeleteActor(DefaultStringDeleteActor())
 
 	cols := table.SelectColumns()
 	assert.Contains(t, cols, "UUID")

--- a/schema/traits.go
+++ b/schema/traits.go
@@ -19,42 +19,60 @@ func SoftDeleteColumnDefs() []ColumnDef {
 	}
 }
 
-// AuditTrailSpec carries the explicit ColumnDefs the audit trail trait
-// appends to a TableDef. Each field is the caller's own ColumnDef, including
-// type, nullability, default, and mutability — chuck does not silently
-// override any of them. Callers that want the historical string-based shape
-// should use DefaultStringAuditTrail; integer/UUID/FK-style actor columns
-// just pass a ColumnDef built with the caller's chosen type and constraints.
+// AuditActorsSpec carries the create/update actor ColumnDefs the audit-actors
+// trait appends to a TableDef. Each field is the caller's own ColumnDef,
+// including type, nullability, default, and mutability — chuck does not
+// silently override any of them. Callers that want the historical
+// string-based shape should use DefaultStringAuditActors; integer / UUID /
+// FK-style actor columns just pass ColumnDefs built with the caller's chosen
+// type and constraints.
+//
+// Delete actor attribution is intentionally NOT part of this spec — it lives
+// behind WithDeleteActor so tables that do not soft-delete never carry a
+// DeletedBy column. This matches the WithTimestamps / WithSoftDelete split
+// on the timestamp side.
 //
 // The created-by column is intentionally not forced immutable here; the
 // caller's ColumnDef wins. Presets that want the historical "created-by is
 // frozen at insert time" behavior should call .Immutable() themselves
-// (DefaultStringAuditTrail does).
-type AuditTrailSpec struct {
+// (DefaultStringAuditActors does).
+type AuditActorsSpec struct {
 	CreatedBy ColumnDef
 	UpdatedBy ColumnDef
-	DeletedBy ColumnDef
 }
 
-// AuditColumnDefs returns the CreatedBy / UpdatedBy / DeletedBy ColumnDefs
-// from the spec, in the order the audit trait appends them to a TableDef.
-func AuditColumnDefs(spec AuditTrailSpec) []ColumnDef {
-	return []ColumnDef{spec.CreatedBy, spec.UpdatedBy, spec.DeletedBy}
+// AuditActorColumnDefs returns the CreatedBy / UpdatedBy ColumnDefs from the
+// spec, in the order the audit-actors trait appends them to a TableDef.
+func AuditActorColumnDefs(spec AuditActorsSpec) []ColumnDef {
+	return []ColumnDef{spec.CreatedBy, spec.UpdatedBy}
 }
 
-// DefaultStringAuditTrail returns the historical chuck audit shape: three
-// VARCHAR(255) actor columns named CreatedBy / UpdatedBy / DeletedBy, with
-// CreatedBy marked Immutable() so it is frozen at insert time and UpdatedBy /
-// DeletedBy left mutable. Use this when the caller stores actor identity as
-// a free-form string (username, email, opaque id) and wants the original
+// DeleteActorColumnDef returns the single DeletedBy ColumnDef appended by the
+// delete-actor trait. The caller's ColumnDef is returned unchanged.
+func DeleteActorColumnDef(col ColumnDef) ColumnDef {
+	return col
+}
+
+// DefaultStringAuditActors returns the historical chuck create/update actor
+// shape: two VARCHAR(255) columns named CreatedBy / UpdatedBy, with
+// CreatedBy marked Immutable() so it is frozen at insert time and UpdatedBy
+// left mutable. Use this when the caller stores actor identity as a
+// free-form string (username, email, opaque id) and wants the original
 // chuck defaults. Callers wanting typed actor identity (e.g. UserID INT
-// referencing Users) should build their own AuditTrailSpec.
-func DefaultStringAuditTrail() AuditTrailSpec {
-	return AuditTrailSpec{
+// referencing Users) should build their own AuditActorsSpec.
+func DefaultStringAuditActors() AuditActorsSpec {
+	return AuditActorsSpec{
 		CreatedBy: Col("CreatedBy", TypeString(255)).Immutable(),
 		UpdatedBy: Col("UpdatedBy", TypeString(255)),
-		DeletedBy: Col("DeletedBy", TypeString(255)),
 	}
+}
+
+// DefaultStringDeleteActor returns the historical chuck delete-actor shape:
+// a single nullable VARCHAR(255) column named DeletedBy. Use this when the
+// caller stores actor identity as a free-form string and wants the original
+// chuck default for soft-delete attribution.
+func DefaultStringDeleteActor() ColumnDef {
+	return Col("DeletedBy", TypeString(255))
 }
 
 // VersionColumnDefs returns a Version column for optimistic concurrency control.


### PR DESCRIPTION
Closes #106.

## Summary

Split the audit-trail API along three orthogonal axes so tables only pay for what they use, while keeping a convenience bundle for the common create/update audit case:

| Axis | Schema trait | dbrepo helper |
|------|--------------|---------------|
| Create/update timestamps | \`WithTimestamps()\` | \`SetCreateTimestamps\`, \`SetUpdateTimestamp\` |
| Create/update actors | \`WithAuditActors(spec)\` | \`SetCreateActor\`, \`SetUpdateActor\` |
| Soft-delete timestamp | \`WithSoftDelete()\` | \`SetSoftDelete\` |
| Soft-delete actor | \`WithDeleteActor(col)\` | \`SetDeleteActor\` |

\`WithAuditTrail(spec)\` is now a convenience bundle equivalent to \`WithTimestamps().WithAuditActors(spec)\`. It deliberately does **not** touch delete semantics, so a table that does not soft-delete never grows a \`DeletedBy\` column.

Schema renames (break clean, no aliases): \`AuditTrailSpec\` → \`AuditActorsSpec\`; \`AuditColumnDefs\` → \`AuditActorColumnDefs\` + new \`DeleteActorColumnDef\`; \`DefaultStringAuditTrail()\` → \`DefaultStringAuditActors()\` + \`DefaultStringDeleteActor()\`.

dbrepo renames: \`SetCreateAudit\` → \`SetCreateActor\`, \`SetUpdateAudit\` → \`SetUpdateActor\`, \`SetDeleteAudit\` → \`SetDeleteActor\`. Helpers stay generic over the actor type with nil safety preserved.

## Test plan

- [x] \`go test ./...\`
- [x] \`golangci-lint run --timeout=5m ./...\`

Source: \`plans/plan-028-split-audit-trail-into-timestamps-audit-actors-and-delete-actor.md\`