### PR TITLE
feat(schema): retired-table tombstones for destructive rebuilds (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [Column Lists](#column-lists)
     - [Seed Data](#seed-data)
     - [Table Dependency Ordering](#table-dependency-ordering)
+    - [Retired Table Tombstones](#retired-table-tombstones)
     - [Owned Views](#owned-views)
     - [Owned Procedures (MSSQL)](#owned-procedures-mssql)
     - [Code-Object Validate and Apply](#code-object-validate-and-apply)
@@ -554,6 +555,41 @@ for _, t := range dropOrder {
 ```
 
 For dry-run logging, call `InboundForeignKeys` and feed each entry to `DropForeignKeySQL` to inspect the generated statements without executing them.
+
+### Retired Table Tombstones
+
+Schema manifests evolve, and a table that was once managed can be removed from the current `*TableDef` slice. The live database still has the old table, so a destructive rebuild that drops only currently-registered tables can leave an orphaned inbound foreign key behind — which then blocks the current managed parent from being dropped. The MSSQL teardown of `dbo.GroupMembershipSources` → `dbo.Groups` is the canonical case.
+
+`RetiredTable` / `RetiredQualifiedTable` declare lightweight tombstones for retired managed tables. They carry only a structured `chuck.ObjectName` identity and render the same dialect-aware `DROP TABLE IF EXISTS` statement as `TableDef.DropSQL`, so callers do not have to temporarily re-register old tables as current schema to drop them.
+
+```go
+retired := []*schema.RetiredTableDef{
+    schema.RetiredQualifiedTable("dbo", "GroupMembershipSources"),
+    schema.RetiredTable("LegacyAudit"),
+}
+
+// Drops each tombstone, on MSSQL detaching any inbound FK whose parent or
+// referenced endpoint is one of the retired tables before issuing the drop.
+// Duplicates are deduped by structured object identity; errors include the
+// failing tombstone's qualified name.
+if err := schema.DropRetiredTables(ctx, db, dialect, retired...); err != nil {
+    log.Fatal(err)
+}
+```
+
+Recommended destructive-rebuild ordering:
+
+1. Drop code-owned views and procedures (`DropSQL` on each `ViewDef` / `ProcedureDef`).
+2. Drop retired table tombstones with `DropRetiredTables` — on MSSQL this also detaches the FKs that pinned them to current managed tables.
+3. Drop inbound FKs on the current managed set with `DropInboundForeignKeys` (MSSQL only; a no-op elsewhere).
+4. Drop current managed tables with `DropOrder`.
+5. Recreate current managed tables, indexes, seeds, views, and procedures.
+
+The tombstone API is intentionally narrow:
+
+- It declares retirement by an explicit list. There is no automatic discovery of stale tables from the live database — that would mean dropping unmanaged tables an operator never agreed to lose.
+- On MSSQL it detaches only the FKs whose parent or referenced endpoint is in the retired set. Unmanaged FKs that touch no retired table are left in place.
+- Postgres callers who need `CASCADE` semantics should drop dependent objects themselves first; chuck does not synthesize `CASCADE` because the blast radius would exceed the explicit-list contract.
 
 ### Owned Views
 

--- a/schema/drop_foreign_keys.go
+++ b/schema/drop_foreign_keys.go
@@ -84,6 +84,20 @@ func inboundForeignKeysMSSQL(ctx context.Context, db *sql.DB, d chuck.Dialect, t
 	if len(owned) == 0 {
 		return nil, nil
 	}
+	return foreignKeysMatchingKeySetMSSQL(ctx, db, owned)
+}
+
+// foreignKeysMatchingKeySetMSSQL returns sys.foreign_keys rows whose parent or
+// referenced table key is in the supplied set. The set must already be in
+// "schema.name" form with both components normalized via the active dialect so
+// it lines up with SCHEMA_NAME / sys.objects.name output. Shared between the
+// owned-set destructive teardown path (InboundForeignKeys) and the retired
+// tombstone teardown path (DropRetiredTables) so a single query pattern keeps
+// both flows in sync.
+func foreignKeysMatchingKeySetMSSQL(ctx context.Context, db *sql.DB, keys map[string]struct{}) ([]ForeignKeyRef, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
 
 	const q = `SELECT fk.name AS constraint_name, ` +
 		`SCHEMA_NAME(parent.schema_id) AS parent_schema, ` +
@@ -107,7 +121,7 @@ func inboundForeignKeysMSSQL(ctx context.Context, db *sql.DB, d chuck.Dialect, t
 		if err := rows.Scan(&fk.Name, &fk.ParentSchema, &fk.ParentTable, &fk.ReferencedSchema, &fk.ReferencedTable); err != nil {
 			return nil, fmt.Errorf("scan sys.foreign_keys row: %w", err)
 		}
-		if !ownedFK(owned, fk) {
+		if !ownedFK(keys, fk) {
 			continue
 		}
 		out = append(out, fk)

--- a/schema/integration_test.go
+++ b/schema/integration_test.go
@@ -960,3 +960,99 @@ func TestViewApplyWithOptions_SQLite_MetadataPointerInOwnershipNotice(t *testing
 	assert.NotContains(t, liveSQL, "Provenance recorded in",
 		"notice-only must not carry a metadata pointer when no ledger is enabled")
 }
+
+// TestDropRetiredTablesMSSQL covers the destructive-rebuild blocker the issue
+// #111 documents: a retired managed table still carries an inbound FK to a
+// current managed table, blocking the rebuild even after the retired table
+// was removed from the manifest.
+//
+// The setup mirrors that scenario: a current managed parent table that the
+// rebuild wants to keep, plus a retired child table that references it via
+// an inline auto-named FK declared back when both were managed. The retired
+// child is no longer in the current `*TableDef` slice, so a naive
+// DropOrder-driven teardown leaves the FK in place and DROP TABLE on the
+// current parent fails with FK violation.
+//
+// DropRetiredTables must:
+//  1. Detach the auto-named FK from the (now unmanaged) retired child to the
+//     current parent before issuing the retired drop.
+//  2. Drop the retired child table.
+//  3. Leave the current parent in a state where InboundForeignKeys reports
+//     no remaining inbound FK and DROP TABLE on the parent succeeds.
+func TestDropRetiredTablesMSSQL(t *testing.T) {
+	dsn := os.Getenv("CHUCK_MSSQL_URL")
+	if dsn == "" {
+		t.Skip("CHUCK_MSSQL_URL not set")
+	}
+
+	ctx := context.Background()
+	db, d, err := chuck.OpenURL(ctx, dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The current parent stays in the manifest; the retired child references
+	// it via an inline FK and is no longer declared. We still need the child's
+	// declared *TableDef during this test's bootstrap so the inline FK
+	// actually gets created — destructive rebuild in production removes that
+	// declaration; here it just produces the live FK we need.
+	parent := schema.NewTable("chuck_tomb_parent").Columns(
+		schema.AutoIncrCol("ID"),
+		schema.Col("Name", schema.TypeVarchar(50)).NotNull(),
+	)
+	childForSetup := schema.NewTable("chuck_tomb_retired_child").Columns(
+		schema.AutoIncrCol("ID"),
+		schema.Col("ParentID", schema.TypeInt()).NotNull().
+			References("chuck_tomb_parent", "ID"),
+	)
+	currentTables := []*schema.TableDef{parent}
+	bootstrapTables := []*schema.TableDef{parent, childForSetup}
+
+	cleanup := func() {
+		if fks, ferr := schema.InboundForeignKeys(ctx, db, d, bootstrapTables...); ferr == nil {
+			for _, fk := range fks {
+				_, _ = db.ExecContext(ctx, schema.DropForeignKeySQL(d, fk))
+			}
+		}
+		if dropOrder, oerr := schema.DropOrder(bootstrapTables...); oerr == nil {
+			for _, td := range dropOrder {
+				_, _ = db.ExecContext(ctx, td.DropSQL(d))
+			}
+		}
+	}
+	cleanup()
+
+	createOrder, err := schema.CreationOrder(bootstrapTables...)
+	require.NoError(t, err)
+	for _, td := range createOrder {
+		for _, stmt := range td.CreateIfNotExistsSQL(d) {
+			_, err := db.ExecContext(ctx, stmt)
+			require.NoError(t, err, "create table: %s", stmt)
+		}
+	}
+	defer cleanup()
+
+	// Sanity check: the retired-child→parent FK is in place and a naive parent
+	// drop fails — that is the regression the helper exists to unblock.
+	_, err = db.ExecContext(ctx, parent.DropSQL(d))
+	require.Error(t, err,
+		"DROP TABLE on the current parent must fail while the retired child's inbound FK still pins it")
+
+	// Tombstone teardown: declare the retired child by name only.
+	retired := []*schema.RetiredTableDef{
+		schema.RetiredTable("chuck_tomb_retired_child"),
+		schema.RetiredTable("chuck_tomb_retired_child"), // duplicate must dedupe
+	}
+	require.NoError(t, schema.DropRetiredTables(ctx, db, d, retired...))
+
+	// Retired table must be gone and no inbound FK should remain over the
+	// current managed set.
+	remaining, err := schema.InboundForeignKeys(ctx, db, d, currentTables...)
+	require.NoError(t, err)
+	assert.Empty(t, remaining,
+		"after retired tombstone drop, the current managed set must have no inbound FKs left")
+
+	// Final confirmation: the current parent can now be dropped cleanly.
+	_, err = db.ExecContext(ctx, parent.DropSQL(d))
+	require.NoError(t, err,
+		"current parent DROP TABLE must succeed once the retired tombstone has detached the FK and dropped the child")
+}

--- a/schema/retired_table.go
+++ b/schema/retired_table.go
@@ -1,0 +1,170 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/catgoose/chuck"
+)
+
+// RetiredTableDef is a lightweight tombstone for a table that was previously
+// managed but is no longer part of the current schema manifest. It carries a
+// structured ObjectName identity so destructive-rebuild flows can drop the old
+// table without temporarily re-registering it as a current *TableDef.
+//
+// RetiredTableDef intentionally has no columns, indexes, or traits: it is not
+// a partial table definition. Its only contracts are dialect-aware DropSQL
+// rendering and participation in DropRetiredTables, including the MSSQL
+// inbound-FK detach path the destructive rebuild sequence needs.
+type RetiredTableDef struct {
+	name   string
+	schema string
+}
+
+// RetiredTable declares a retired (unqualified) managed table for tombstone
+// teardown. Use RetiredQualifiedTable when the original table lived in a
+// non-default schema.
+func RetiredTable(name string) *RetiredTableDef {
+	return &RetiredTableDef{name: name}
+}
+
+// RetiredQualifiedTable declares a retired managed table with an explicit
+// schema namespace. Equivalent to RetiredTable(name) with WithSchema applied.
+func RetiredQualifiedTable(schema, name string) *RetiredTableDef {
+	return &RetiredTableDef{schema: schema, name: name}
+}
+
+// Name returns the retired table's bare name.
+func (r *RetiredTableDef) Name() string { return r.name }
+
+// Schema returns the retired table's schema namespace, or "" if unqualified.
+func (r *RetiredTableDef) Schema() string { return r.schema }
+
+// Object returns the structured ObjectName for the retired table.
+func (r *RetiredTableDef) Object() chuck.ObjectName {
+	return chuck.ObjectName{Schema: r.schema, Name: r.name}
+}
+
+// QualifiedNameFor returns the dialect-rendered, quoted, schema-qualified
+// identifier (e.g. [dbo].[GroupMembershipSources] on MSSQL,
+// "public"."group_membership_sources" on Postgres). On SQLite the schema
+// component is dropped because SQLite has no namespace.
+func (r *RetiredTableDef) QualifiedNameFor(d chuck.Dialect) string {
+	return qualifyTable(d, r.Object())
+}
+
+// DropSQL returns the dialect-rendered DROP TABLE IF EXISTS statement for the
+// retired table. Same rendering path as TableDef.DropSQL, so MSSQL emits the
+// `sys.objects` existence probe and Postgres/SQLite use their native
+// `DROP TABLE IF EXISTS` forms.
+func (r *RetiredTableDef) DropSQL(d chuck.Dialect) string {
+	return dropTableIfExistsSQL(d, r.Object())
+}
+
+// DropRetiredTables drops each declared retired table tombstone in
+// caller-supplied order. Duplicates (by structured object identity) are
+// deduped so callers can compose tombstone lists from multiple feature
+// modules without coordinating across them.
+//
+// On MSSQL, inbound foreign keys whose parent or referenced endpoint is in the
+// retired set are detached first via ALTER TABLE ... DROP CONSTRAINT, so a
+// retired table that is still referenced by a current managed table (the
+// issue #111 case) can actually be dropped. The FK detach is scoped to the
+// retired endpoints only — unmanaged FKs that touch no retired table are left
+// alone, matching the issue's "no broad teardown of unmanaged tables"
+// constraint.
+//
+// On SQLite and Postgres, DROP TABLE IF EXISTS is issued directly. Postgres
+// callers needing CASCADE semantics should drop dependent objects themselves
+// first; chuck does not synthesize CASCADE because the surprise blast radius
+// would exceed this helper's explicit-list contract.
+//
+// Errors include the failing tombstone's qualified identity for traceability.
+// Returns nil when the retired list is empty.
+func DropRetiredTables(ctx context.Context, db *sql.DB, d chuck.Dialect, retired ...*RetiredTableDef) error {
+	if len(retired) == 0 {
+		return nil
+	}
+	ordered, err := dedupeRetired(retired)
+	if err != nil {
+		return err
+	}
+	if len(ordered) == 0 {
+		return nil
+	}
+	if d.Engine() == chuck.MSSQL {
+		if err := dropRetiredInboundForeignKeysMSSQL(ctx, db, d, ordered); err != nil {
+			return err
+		}
+	}
+	for _, r := range ordered {
+		stmt := r.DropSQL(d)
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			display := displayQualifiedName(d, r.Object())
+			return fmt.Errorf("schema: drop retired table %s: %w", display, err)
+		}
+	}
+	return nil
+}
+
+// dedupeRetired returns retired tombstones in caller-supplied order with
+// duplicates removed by structured object identity. Empty names fail loud so
+// misuse surfaces at declaration time rather than as a confusing live error.
+func dedupeRetired(retired []*RetiredTableDef) ([]*RetiredTableDef, error) {
+	seen := make(map[string]struct{}, len(retired))
+	out := make([]*RetiredTableDef, 0, len(retired))
+	for i, r := range retired {
+		if r == nil {
+			return nil, fmt.Errorf("schema: retired table at index %d is nil", i)
+		}
+		if r.name == "" {
+			return nil, fmt.Errorf("schema: retired table at index %d has empty name", i)
+		}
+		k := objectKey(r.Object())
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// dropRetiredInboundForeignKeysMSSQL detaches every live FK whose parent or
+// referenced table is one of the supplied retired tombstones. Unqualified
+// tombstones default to the `dbo` schema so they line up with what
+// sys.foreign_keys reports for default-schema tables, matching the existing
+// ownedTableKeySet convention.
+func dropRetiredInboundForeignKeysMSSQL(ctx context.Context, db *sql.DB, d chuck.Dialect, retired []*RetiredTableDef) error {
+	keys := retiredTableKeySet(d, retired, "dbo")
+	if len(keys) == 0 {
+		return nil
+	}
+	fks, err := foreignKeysMatchingKeySetMSSQL(ctx, db, keys)
+	if err != nil {
+		return err
+	}
+	for _, fk := range fks {
+		stmt := DropForeignKeySQL(d, fk)
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			parent := displayQualifiedName(d, chuck.ObjectName{Schema: fk.ParentSchema, Name: fk.ParentTable})
+			return fmt.Errorf("schema: drop foreign key %q on %s before retired table drop: %w", fk.Name, parent, err)
+		}
+	}
+	return nil
+}
+
+// retiredTableKeySet builds the "schema.name" key set for retired tombstones,
+// mirroring ownedTableKeySet so the MSSQL FK filter logic stays uniform.
+func retiredTableKeySet(d chuck.Dialect, retired []*RetiredTableDef, defaultSchema string) map[string]struct{} {
+	keys := make(map[string]struct{}, len(retired))
+	for _, r := range retired {
+		schema := r.schema
+		if schema == "" {
+			schema = defaultSchema
+		}
+		keys[d.NormalizeIdentifier(schema)+"."+d.NormalizeIdentifier(r.name)] = struct{}{}
+	}
+	return keys
+}

--- a/schema/retired_table_test.go
+++ b/schema/retired_table_test.go
@@ -1,0 +1,151 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/catgoose/chuck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestRetiredTable_Constructors(t *testing.T) {
+	bare := RetiredTable("GroupMembershipSources")
+	assert.Equal(t, "GroupMembershipSources", bare.Name())
+	assert.Equal(t, "", bare.Schema())
+	assert.Equal(t, chuck.ObjectName{Name: "GroupMembershipSources"}, bare.Object())
+
+	qual := RetiredQualifiedTable("sg", "RetiredAgents")
+	assert.Equal(t, "RetiredAgents", qual.Name())
+	assert.Equal(t, "sg", qual.Schema())
+	assert.Equal(t, chuck.ObjectName{Schema: "sg", Name: "RetiredAgents"}, qual.Object())
+}
+
+func TestRetiredTable_QualifiedNameFor_PerDialect(t *testing.T) {
+	r := RetiredQualifiedTable("sg", "RetiredAgents")
+	assert.Equal(t, "[sg].[RetiredAgents]", r.QualifiedNameFor(chuck.MSSQLDialect{}))
+	assert.Equal(t, `"sg"."retired_agents"`, r.QualifiedNameFor(chuck.PostgresDialect{}))
+	assert.Equal(t, `"RetiredAgents"`, r.QualifiedNameFor(chuck.SQLiteDialect{}),
+		"SQLite must drop the schema component because it has no namespace")
+}
+
+func TestRetiredTable_DropSQL_PerDialect(t *testing.T) {
+	r := RetiredQualifiedTable("dbo", "GroupMembershipSources")
+
+	mssql := r.DropSQL(chuck.MSSQLDialect{})
+	assert.Contains(t, mssql, "OBJECT_ID(N'[dbo].[GroupMembershipSources]')",
+		"MSSQL drop must wrap in sys.objects existence probe with schema-qualified arg")
+	assert.Contains(t, mssql, "DROP TABLE [dbo].[GroupMembershipSources]")
+
+	pg := r.DropSQL(chuck.PostgresDialect{})
+	assert.Equal(t, `DROP TABLE IF EXISTS "dbo"."group_membership_sources"`, pg)
+
+	lite := r.DropSQL(chuck.SQLiteDialect{})
+	assert.Equal(t, `DROP TABLE IF EXISTS "GroupMembershipSources"`, lite,
+		"SQLite must drop the schema component and use the simple IF EXISTS form")
+}
+
+func TestDropRetiredTables_NilSlice_Noop(t *testing.T) {
+	require.NoError(t, DropRetiredTables(context.Background(), nil, chuck.SQLiteDialect{}))
+}
+
+func TestDropRetiredTables_EmptyName_FailsLoud(t *testing.T) {
+	err := DropRetiredTables(context.Background(), nil, chuck.SQLiteDialect{}, RetiredTable(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty name")
+}
+
+func TestDropRetiredTables_NilEntry_FailsLoud(t *testing.T) {
+	err := DropRetiredTables(context.Background(), nil, chuck.SQLiteDialect{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestDedupeRetired_PreservesOrderAndDedupesByIdentity(t *testing.T) {
+	in := []*RetiredTableDef{
+		RetiredQualifiedTable("dbo", "Old"),
+		RetiredTable("Bare"),
+		RetiredQualifiedTable("dbo", "Old"),    // duplicate
+		RetiredQualifiedTable("sg", "Old"),     // distinct schema → distinct identity
+		RetiredTable("Bare"),                   // duplicate
+		RetiredQualifiedTable("dbo", "Another"),
+	}
+	out, err := dedupeRetired(in)
+	require.NoError(t, err)
+	require.Len(t, out, 4)
+	assert.Equal(t, "dbo", out[0].Schema())
+	assert.Equal(t, "Old", out[0].Name())
+	assert.Equal(t, "", out[1].Schema())
+	assert.Equal(t, "Bare", out[1].Name())
+	assert.Equal(t, "sg", out[2].Schema())
+	assert.Equal(t, "Old", out[2].Name())
+	assert.Equal(t, "dbo", out[3].Schema())
+	assert.Equal(t, "Another", out[3].Name())
+}
+
+func TestRetiredTableKeySet_DefaultsUnqualifiedToDefaultSchema(t *testing.T) {
+	d := chuck.MSSQLDialect{}
+	retired := []*RetiredTableDef{
+		RetiredTable("GroupMembershipSources"),
+		RetiredQualifiedTable("sg", "RetiredAgents"),
+	}
+	keys := retiredTableKeySet(d, retired, "dbo")
+	assert.Contains(t, keys, "dbo.GroupMembershipSources",
+		"unqualified retired declarations must default to the engine default schema")
+	assert.Contains(t, keys, "sg.RetiredAgents",
+		"qualified retired declarations must keep their schema")
+	assert.Len(t, keys, 2)
+}
+
+// TestDropRetiredTables_SQLite_LiveDrop covers the SQLite live-drop path:
+// declared retired tombstones for tables that exist must be dropped; tombstones
+// for already-absent tables must succeed as no-ops via the IF EXISTS form.
+func TestDropRetiredTables_SQLite_LiveDrop(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	d := chuck.SQLiteDialect{}
+
+	// Two existing tables we will retire, plus a tombstone that names a table
+	// that does not exist; the IF EXISTS form must keep the call clean.
+	_, err = db.ExecContext(ctx, `CREATE TABLE retired_alpha (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `CREATE TABLE retired_beta (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	require.NoError(t, DropRetiredTables(ctx, db, d,
+		RetiredTable("retired_alpha"),
+		RetiredTable("retired_beta"),
+		RetiredTable("retired_alpha"), // duplicate must not double-drop or error
+		RetiredTable("never_existed"), // tombstone for absent table is IF EXISTS clean
+	))
+
+	for _, name := range []string{"retired_alpha", "retired_beta", "never_existed"} {
+		var n int
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&n))
+		assert.Equalf(t, 0, n, "retired table %q must be absent after DropRetiredTables", name)
+	}
+}
+
+// TestDropRetiredTables_SQLite_ErrorContext asserts that a non-IF-EXISTS-style
+// failure surfaces the qualified identity of the failing tombstone. SQLite's
+// IF EXISTS form makes a genuine DROP failure hard to engineer in unit tests,
+// so we close the connection first and confirm the resulting error wraps the
+// retired table's display name.
+func TestDropRetiredTables_SQLite_ErrorContext(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = DropRetiredTables(context.Background(), db, chuck.SQLiteDialect{},
+		RetiredTable("retired_alpha"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drop retired table")
+	assert.Contains(t, err.Error(), "retired_alpha")
+}


### PR DESCRIPTION
## Summary

Closes #111.

Adds explicit table tombstone support so destructive rebuild flows can drop tables that were removed from the current `*TableDef` manifest without temporarily re-registering them as current schema. The motivating case is the `dbo.GroupMembershipSources` → `dbo.Groups` MSSQL teardown failure: a retired table's inbound foreign key pinned a still-managed parent and blocked rebuild.

### API

- `schema.RetiredTable(name)` / `schema.RetiredQualifiedTable(schema, name)` — lightweight tombstone carrying a structured `chuck.ObjectName` identity.
- `(*RetiredTableDef).Name() / Schema() / Object() / QualifiedNameFor(d) / DropSQL(d)` — the same dialect-aware identifier and `DROP TABLE IF EXISTS` rendering path as `TableDef`.
- `schema.DropRetiredTables(ctx, db, d, retired...)` — dedupes by structured identity, preserves caller order, and on MSSQL detaches every inbound FK whose parent or referenced endpoint is in the retired set before issuing the drops. Errors carry the failing tombstone's qualified name.

### Scope (intentionally narrow)

- Explicit declared list only. No automatic stale-table discovery from the live database.
- MSSQL FK detach is scoped to retired endpoints — unmanaged FKs that touch no retired table are left alone.
- No implicit `CASCADE` on Postgres. Callers that need it drop dependents themselves first.
- No change to view/procedure `WithReplaces` lifecycle.

### Destructive rebuild order documented in README

1. Drop owned views/procedures.
2. `DropRetiredTables` (also detaches retired-endpoint FKs on MSSQL).
3. `DropInboundForeignKeys` on the current managed set.
4. `DropOrder` over current managed tables.
5. Recreate current objects.

## Test plan

- [x] `go test ./...` (full suite green)
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m ./schema/...` → 0 issues
- [x] Unit coverage:
  - constructors (`RetiredTable`, `RetiredQualifiedTable`)
  - per-dialect `QualifiedNameFor` / `DropSQL` rendering (MSSQL probe form, Postgres snake_case, SQLite schema-stripped IF EXISTS)
  - `dedupeRetired` order preservation + identity-based dedupe (including same name across different schemas treated as distinct)
  - `retiredTableKeySet` defaulting unqualified entries to `dbo` on MSSQL
  - fail-loud on nil entry / empty name
  - SQLite live drop including IF EXISTS no-op for absent tombstones
  - error context surfaces the qualified table name on driver failure
- [x] MSSQL integration test gated on `CHUCK_MSSQL_URL` reproduces the FK-blocking scenario from the issue and asserts `DropRetiredTables` unblocks the current parent drop (run locally when MSSQL env available).