### PR TITLE
fix(ci): stop failure notifier depending on missing label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,13 +214,12 @@ jobs:
         run: |
           EXISTING=$(gh issue list \
             --repo "${{ github.repository }}" \
-            --label "ci" \
             --state open \
-            --limit 1 \
-            --json number \
-            --jq '.[0].number')
+            --limit 100 \
+            --json number,title | jq -r --arg title "$ISSUE_TITLE" \
+            '.[] | select(.title == $title) | .number' | head -n 1)
 
-          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+          if [ -n "$EXISTING" ]; then
             gh issue close "$EXISTING" \
               --repo "${{ github.repository }}" \
               --comment "Pipeline succeeded — closing resolved issue.
@@ -232,6 +231,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "Pipeline failure: ${{ github.workflow }}"
 
   notify-failure:
     if: ${{ failure() }}
@@ -250,17 +250,15 @@ jobs:
 
           EXISTING=$(gh issue list \
             --repo "${{ github.repository }}" \
-            --label "ci" \
             --state all \
-            --limit 1 \
-            --json number,state \
-            --jq '.[0]')
+            --limit 100 \
+            --json number,state,title | jq -c --arg title "$ISSUE_TITLE" \
+            '.[] | select(.title == $title) | {number, state}' | head -n 1)
 
-          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+          if [ -z "$EXISTING" ]; then
             gh issue create \
               --repo "${{ github.repository }}" \
-              --title "Pipeline failure: ${{ github.workflow }}" \
-              --label "ci" \
+              --title "$ISSUE_TITLE" \
               --body "$BODY"
           else
             NUMBER=$(echo "$EXISTING" | jq -r '.number')
@@ -274,3 +272,4 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "Pipeline failure: ${{ github.workflow }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,17 +83,15 @@ jobs:
 
           EXISTING=$(gh issue list \
             --repo "${{ github.repository }}" \
-            --label "ci" \
             --state all \
-            --limit 1 \
-            --json number,state \
-            --jq '.[0]')
+            --limit 100 \
+            --json number,state,title | jq -c --arg title "$ISSUE_TITLE" \
+            '.[] | select(.title == $title) | {number, state}' | head -n 1)
 
-          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+          if [ -z "$EXISTING" ]; then
             gh issue create \
               --repo "${{ github.repository }}" \
-              --title "Pipeline failure: ${{ github.workflow }}" \
-              --label "ci" \
+              --title "$ISSUE_TITLE" \
               --body "$BODY"
           else
             NUMBER=$(echo "$EXISTING" | jq -r '.number')
@@ -107,3 +105,4 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: "Pipeline failure: ${{ github.workflow }}"


### PR DESCRIPTION
## Summary
- stop PR and main failure-notify jobs from depending on missing \ label
- look up existing failure issues by exact title instead
- keep main close-resolved step aligned with same title-based lookup

## Why
Recent PR failure runs showed real test/lint failure first, then the notifier job failed again with:

`could not add label: 'ci' not found`

That makes CI noisier and breaks failure reporting when repo has no \ label.

## Validation
- \
- live CLI smoke check of new \ lookup against repo