### PR TITLE
docs(readme): add Schema-Qualified Tables to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Schema as Code](#schema-as-code)
     - [Primary Keys](#primary-keys)
     - [Foreign Key References](#foreign-key-references)
+    - [Schema-Qualified Tables](#schema-qualified-tables)
     - [CHECK Constraints](#check-constraints)
     - [Traits](#traits)
     - [Table Factories](#table-factories)


### PR DESCRIPTION
## Summary

- Audit of public docs (README, example tests, exported comments) against current code on `main` after plan-031.
- One TOC drift found and fixed: the **Schema-Qualified Tables** section (added to the body around the schema-qualified table work) was missing from the table of contents between **Foreign Key References** and **CHECK Constraints**. Restored.
- No other stale, misleading, or inconsistent documentation found:
  - All README API names verified against current exports in `chuck/`, `schema/`, and `dbrepo/`.
  - All example tests compile and pass (`go test ./...`).
  - Exported package, type, and function doc comments match current behavior (audit traits split, FromStruct, retired tombstones, owned views/procedures, validate/apply, ownership notice + metadata ledger, dbrepo builders).

## Validation

- [x] `go test ./...` — all green.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run --timeout=5m` — 0 issues.

## Test plan

- [ ] Confirm the rendered README TOC on GitHub now links to **Schema-Qualified Tables** correctly.

Closes the documentation-audit ask in plan-031.