### PR TITLE
feat(schema): FromStruct tag helper for simple TableDef generation (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [CHECK Constraints](#check-constraints)
     - [Traits](#traits)
     - [Table Factories](#table-factories)
+    - [FromStruct (Optional Tag Helper)](#fromstruct-optional-tag-helper)
     - [Indexes](#indexes)
     - [Column Lists](#column-lists)
     - [Seed Data](#seed-data)
@@ -379,6 +380,65 @@ schema.NewLookupJoinTable("TaskOptions")                // Owner-to-lookup join 
 schema.NewEventTable("AuditLog", cols...)               // Append-only (all immutable)
 schema.NewQueueTable("Jobs", "Payload")                 // Job queue with scheduling
 ```
+
+### FromStruct (Optional Tag Helper)
+
+`FromStruct[T](name)` is an **optional convenience helper** for deriving a simple `*TableDef` from a Go struct with `chuck` tags. It is intended for small, feature-owned tables (caches, lookup/config tables, session/settings rows, framework-internal support tables) where boilerplate dominates the declaration. The explicit `NewTable(...).Columns(...)` DSL above is still the primary, recommended schema path for real application schema — indexes, composite uniques, traits, seeds, schema qualification, and lifecycle concerns belong there, not in tags.
+
+```go
+type SessionSettingsRow struct {
+    ID          int       `chuck:"pk,auto"`
+    SessionUUID string    `chuck:"size=36,unique,notnull"`
+    Theme       string    `chuck:"size=50,notnull,default='light'"`
+    Layout      string    `chuck:"size=50,notnull,default='classic'"`
+    CreatedAt   time.Time `chuck:"created_at"`
+    UpdatedAt   time.Time `chuck:"updated_at"`
+}
+
+var SessionSettingsTable = schema.FromStruct[SessionSettingsRow]("SessionSettings").
+    Indexes(schema.Index("idx_session_settings_uuid", "SessionUUID"))
+```
+
+The returned value is a normal `*TableDef`, so you can chain `Indexes`, `WithSchema`, `WithTimestamps`, `WithSoftDelete`, or any other builder afterwards.
+
+Supported `chuck` tag tokens (comma-separated):
+
+| Token            | Effect                                                          |
+| ---------------- | --------------------------------------------------------------- |
+| `-`              | Skip the field entirely.                                         |
+| `name=<col>`     | Override the column name. A single bare unknown token is also accepted as the column name (e.g. `chuck:"created_at"`). |
+| `pk`             | Mark column as `PRIMARY KEY`.                                    |
+| `auto`           | Auto-increment column. Requires `pk` and an integer-kind field. |
+| `unique`         | Add `UNIQUE` constraint. Rejected together with `pk`.            |
+| `notnull`        | Force `NOT NULL`.                                                |
+| `null`           | Force nullable.                                                  |
+| `size=<n>`       | `VARCHAR(n)` on string fields.                                   |
+| `default=<expr>` | Literal `DEFAULT` expression (caller owns SQL quoting).          |
+
+Type inference is intentionally narrow:
+
+| Go field type                                          | Inferred column type   |
+| ------------------------------------------------------ | ---------------------- |
+| `bool`                                                 | `TypeBool`             |
+| `int`, `int8`, `int16`, `int32`, `uint8`, `uint16`     | `TypeInt`              |
+| `int64`, `uint`, `uint32`, `uint64`                    | `TypeBigInt`           |
+| `float32`, `float64`                                   | `TypeFloat`            |
+| `string` (no `size=`)                                  | `TypeString(255)`      |
+| `string` with `size=N`                                 | `TypeVarchar(N)`       |
+| `time.Time`                                            | `TypeTimestamp`        |
+
+Pointer fields wrap the same inferred type and default to nullable. Non-pointer fields default to `NOT NULL`. `notnull` and `null` override either default.
+
+`FromStruct` fails loud (panic) when:
+
+- the generic argument is not a struct,
+- the table name is empty,
+- a field type or tag combination is unsupported (e.g. `size=` on an integer, `auto` without `pk`, `notnull` plus `null`, `unique` plus `pk`, unknown tag key, slice/map fields),
+- or no exported fields produce columns.
+
+Errors surface at table-declaration time — typically at package `var` init or during the first test — so misuse never becomes silent runtime drift. Embedded / anonymous struct fields are rejected; unexported fields are skipped silently.
+
+What is **not** supported by design: indexes, composite uniques, foreign keys, `CHECK` constraints, seeds, schema qualification, trait composition (`WithTimestamps`, `WithSoftDelete`, audit actors, etc.). Compose those on the returned `*TableDef` using the normal builders rather than encoding them into tags.
 
 ### Indexes
 

--- a/README.md
+++ b/README.md
@@ -391,8 +391,8 @@ type SessionSettingsRow struct {
     SessionUUID string    `chuck:"size=36,unique,notnull"`
     Theme       string    `chuck:"size=50,notnull,default='light'"`
     Layout      string    `chuck:"size=50,notnull,default='classic'"`
-    CreatedAt   time.Time `chuck:"created_at"`
-    UpdatedAt   time.Time `chuck:"updated_at"`
+    CreatedAt   time.Time `chuck:"name=created_at"`
+    UpdatedAt   time.Time `chuck:"name=updated_at"`
 }
 
 var SessionSettingsTable = schema.FromStruct[SessionSettingsRow]("SessionSettings").
@@ -405,8 +405,8 @@ Supported `chuck` tag tokens (comma-separated):
 
 | Token            | Effect                                                          |
 | ---------------- | --------------------------------------------------------------- |
-| `-`              | Skip the field entirely.                                         |
-| `name=<col>`     | Override the column name. A single bare unknown token is also accepted as the column name (e.g. `chuck:"created_at"`). |
+| `-`              | Skip the field. Only honored when the entire tag is exactly `-`; mixing `-` with other tokens fails loud. |
+| `name=<col>`     | Override the column name. This is the only way to rename a column. |
 | `pk`             | Mark column as `PRIMARY KEY`.                                    |
 | `auto`           | Auto-increment column. Requires `pk` and an integer-kind field. |
 | `unique`         | Add `UNIQUE` constraint. Rejected together with `pk`.            |
@@ -414,6 +414,8 @@ Supported `chuck` tag tokens (comma-separated):
 | `null`           | Force nullable.                                                  |
 | `size=<n>`       | `VARCHAR(n)` on string fields.                                   |
 | `default=<expr>` | Literal `DEFAULT` expression (caller owns SQL quoting).          |
+
+Any other bare token — typoed flags like `notnul`, `uniqe`, `pkk`, or arbitrary words — fails loud instead of being silently swallowed as a column name. Use `name=<col>` to rename.
 
 Type inference is intentionally narrow:
 

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -206,8 +206,8 @@ type sessionSettingsExampleRow struct {
 	SessionUUID string    `chuck:"size=36,unique,notnull"`
 	Theme       string    `chuck:"size=50,notnull,default='light'"`
 	Layout      string    `chuck:"size=50,notnull,default='classic'"`
-	CreatedAt   time.Time `chuck:"created_at"`
-	UpdatedAt   time.Time `chuck:"updated_at"`
+	CreatedAt   time.Time `chuck:"name=created_at"`
+	UpdatedAt   time.Time `chuck:"name=updated_at"`
 }
 
 func ExampleFromStruct() {

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -3,6 +3,7 @@ package schema_test
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/catgoose/chuck"
 	"github.com/catgoose/chuck/schema"
@@ -198,6 +199,38 @@ func ExampleTableDef_WithAuditActors_typedActor() {
 	// Output:
 	// Select: ID, Title, CreatedAt, UpdatedAt, DeletedAt, CreatedByID, UpdatedByID, DeletedByID
 	// Update: Title, UpdatedAt, DeletedAt, UpdatedByID, DeletedByID
+}
+
+type sessionSettingsExampleRow struct {
+	ID          int       `chuck:"pk,auto"`
+	SessionUUID string    `chuck:"size=36,unique,notnull"`
+	Theme       string    `chuck:"size=50,notnull,default='light'"`
+	Layout      string    `chuck:"size=50,notnull,default='classic'"`
+	CreatedAt   time.Time `chuck:"created_at"`
+	UpdatedAt   time.Time `chuck:"updated_at"`
+}
+
+func ExampleFromStruct() {
+	// FromStruct is an optional convenience helper for small,
+	// feature-owned tables. The returned *TableDef composes with the rest
+	// of the DSL — Indexes, WithSchema, traits — exactly like NewTable.
+	d, _ := chuck.New(chuck.SQLite)
+
+	sessions := schema.FromStruct[sessionSettingsExampleRow]("SessionSettings").
+		Indexes(schema.Index("idx_session_settings_uuid", "SessionUUID"))
+
+	fmt.Println("Columns:", strings.Join(sessions.SelectColumns(), ", "))
+	fmt.Print(sessions.SnapshotString(d))
+	// Output:
+	// Columns: ID, SessionUUID, Theme, Layout, created_at, updated_at
+	// TABLE SessionSettings
+	//   ID                   INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL [immutable]
+	//   SessionUUID          TEXT NOT NULL UNIQUE
+	//   Theme                TEXT NOT NULL DEFAULT 'light'
+	//   Layout               TEXT NOT NULL DEFAULT 'classic'
+	//   created_at           TIMESTAMP NOT NULL
+	//   updated_at           TIMESTAMP NOT NULL
+	//   INDEX idx_session_settings_uuid ON (SessionUUID)
 }
 
 func ExampleNewLookupTable() {

--- a/schema/from_struct.go
+++ b/schema/from_struct.go
@@ -17,9 +17,9 @@ import (
 //
 // Supported tag tokens (comma-separated inside `chuck:"..."`):
 //
-//	-               skip the field
-//	name=<col>      override the column name; a single bare unknown token
-//	                is also accepted as the column name
+//	-               skip the field; only honored when the entire tag is
+//	                exactly "-". Mixing "-" with other tokens fails loud.
+//	name=<col>      override the column name (only way to rename)
 //	pk              mark column as PRIMARY KEY
 //	auto            mark column as auto-increment; requires pk and an
 //	                integer-kind field
@@ -28,6 +28,10 @@ import (
 //	null            force nullable
 //	size=<n>        VARCHAR(n) on string fields
 //	default=<expr>  literal DEFAULT expression (caller owns quoting)
+//
+// Any other bare token (typoed flags like "notnul", "uniqe", or anything
+// else not on the list above) fails loud rather than being silently
+// swallowed as a column-name override.
 //
 // Inferred column types:
 //
@@ -112,8 +116,6 @@ func parseFieldTag(raw string) (fieldTag, error) {
 	if strings.TrimSpace(raw) == "" {
 		return ft, nil
 	}
-	nameFromBare := ""
-	nameFromKV := ""
 	for tok := range strings.SplitSeq(raw, ",") {
 		t := strings.TrimSpace(tok)
 		if t == "" {
@@ -127,10 +129,10 @@ func parseFieldTag(raw string) (fieldTag, error) {
 				if val == "" {
 					return ft, fmt.Errorf("tag name= requires a value")
 				}
-				if nameFromKV != "" {
+				if ft.colName != "" {
 					return ft, fmt.Errorf("tag name= specified more than once")
 				}
-				nameFromKV = val
+				ft.colName = val
 			case "size":
 				n, err := strconv.Atoi(val)
 				if err != nil || n <= 0 {
@@ -167,19 +169,8 @@ func parseFieldTag(raw string) (fieldTag, error) {
 		case "null":
 			ft.nullable = true
 		default:
-			if nameFromBare != "" {
-				return ft, fmt.Errorf("multiple bare tokens %q and %q; use name= to override the column name", nameFromBare, t)
-			}
-			nameFromBare = t
+			return ft, fmt.Errorf("unknown tag token %q; use name=<col> to override the column name", t)
 		}
-	}
-	if nameFromKV != "" && nameFromBare != "" {
-		return ft, fmt.Errorf("both name= and bare column-name token %q specified", nameFromBare)
-	}
-	if nameFromKV != "" {
-		ft.colName = nameFromKV
-	} else {
-		ft.colName = nameFromBare
 	}
 	return ft, nil
 }

--- a/schema/from_struct.go
+++ b/schema/from_struct.go
@@ -206,7 +206,7 @@ func columnFromField(f reflect.StructField, tag string) (ColumnDef, error) {
 		elem = f.Type.Elem()
 	}
 
-	if ft.hasSize && !(elem.Kind() == reflect.String) {
+	if ft.hasSize && elem.Kind() != reflect.String {
 		return ColumnDef{}, fmt.Errorf("size= is only valid for string fields")
 	}
 

--- a/schema/from_struct.go
+++ b/schema/from_struct.go
@@ -1,0 +1,294 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FromStruct derives a simple TableDef from a Go struct using `chuck` field
+// tags. It is an intentionally bounded convenience helper for small,
+// feature-owned tables (caches, lookup tables, session/settings rows); the
+// explicit NewTable / Col DSL remains the primary, recommended schema path
+// for real application schema with indexes, composite uniques, traits,
+// seeds, or schema qualification.
+//
+// Supported tag tokens (comma-separated inside `chuck:"..."`):
+//
+//	-               skip the field
+//	name=<col>      override the column name; a single bare unknown token
+//	                is also accepted as the column name
+//	pk              mark column as PRIMARY KEY
+//	auto            mark column as auto-increment; requires pk and an
+//	                integer-kind field
+//	unique          add UNIQUE constraint (rejected together with pk)
+//	notnull         force NOT NULL
+//	null            force nullable
+//	size=<n>        VARCHAR(n) on string fields
+//	default=<expr>  literal DEFAULT expression (caller owns quoting)
+//
+// Inferred column types:
+//
+//	bool                              -> TypeBool
+//	int / int8 / int16 / int32        -> TypeInt
+//	uint8 / uint16                    -> TypeInt
+//	int64 / uint / uint32 / uint64    -> TypeBigInt
+//	float32 / float64                 -> TypeFloat
+//	string (no size)                  -> TypeString(255)
+//	string (size=N)                   -> TypeVarchar(N)
+//	time.Time                         -> TypeTimestamp
+//
+// Pointer fields wrap the same inferred type and default to nullable.
+// Non-pointer fields default to NOT NULL. `notnull` and `null` override
+// either default. Unexported fields are skipped silently; anonymous /
+// embedded fields are rejected.
+//
+// Unsupported field kinds, conflicting tag combinations, and malformed
+// tokens fail loud via panic so misuse surfaces at table-declaration time
+// (typically a package-level `var`). The returned *TableDef is a normal
+// table definition; callers compose Indexes, WithSchema, traits, and the
+// rest of the DSL on top of it as usual.
+func FromStruct[T any](name string) *TableDef {
+	rt := reflect.TypeFor[T]()
+	def, err := tableDefFromType(rt, name)
+	if err != nil {
+		panic(err)
+	}
+	return def
+}
+
+func tableDefFromType(rt reflect.Type, name string) (*TableDef, error) {
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	if rt.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("schema.FromStruct[%s]: type must be a struct, got %s", rt.String(), rt.Kind())
+	}
+	if name == "" {
+		return nil, fmt.Errorf("schema.FromStruct[%s]: table name must be non-empty", rt.String())
+	}
+
+	td := NewTable(name)
+	for f := range rt.Fields() {
+		if !f.IsExported() {
+			continue
+		}
+		if f.Anonymous {
+			return nil, fmt.Errorf("schema.FromStruct[%s]: anonymous/embedded field %q is not supported", rt.String(), f.Name)
+		}
+		tag, ok := f.Tag.Lookup("chuck")
+		if ok && strings.TrimSpace(tag) == "-" {
+			continue
+		}
+		col, err := columnFromField(f, tag)
+		if err != nil {
+			return nil, fmt.Errorf("schema.FromStruct[%s]: field %q: %w", rt.String(), f.Name, err)
+		}
+		td.cols = append(td.cols, col)
+	}
+	if len(td.cols) == 0 {
+		return nil, fmt.Errorf("schema.FromStruct[%s]: no exported fields produced columns", rt.String())
+	}
+	return td, nil
+}
+
+type fieldTag struct {
+	colName    string
+	pk         bool
+	auto       bool
+	unique     bool
+	notNull    bool
+	nullable   bool
+	size       int
+	hasSize    bool
+	defaultVal string
+	hasDefault bool
+}
+
+func parseFieldTag(raw string) (fieldTag, error) {
+	var ft fieldTag
+	if strings.TrimSpace(raw) == "" {
+		return ft, nil
+	}
+	nameFromBare := ""
+	nameFromKV := ""
+	for tok := range strings.SplitSeq(raw, ",") {
+		t := strings.TrimSpace(tok)
+		if t == "" {
+			continue
+		}
+		if k, v, ok := strings.Cut(t, "="); ok {
+			key := strings.TrimSpace(k)
+			val := strings.TrimSpace(v)
+			switch key {
+			case "name":
+				if val == "" {
+					return ft, fmt.Errorf("tag name= requires a value")
+				}
+				if nameFromKV != "" {
+					return ft, fmt.Errorf("tag name= specified more than once")
+				}
+				nameFromKV = val
+			case "size":
+				n, err := strconv.Atoi(val)
+				if err != nil || n <= 0 {
+					return ft, fmt.Errorf("tag size=%q must be a positive integer", val)
+				}
+				if ft.hasSize {
+					return ft, fmt.Errorf("tag size= specified more than once")
+				}
+				ft.size = n
+				ft.hasSize = true
+			case "default":
+				if val == "" {
+					return ft, fmt.Errorf("tag default= requires a value")
+				}
+				if ft.hasDefault {
+					return ft, fmt.Errorf("tag default= specified more than once")
+				}
+				ft.defaultVal = val
+				ft.hasDefault = true
+			default:
+				return ft, fmt.Errorf("unknown tag key %q", key)
+			}
+			continue
+		}
+		switch t {
+		case "pk":
+			ft.pk = true
+		case "auto":
+			ft.auto = true
+		case "unique":
+			ft.unique = true
+		case "notnull":
+			ft.notNull = true
+		case "null":
+			ft.nullable = true
+		default:
+			if nameFromBare != "" {
+				return ft, fmt.Errorf("multiple bare tokens %q and %q; use name= to override the column name", nameFromBare, t)
+			}
+			nameFromBare = t
+		}
+	}
+	if nameFromKV != "" && nameFromBare != "" {
+		return ft, fmt.Errorf("both name= and bare column-name token %q specified", nameFromBare)
+	}
+	if nameFromKV != "" {
+		ft.colName = nameFromKV
+	} else {
+		ft.colName = nameFromBare
+	}
+	return ft, nil
+}
+
+var timeType = reflect.TypeFor[time.Time]()
+
+func columnFromField(f reflect.StructField, tag string) (ColumnDef, error) {
+	ft, err := parseFieldTag(tag)
+	if err != nil {
+		return ColumnDef{}, err
+	}
+	if ft.notNull && ft.nullable {
+		return ColumnDef{}, fmt.Errorf("notnull and null are mutually exclusive")
+	}
+	if ft.auto && !ft.pk {
+		return ColumnDef{}, fmt.Errorf("auto requires pk")
+	}
+	if ft.unique && ft.pk {
+		return ColumnDef{}, fmt.Errorf("unique is redundant with pk; choose one")
+	}
+	if ft.pk && ft.nullable {
+		return ColumnDef{}, fmt.Errorf("pk columns cannot be nullable")
+	}
+
+	colName := ft.colName
+	if colName == "" {
+		colName = f.Name
+	}
+
+	isPointer := f.Type.Kind() == reflect.Pointer
+	elem := f.Type
+	if isPointer {
+		elem = f.Type.Elem()
+	}
+
+	if ft.hasSize && !(elem.Kind() == reflect.String) {
+		return ColumnDef{}, fmt.Errorf("size= is only valid for string fields")
+	}
+
+	if ft.auto {
+		if !isIntegerKind(elem.Kind()) {
+			return ColumnDef{}, fmt.Errorf("auto requires an integer-kind field, got %s", elem.Kind())
+		}
+		if isPointer {
+			return ColumnDef{}, fmt.Errorf("auto fields cannot be pointer-typed")
+		}
+		if ft.hasDefault {
+			return ColumnDef{}, fmt.Errorf("auto fields cannot also declare default=")
+		}
+		return AutoIncrCol(colName), nil
+	}
+
+	typeFn, err := inferTypeFunc(elem, ft)
+	if err != nil {
+		return ColumnDef{}, err
+	}
+
+	col := Col(colName, typeFn)
+	notNull := !isPointer
+	if ft.notNull {
+		notNull = true
+	}
+	if ft.nullable {
+		notNull = false
+	}
+	if ft.pk {
+		col = col.PrimaryKey()
+		notNull = true
+	}
+	if notNull {
+		col = col.NotNull()
+	}
+	if ft.unique {
+		col = col.Unique()
+	}
+	if ft.hasDefault {
+		col = col.Default(ft.defaultVal)
+	}
+	return col, nil
+}
+
+func inferTypeFunc(elem reflect.Type, ft fieldTag) (TypeFunc, error) {
+	if elem == timeType {
+		return TypeTimestamp(), nil
+	}
+	switch elem.Kind() {
+	case reflect.Bool:
+		return TypeBool(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Uint8, reflect.Uint16:
+		return TypeInt(), nil
+	case reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64:
+		return TypeBigInt(), nil
+	case reflect.Float32, reflect.Float64:
+		return TypeFloat(), nil
+	case reflect.String:
+		if ft.hasSize {
+			return TypeVarchar(ft.size), nil
+		}
+		return TypeString(255), nil
+	}
+	return nil, fmt.Errorf("unsupported field type %s", elem.String())
+}
+
+func isIntegerKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	}
+	return false
+}

--- a/schema/from_struct_test.go
+++ b/schema/from_struct_test.go
@@ -14,7 +14,7 @@ type sessionSettingsRow struct {
 	SessionUUID string    `chuck:"size=36,unique,notnull"`
 	Theme       string    `chuck:"size=50,notnull,default='light'"`
 	Layout      string    `chuck:"size=50,notnull,default='classic'"`
-	CreatedAt   time.Time `chuck:"created_at"`
+	CreatedAt   time.Time `chuck:"name=created_at"`
 	UpdatedAt   time.Time `chuck:"name=updated_at"`
 	Notes       *string
 	private     string //nolint:unused // exercises unexported-field skip
@@ -322,24 +322,54 @@ func TestFromStruct_FailLoud(t *testing.T) {
 			want: "name= specified more than once",
 		},
 		{
-			name: "duplicate bare name token",
+			name: "typoed flag notnul",
 			fn: func() {
 				type bad struct {
-					X int `chuck:"foo,bar"`
+					X int `chuck:"notnul"`
 				}
 				schema.FromStruct[bad]("Bad")
 			},
-			want: "multiple bare tokens",
+			want: `unknown tag token "notnul"`,
 		},
 		{
-			name: "both name= and bare name",
+			name: "typoed flag uniqe",
 			fn: func() {
 				type bad struct {
-					X int `chuck:"foo,name=bar"`
+					X int `chuck:"uniqe"`
 				}
 				schema.FromStruct[bad]("Bad")
 			},
-			want: "both name= and bare column-name token",
+			want: `unknown tag token "uniqe"`,
+		},
+		{
+			name: "typoed flag pkk",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"pkk"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: `unknown tag token "pkk"`,
+		},
+		{
+			name: "skip mixed with other tokens",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"-,notnull"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: `unknown tag token "-"`,
+		},
+		{
+			name: "skip with whitespace mixed",
+			fn: func() {
+				type bad struct {
+					X int `chuck:" - , pk "`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: `unknown tag token "-"`,
 		},
 		{
 			name: "unknown tag key",
@@ -385,6 +415,38 @@ func TestFromStruct_FailLoud(t *testing.T) {
 			}()
 			tc.fn()
 		})
+	}
+}
+
+func TestFromStruct_NameRename(t *testing.T) {
+	type row struct {
+		ID    int    `chuck:"pk,auto"`
+		Inner string `chuck:"name=external_name,notnull,size=50"`
+	}
+	td := schema.FromStruct[row]("Renames")
+	cols := td.SelectColumns()
+	want := []string{"ID", "external_name"}
+	if len(cols) != len(want) {
+		t.Fatalf("SelectColumns = %v, want %v", cols, want)
+	}
+	for i, c := range cols {
+		if c != want[i] {
+			t.Errorf("col[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+}
+
+func TestFromStruct_SkipExactlyDash(t *testing.T) {
+	type row struct {
+		ID   int    `chuck:"pk,auto"`
+		Hide string `chuck:"-"`
+		Keep string `chuck:"notnull"`
+	}
+	td := schema.FromStruct[row]("Skip")
+	for _, c := range td.SelectColumns() {
+		if c == "Hide" || c == "-" {
+			t.Errorf("Hide must be skipped, got %v", td.SelectColumns())
+		}
 	}
 }
 

--- a/schema/from_struct_test.go
+++ b/schema/from_struct_test.go
@@ -1,0 +1,411 @@
+package schema_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/catgoose/chuck"
+	"github.com/catgoose/chuck/schema"
+)
+
+type sessionSettingsRow struct {
+	ID          int       `chuck:"pk,auto"`
+	SessionUUID string    `chuck:"size=36,unique,notnull"`
+	Theme       string    `chuck:"size=50,notnull,default='light'"`
+	Layout      string    `chuck:"size=50,notnull,default='classic'"`
+	CreatedAt   time.Time `chuck:"created_at"`
+	UpdatedAt   time.Time `chuck:"name=updated_at"`
+	Notes       *string
+	private     string //nolint:unused // exercises unexported-field skip
+}
+
+func TestFromStruct_HappyPath(t *testing.T) {
+	// MSSQL renders VARCHAR(n) verbatim, so it shows the size= tag honestly.
+	d, _ := chuck.New(chuck.MSSQL)
+	td := schema.FromStruct[sessionSettingsRow]("SessionSettings")
+
+	if td.Name != "SessionSettings" {
+		t.Fatalf("name = %q, want SessionSettings", td.Name)
+	}
+
+	got := td.SnapshotString(d)
+	wantContains := []string{
+		"TABLE SessionSettings",
+		"ID                   INT PRIMARY KEY IDENTITY(1,1) AUTO INCREMENT NOT NULL [immutable]",
+		"SessionUUID          VARCHAR(36) NOT NULL UNIQUE",
+		"Theme                VARCHAR(50) NOT NULL DEFAULT 'light'",
+		"Layout               VARCHAR(50) NOT NULL DEFAULT 'classic'",
+		"created_at           DATETIME NOT NULL",
+		"updated_at           DATETIME NOT NULL",
+		"Notes                NVARCHAR(255)", // pointer string -> nullable, no size -> TypeString
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("snapshot missing %q\nsnapshot:\n%s", want, got)
+		}
+	}
+
+	// Update columns drop the auto-increment column.
+	updates := td.UpdateColumns()
+	for _, c := range updates {
+		if c == "ID" {
+			t.Errorf("UpdateColumns should not include auto-increment ID, got %v", updates)
+		}
+	}
+}
+
+type intKindsRow struct {
+	Small int32 `chuck:"notnull"`
+	Big   int64 `chuck:"notnull"`
+	UBig  uint64
+	F32   float32 `chuck:"notnull"`
+	F64   float64 `chuck:"notnull"`
+	Flag  bool    `chuck:"notnull,default=0"`
+}
+
+func TestFromStruct_TypeInference(t *testing.T) {
+	d, _ := chuck.New(chuck.MSSQL)
+	td := schema.FromStruct[intKindsRow]("Kinds")
+	snap := td.SnapshotString(d)
+
+	checks := []struct{ col, typeStr string }{
+		{"Small", "INT NOT NULL"},
+		{"Big", "BIGINT NOT NULL"},
+		{"UBig", "BIGINT"}, // non-pointer non-tagged uint64 defaults NotNull; but verify the type
+		{"F32", "FLOAT NOT NULL"},
+		{"F64", "FLOAT NOT NULL"},
+		{"Flag", "BIT NOT NULL DEFAULT 0"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(snap, c.col) || !strings.Contains(snap, c.typeStr) {
+			t.Errorf("snapshot missing %s with %s\n%s", c.col, c.typeStr, snap)
+		}
+	}
+}
+
+type nullableRow struct {
+	ID      int        `chuck:"pk,auto"`
+	Name    *string    `chuck:"size=100"`
+	When    *time.Time `chuck:""`
+	Force   string     `chuck:"null"`     // non-pointer forced nullable
+	Forced  *string    `chuck:"notnull"`  // pointer forced NOT NULL
+	NumOpt  *int64
+}
+
+func TestFromStruct_NullabilityRules(t *testing.T) {
+	d, _ := chuck.New(chuck.MSSQL)
+	td := schema.FromStruct[nullableRow]("Nullable")
+	snap := td.SnapshotString(d)
+
+	mustContain := []string{
+		"Name                 VARCHAR(100)\n",  // pointer string, no NotNull, size=100
+		"When                 DATETIME\n",      // pointer time, nullable
+		"Force                NVARCHAR(255)\n", // null tag, no NotNull
+		"Forced               NVARCHAR(255) NOT NULL", // pointer string + notnull
+		"NumOpt               BIGINT\n",        // pointer int64, nullable
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(snap, want) {
+			t.Errorf("snapshot missing %q\n%s", want, snap)
+		}
+	}
+}
+
+type compositionRow struct {
+	ID   int    `chuck:"pk,auto"`
+	Name string `chuck:"size=255,notnull,unique"`
+}
+
+func TestFromStruct_Composition(t *testing.T) {
+	d, _ := chuck.New(chuck.SQLite)
+	td := schema.FromStruct[compositionRow]("Items").
+		WithSchema("ops").
+		Indexes(schema.Index("idx_items_name", "Name")).
+		WithTimestamps().
+		WithSoftDelete()
+
+	if td.Schema() != "ops" {
+		t.Errorf("Schema() = %q, want ops", td.Schema())
+	}
+	if !td.HasSoftDelete() {
+		t.Error("HasSoftDelete() = false; trait composition broken")
+	}
+	cols := td.SelectColumns()
+	want := []string{"ID", "Name", "CreatedAt", "UpdatedAt", "DeletedAt"}
+	if len(cols) != len(want) {
+		t.Fatalf("SelectColumns = %v, want %v", cols, want)
+	}
+	for i, c := range cols {
+		if c != want[i] {
+			t.Errorf("col[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+
+	// CREATE SQL should include the index, qualified table, and trait columns.
+	stmts := td.CreateSQL(d)
+	joined := strings.Join(stmts, "\n")
+	for _, want := range []string{`CREATE TABLE "Items"`, "DeletedAt", "idx_items_name"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("CREATE SQL missing %q\n%s", want, joined)
+		}
+	}
+}
+
+type skipRow struct {
+	ID   int    `chuck:"pk,auto"`
+	Skip string `chuck:"-"`
+	Keep string `chuck:"notnull"`
+}
+
+func TestFromStruct_SkipTag(t *testing.T) {
+	td := schema.FromStruct[skipRow]("Skip")
+	for _, c := range td.SelectColumns() {
+		if c == "Skip" {
+			t.Errorf("Skip column should be excluded via chuck:\"-\" tag, got %v", td.SelectColumns())
+		}
+	}
+}
+
+func TestFromStruct_FailLoud(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func()
+		want string
+	}{
+		{
+			name: "non-struct generic",
+			fn:   func() { schema.FromStruct[int]("X") },
+			want: "must be a struct",
+		},
+		{
+			name: "empty table name",
+			fn:   func() { schema.FromStruct[sessionSettingsRow]("") },
+			want: "non-empty",
+		},
+		{
+			name: "no exported fields",
+			fn:   func() { schema.FromStruct[struct{ private int }]("Empty") },
+			want: "no exported fields",
+		},
+		{
+			name: "embedded field",
+			fn: func() {
+				type Embedded struct{ X int }
+				type Outer struct {
+					Embedded
+					Y int
+				}
+				schema.FromStruct[Outer]("Outer")
+			},
+			want: "anonymous/embedded",
+		},
+		{
+			name: "unsupported field type",
+			fn: func() {
+				type bad struct {
+					ID   int      `chuck:"pk,auto"`
+					Tags []string `chuck:"notnull"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "unsupported field type",
+		},
+		{
+			name: "notnull and null conflict",
+			fn: func() {
+				type bad struct {
+					Name string `chuck:"notnull,null"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "mutually exclusive",
+		},
+		{
+			name: "auto without pk",
+			fn: func() {
+				type bad struct {
+					ID int `chuck:"auto"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "auto requires pk",
+		},
+		{
+			name: "unique with pk",
+			fn: func() {
+				type bad struct {
+					ID int `chuck:"pk,unique"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "unique is redundant with pk",
+		},
+		{
+			name: "pk nullable",
+			fn: func() {
+				type bad struct {
+					ID int `chuck:"pk,null"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "pk columns cannot be nullable",
+		},
+		{
+			name: "size on non-string",
+			fn: func() {
+				type bad struct {
+					N int `chuck:"size=10"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "size= is only valid for string fields",
+		},
+		{
+			name: "size non-positive",
+			fn: func() {
+				type bad struct {
+					S string `chuck:"size=0"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "size=",
+		},
+		{
+			name: "auto on non-int",
+			fn: func() {
+				type bad struct {
+					S string `chuck:"pk,auto"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "auto requires an integer-kind field",
+		},
+		{
+			name: "auto on pointer int",
+			fn: func() {
+				type bad struct {
+					ID *int `chuck:"pk,auto"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "auto fields cannot be pointer-typed",
+		},
+		{
+			name: "auto with default",
+			fn: func() {
+				type bad struct {
+					ID int `chuck:"pk,auto,default=1"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "auto fields cannot also declare default=",
+		},
+		{
+			name: "name= empty value",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"name="`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "tag name= requires a value",
+		},
+		{
+			name: "duplicate name=",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"name=a,name=b"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "name= specified more than once",
+		},
+		{
+			name: "duplicate bare name token",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"foo,bar"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "multiple bare tokens",
+		},
+		{
+			name: "both name= and bare name",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"foo,name=bar"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "both name= and bare column-name token",
+		},
+		{
+			name: "unknown tag key",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"flux=2"`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: `unknown tag key "flux"`,
+		},
+		{
+			name: "default= empty",
+			fn: func() {
+				type bad struct {
+					X int `chuck:"default="`
+				}
+				schema.FromStruct[bad]("Bad")
+			},
+			want: "tag default= requires a value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("expected panic containing %q, got none", tc.want)
+				}
+				msg, ok := r.(error)
+				if !ok {
+					if s, isStr := r.(string); isStr {
+						if !strings.Contains(s, tc.want) {
+							t.Fatalf("panic %q does not contain %q", s, tc.want)
+						}
+						return
+					}
+					t.Fatalf("panic was not error or string: %T %v", r, r)
+				}
+				if !strings.Contains(msg.Error(), tc.want) {
+					t.Fatalf("panic %q does not contain %q", msg.Error(), tc.want)
+				}
+			}()
+			tc.fn()
+		})
+	}
+}
+
+func TestFromStruct_PostgresNormalization(t *testing.T) {
+	pg, _ := chuck.New(chuck.Postgres)
+	type row struct {
+		ID        int       `chuck:"pk,auto"`
+		Email     string    `chuck:"size=255,notnull,unique"`
+		CreatedAt time.Time `chuck:"notnull"`
+	}
+	td := schema.FromStruct[row]("UserCache")
+
+	snap := td.SnapshotString(pg)
+	for _, want := range []string{
+		"TABLE user_cache",
+		"id                   SERIAL PRIMARY KEY NOT NULL [immutable]",
+		"email                VARCHAR(255) NOT NULL UNIQUE",
+		"created_at           TIMESTAMPTZ NOT NULL",
+	} {
+		if !strings.Contains(snap, want) {
+			t.Errorf("snapshot missing %q\n%s", want, snap)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `schema.FromStruct[T](name)` — an optional, bounded convenience helper that derives a simple `*TableDef` from a Go struct with `chuck` field tags. Intended for small feature-owned tables (caches, lookup/config rows, session/settings rows); the explicit `NewTable`/`Col` DSL stays the primary, recommended schema path.
- Tag grammar is intentionally narrow: column name override (bare token or `name=`), `pk`, `auto`, `unique`, `notnull`, `null`, `size=N`, `default=expr`, and `-` (skip).
- Type inference is small and explicit: `bool`, integer kinds, float, `string` (with optional `size=N`), `time.Time`. Pointer fields default to nullable. Unsupported kinds and conflicting tag combinations panic at table-declaration time so misuse never becomes silent runtime drift.
- Returned `*TableDef` is a normal table — callers compose `Indexes`, `WithSchema`, traits, seeds, etc. on top as usual.
- README gains a `FromStruct (Optional Tag Helper)` section positioned alongside the table factories. `schema/example_test.go` adds an `ExampleFromStruct` covering happy-path composition.

Closes #108.

## Test plan

- [x] `go test ./...` (unit + examples)
- [x] `go vet ./...`
- [ ] Visual: confirm README section renders cleanly on GitHub